### PR TITLE
perftools: Add socwatch and socperf kernel driver

### DIFF
--- a/perftools-external/soc_perf_driver/include/lwpmudrv_defines.h
+++ b/perftools-external/soc_perf_driver/include/lwpmudrv_defines.h
@@ -1,0 +1,435 @@
+/***
+ * -------------------------------------------------------------------------
+ *               INTEL CORPORATION PROPRIETARY INFORMATION
+ *  This software is supplied under the terms of the accompanying license
+ *  agreement or nondisclosure agreement with Intel Corporation and may not
+ *  be copied or disclosed except in accordance with the terms of that
+ *  agreement.
+ *        Copyright(C) 2007-2018 Intel Corporation.  All Rights Reserved.
+ * -------------------------------------------------------------------------
+***/
+
+#ifndef  _LWPMUDRV_DEFINES_H_
+#define  _LWPMUDRV_DEFINES_H_
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+//
+// Start off with none of the OS'es are defined
+//
+#undef DRV_OS_WINDOWS
+#undef DRV_OS_LINUX
+#undef DRV_OS_SOLARIS
+#undef DRV_OS_MAC
+#undef DRV_OS_ANDROID
+#undef DRV_OS_UNIX
+
+//
+// Make sure none of the architectures is defined here
+//
+#undef DRV_IA32
+#undef DRV_EM64T
+
+//
+// Make sure one (and only one) of the OS'es gets defined here
+//
+// Unfortunately entirex defines _WIN32 so we need to check for linux
+// first.  The definition of these flags is one and only one
+// _OS_xxx is allowed to be defined.
+//
+#if defined(__ANDROID__)
+#define DRV_OS_ANDROID
+#define DRV_OS_UNIX
+#elif defined(__linux__)
+#define DRV_OS_LINUX
+#define DRV_OS_UNIX
+#elif defined(sun)
+#define DRV_OS_SOLARIS
+#define DRV_OS_UNIX
+#elif defined(_WIN32)
+#define DRV_OS_WINDOWS
+#elif defined(__APPLE__)
+#define DRV_OS_MAC
+#define DRV_OS_UNIX
+#elif defined(__FreeBSD__)
+#define DRV_OS_FREEBSD
+#define DRV_OS_UNIX
+#else
+#error "Compiling for an unknown OS"
+#endif
+
+//
+// Make sure one (and only one) architecture is defined here
+// as well as one (and only one) pointer__ size
+//
+#if defined(_M_IX86) || defined(__i386__)
+#define DRV_IA32
+#elif defined(_M_AMD64) || defined(__x86_64__)
+#define DRV_EM64T
+#else
+#error "Unknown architecture for compilation"
+#endif
+
+//
+// Add a well defined definition of compiling for release (free) vs.
+// debug (checked). Once again, don't assume these are the only two values,
+// always have an else clause in case we want to expand this.
+//
+#if defined(DRV_OS_UNIX)
+#define WINAPI
+#endif
+
+/*
+ *  Add OS neutral defines for file processing.  This is needed in both
+ *  the user code and the kernel code for cleanliness
+ */
+#undef DRV_FILE_DESC
+#undef DRV_INVALID_FILE_DESC_VALUE
+#define DRV_ASSERT  assert
+
+#if defined(DRV_OS_WINDOWS)
+
+#define DRV_FILE_DESC                HANDLE
+#define DRV_INVALID_FILE_DESC_VALUE  INVALID_HANDLE_VALUE
+
+#elif defined(DRV_OS_LINUX) || defined(DRV_OS_SOLARIS) || defined(DRV_OS_ANDROID)
+
+#define DRV_IOCTL_FILE_DESC                 SIOP
+#define DRV_FILE_DESC                       SIOP
+#define DRV_INVALID_FILE_DESC_VALUE         -1
+
+#elif defined(DRV_OS_FREEBSD)
+
+#define DRV_IOCTL_FILE_DESC                 S64
+#define DRV_FILE_DESC                       S64
+#define DRV_INVALID_FILE_DESC_VALUE         -1
+
+#elif defined(DRV_OS_MAC)
+#if defined __LP64__
+#define DRV_IOCTL_FILE_DESC                 S64
+#define DRV_FILE_DESC                       S64
+#define DRV_INVALID_FILE_DESC_VALUE         (S64)(-1)
+#else
+#define DRV_IOCTL_FILE_DESC                 S32
+#define DRV_FILE_DESC                       S32
+#define DRV_INVALID_FILE_DESC_VALUE         (S32)(-1)
+#endif
+
+#else
+
+#error "Compiling for an unknown OS"
+
+#endif
+
+#define OUT
+#define IN
+#define INOUT
+
+//
+// VERIFY_SIZEOF let's you insert a compile-time check that the size of a data
+// type (e.g. a struct) is what you think it should be.  Usually it is
+// important to know what the actual size of your struct is, and to make sure
+// it is the same across all platforms.  So this will prevent the code from
+// compiling if something happens that you didn't expect, whether it's because
+// you counted wring, or more often because the compiler inserted padding that
+// you don't want.
+//
+// NOTE: 'elem' and 'size' must both be identifier safe, e.g. matching the
+// regular expression /^[0-9a-zA-Z_]$/.
+//
+// Example:
+//   typedef struct { void *ptr; int data; } mytype;
+//   VERIFY_SIZEOF(mytype, 8);
+//                         ^-- this is correct on 32-bit platforms, but fails
+//                             on 64-bit platforms, indicating a possible
+//                             portability issue.
+//
+#define VERIFY_SIZEOF(type, size) \
+    enum { sizeof_ ## type ## _eq_ ## size = 1 / (int)(sizeof(type) == size) }
+
+#if defined(DRV_OS_WINDOWS)
+#define DRV_DLLIMPORT      __declspec(dllimport)
+#define DRV_DLLEXPORT      __declspec(dllexport)
+#endif
+#if defined(DRV_OS_UNIX)
+#define DRV_DLLIMPORT
+#define DRV_DLLEXPORT
+#endif
+
+#if defined(DRV_OS_WINDOWS)
+#define FSI64RAW              "I64"
+#define FSS64                 "%"FSI64RAW"d"
+#define FSU64                 "%"FSI64RAW"u"
+#define FSX64                 "%"FSI64RAW"x"
+#define DRV_PATH_SEPARATOR    "\\"
+#define L_DRV_PATH_SEPARATOR L"\\"
+#endif
+
+#if defined(DRV_OS_UNIX)
+#define FSI64RAW              "ll"
+#define FSS64                 "%"FSI64RAW"d"
+#define FSU64                 "%"FSI64RAW"u"
+#define FSX64                 "%"FSI64RAW"x"
+#define DRV_PATH_SEPARATOR    "/"
+#define L_DRV_PATH_SEPARATOR L"/"
+#endif
+
+#if defined(DRV_OS_WINDOWS)
+#define DRV_RTLD_NOW    0
+#endif
+#if defined(DRV_OS_UNIX)
+#if defined(DRV_OS_FREEBSD)
+#define DRV_RTLD_NOW 0
+#else
+#define DRV_RTLD_NOW    RTLD_NOW
+#endif
+#endif
+
+#define DRV_STRLEN                       (U32)strlen
+#define DRV_WCSLEN                       (U32)wcslen
+#define DRV_STRCSPN                      strcspn
+#define DRV_STRCHR                       strchr
+#define DRV_STRRCHR                      strrchr
+#define DRV_WCSRCHR                      wcsrchr
+
+#if defined(DRV_OS_WINDOWS)
+#define DRV_STCHARLEN                    DRV_WCSLEN
+#else
+#define DRV_STCHARLEN                    DRV_STRLEN
+#endif
+
+#if defined(DRV_OS_WINDOWS)
+#define DRV_STRCPY                       strcpy_s
+#define DRV_STRNCPY                      strncpy_s
+#define DRV_STRICMP                     _stricmp
+#define DRV_STRNCMP                      strncmp
+#define DRV_STRNICMP                    _strnicmp
+#define DRV_STRDUP                      _strdup
+#define DRV_WCSDUP                      _wcsdup
+#define DRV_STRCMP                       strcmp
+#define DRV_WCSCMP                       wcscmp
+#define DRV_SNPRINTF                    _snprintf_s
+#define DRV_SNWPRINTF                   _snwprintf_s
+#define DRV_VSNPRINTF                   _vsnprintf_s
+#define DRV_SSCANF                       sscanf_s
+#define DRV_STRCAT                       strcat_s
+#define DRV_STRNCAT                      strncat_s
+#define DRV_MEMCPY                       memcpy_s
+#define DRV_STRTOK                       strtok_s
+#define DRV_STRTOUL                      strtoul
+#define DRV_STRTOULL                     _strtoui64
+#define DRV_STRTOQ                      _strtoui64
+#define DRV_FOPEN(fp,name,mode)          fopen_s(&(fp),(name),(mode))
+#define DRV_WFOPEN(fp,name,mode)        _wfopen_s(&(fp),(name),(mode))
+#define DRV_FCLOSE(fp)                   if ((fp) != NULL) { fclose((fp)); }
+#define DRV_WCSCPY                       wcscpy_s
+#define DRV_WCSNCPY                      wcsncpy_s
+#define DRV_WCSCAT                       wcscat_s
+#define DRV_WCSNCAT                      wcsncat_s
+#define DRV_WCSTOK                       wcstok_s
+#define DRV_WCSSTR                       wcsstr
+#define DRV_STRERROR                     strerror_s
+#define DRV_SPRINTF                      sprintf_s
+#define DRV_VSPRINTF                     vsprintf_s
+#define DRV_VSWPRINTF                    vswprintf_s
+#define DRV_GETENV_S                     getenv_s
+#define DRV_WGETENV_S                    wgetenv_s
+#define DRV_PUTENV(name)                _putenv(name)
+#define DRV_USTRCMP(X, Y)                DRV_WCSCMP(X, Y)
+#define DRV_USTRDUP(X)                   DRV_WCSDUP(X)
+#define DRV_ACCESS(X)                    _access_s(X, 4)
+#define DRV_STRSTR                       strstr
+
+#define DRV_GETENV(buf,buf_size,name)   _dupenv_s(&(buf),&(buf_size),(name))
+#define DRV_WGETENV(buf,buf_size,name)  _wdupenv_s(&(buf),&(buf_size),(name))
+#endif
+
+#if defined(DRV_OS_UNIX)
+/*
+   Note: Many of the following macros have a "size" as the second argument.  Generally
+         speaking, this is for compatibility with the _s versions available on Windows.
+         On Linux/Solaris/Mac, it is ignored.  On Windows, it is the size of the destination
+         buffer and is used wrt memory checking features available in the C runtime in debug
+         mode.  Do not confuse it with the number of bytes to be copied, or such.
+
+         On Windows, this size should correspond to the number of allocated characters
+         (char or wchar_t) pointed to by the first argument.  See MSDN for more details.
+*/
+#define DRV_STRICMP                              strcasecmp
+#define DRV_STRDUP                               strdup
+#define DRV_STRNDUP                              strndup
+#define DRV_STRCMP                               strcmp
+#define DRV_STRNCMP                              strncmp
+#define DRV_STRSTR                               strstr
+#define DRV_SNPRINTF(buf,buf_size,length,args...)   snprintf((buf),(length),##args)
+#define DRV_SNWPRINTF(buf,buf_size,length,args...)  snwprintf((buf),(length),##args)
+#define DRV_VSNPRINTF(buf,buf_size,length,args...)  vsnprintf((buf),(length),##args)
+#define DRV_SSCANF                               sscanf
+#define DRV_STRCPY(dst,dst_size,src)             strcpy((dst),(src))
+#define DRV_STRNCPY(dst,dst_size,src,n)          strncpy((dst),(src),(n))
+#define DRV_STRCAT(dst,dst_size,src)             strcat((dst),(src))
+#define DRV_STRNCAT(dst,dst_size,src,n)          strncat((dst),(src),(n))
+#define DRV_MEMCPY(dst,dst_size,src,n)           memcpy((dst),(src), (n))
+#define DRV_STRTOK(tok,delim,context)            strtok((tok),(delim))
+#define DRV_STRTOUL                              strtoul
+#define DRV_STRTOULL                             strtoull
+#define DRV_STRTOL                               strtol
+#define DRV_FOPEN(fp,name,mode)                  (fp) = fopen((name),(mode))
+#define DRV_FCLOSE(fp)                           if ((fp) != NULL) { fclose((fp)); }
+#define DRV_WCSCPY(dst,dst_size,src)             wcscpy((dst),(const wchar_t *)(src))
+#define DRV_WCSNCPY(dst,dst_size,src,count)      wcsncpy((dst),(const wchar_t *)(src),(count))
+#define DRV_WCSCAT(dst,dst_size,src)             wcscat((dst),(const wchar_t *)(src))
+#define DRV_WCSTOK(tok,delim,context)            wcstok((tok),(const wchar_t *)(delim),(context))
+#define DRV_STRERROR                             strerror
+#define DRV_SPRINTF(dst,dst_size,args...)        sprintf((dst),##args)
+#define DRV_VSPRINTF(dst,dst_size,length,args...)    vsprintf((dst),(length),##args)
+#define DRV_VSWPRINTF(dst,dst_size,length,args...)   vswprintf((dst),(length),##args)
+#define DRV_GETENV_S(dst,dst_size)               getenv(dst)
+#define DRV_WGETENV_S(dst,dst_size)              wgetenv(dst)
+#define DRV_PUTENV(name)                         putenv(name)
+#define DRV_GETENV(buf,buf_size,name)            ((buf)=getenv((name)))
+#define DRV_USTRCMP(X, Y)                        DRV_STRCMP(X, Y)
+#define DRV_USTRDUP(X)                           DRV_STRDUP(X)
+#define DRV_ACCESS(X)                            access(X, X_OK)
+#endif
+
+#if defined(DRV_OS_LINUX) || defined(DRV_OS_MAC) || defined(DRV_OS_FREEBSD)
+#define DRV_STRTOQ                               strtoq
+#endif
+
+#if defined(DRV_OS_ANDROID)
+#define DRV_STRTOQ                               strtol
+#endif
+
+#if defined(DRV_OS_SOLARIS)
+#define DRV_STRTOQ                               strtoll
+#endif
+
+#if defined(DRV_OS_LINUX) || defined(DRV_OS_FREEBSD) || defined(DRV_OS_MAC)
+#define DRV_WCSDUP                               wcsdup
+#endif
+
+#if defined(DRV_OS_SOLARIS)
+#define DRV_WCSDUP                               solaris_wcsdup
+#endif
+
+#if defined(DRV_OS_ANDROID)
+#define DRV_WCSDUP                               android_wcsdup
+#endif
+
+/*
+ * Windows uses wchar_t and linux uses char for strings.
+ * Need an extra level of abstraction to standardize it.
+ */
+#if defined(DRV_OS_WINDOWS)
+#define DRV_STDUP                               DRV_WCSDUP
+#define DRV_FORMAT_STRING(x)                    L ## x
+#define DRV_PRINT_STRING(stream, format, ...)   fwprintf((stream), (format), __VA_ARGS__)
+#else
+#define DRV_STDUP                               DRV_STRDUP
+#define DRV_FORMAT_STRING(x)                    x
+#define DRV_PRINT_STRING(stream, format, ...)   fprintf((stream), (format), __VA_ARGS__)
+#endif
+
+
+/*
+ * OS return types
+ */
+#if defined(DRV_OS_UNIX)
+#define OS_STATUS           int
+#define OS_SUCCESS          0
+#define OS_ILLEGAL_IOCTL    -ENOTTY
+#define OS_NO_MEM           -ENOMEM
+#define OS_FAULT            -EFAULT
+#define OS_INVALID          -EINVAL
+#define OS_NO_SYSCALL       -ENOSYS
+#define OS_RESTART_SYSCALL  -ERESTARTSYS
+#define OS_IN_PROGRESS      -EALREADY
+#endif
+
+/****************************************************************************
+ **  Driver State defintions
+ ***************************************************************************/
+#define  DRV_STATE_UNINITIALIZED       0
+#define  DRV_STATE_RESERVED            1
+#define  DRV_STATE_IDLE                2
+#define  DRV_STATE_PAUSED              3
+#define  DRV_STATE_STOPPED             4
+#define  DRV_STATE_RUNNING             5
+#define  DRV_STATE_PAUSING             6
+#define  DRV_STATE_PREPARE_STOP        7
+#define  DRV_STATE_TERMINATING         8
+
+#define  MATCHING_STATE_BIT(state)     ((U32)1 << state)
+#define  STATE_BIT_UNINITIALIZED       MATCHING_STATE_BIT(DRV_STATE_UNINITIALIZED)
+#define  STATE_BIT_RESERVED            MATCHING_STATE_BIT(DRV_STATE_RESERVED)
+#define  STATE_BIT_IDLE                MATCHING_STATE_BIT(DRV_STATE_IDLE)
+#define  STATE_BIT_PAUSED              MATCHING_STATE_BIT(DRV_STATE_PAUSED)
+#define  STATE_BIT_STOPPED             MATCHING_STATE_BIT(DRV_STATE_STOPPED)
+#define  STATE_BIT_RUNNING             MATCHING_STATE_BIT(DRV_STATE_RUNNING)
+#define  STATE_BIT_PAUSING             MATCHING_STATE_BIT(DRV_STATE_PAUSING)
+#define  STATE_BIT_PREPARE_STOP        MATCHING_STATE_BIT(DRV_STATE_PREPARE_STOP)
+#define  STATE_BIT_TERMINATING         MATCHING_STATE_BIT(DRV_STATE_TERMINATING)
+#define  STATE_BIT_ANY                 ((U32)-1)
+
+#define  IS_COLLECTING_STATE(state)    (!!(MATCHING_STATE_BIT(state) & (STATE_BIT_RUNNING | STATE_BIT_PAUSING | STATE_BIT_PAUSED)))
+
+/*
+ *  Stop codes
+ */
+#define DRV_STOP_BASE      0
+#define DRV_STOP_NORMAL    1
+#define DRV_STOP_ASYNC     2
+#define DRV_STOP_CANCEL    3
+
+#define SEP_FREE(loc)   if ((loc)) { free(loc); loc = NULL; }
+
+#define MAX_EVENTS 256       // Limiting maximum multiplexing events to 256.
+#if defined(DRV_OS_UNIX)
+#define UNREFERENCED_PARAMETER(p)       ((p) = (p))
+#endif
+
+/*
+ * Global marker names
+ */
+#define START_MARKER_NAME       "SEP_START_MARKER"
+#define PAUSE_MARKER_NAME       "SEP_PAUSE_MARKER"
+#define RESUME_MARKER_NAME      "SEP_RESUME_MARKER"
+
+#define DRV_SOC_STRING_LEN      100 + MAX_MARKER_LENGTH
+
+/*
+ * Temp path
+ */
+#define SEP_TMPDIR                               "SEP_TMP_DIR"
+#if defined(DRV_OS_WINDOWS)
+#define OS_TMPDIR                                "TEMP"
+#define GET_DEFAULT_TMPDIR(dir, size)            {GetTempPath((U32)size, dir);}
+#else
+#define OS_TMPDIR              "TMPDIR"
+/*
+ * Unix has default tmp dir
+ */
+#if defined(DRV_OS_ANDROID)
+#define TEMP_PATH              "/data"
+#else
+#define TEMP_PATH              "/tmp"
+#endif
+#define GET_DEFAULT_TMPDIR(dir, size)            {DRV_STRCPY((STCHAR *)dir, (U32)size, (STCHAR *)TEMP_PATH);}
+#endif
+
+#define  OS_ID_UNKNOWN          -1
+#define  OS_ID_NATIVE           0
+#define  OS_ID_VMM              0
+#define  OS_ID_MODEM            1
+#define  OS_ID_ANDROID          2
+#define  OS_ID_SECVM            3
+
+#define PERF_HW_VER4           (5)
+#if defined(__cplusplus)
+}
+#endif
+
+#endif
+

--- a/perftools-external/soc_perf_driver/include/lwpmudrv_ecb.h
+++ b/perftools-external/soc_perf_driver/include/lwpmudrv_ecb.h
@@ -1,0 +1,1004 @@
+/***
+ * -------------------------------------------------------------------------
+ *               INTEL CORPORATION PROPRIETARY INFORMATION
+ *  This software is supplied under the terms of the accompanying license
+ *  agreement or nondisclosure agreement with Intel Corporation and may not
+ *  be copied or disclosed except in accordance with the terms of that
+ *  agreement.
+ *        Copyright(C) 2007-2018 Intel Corporation.  All Rights Reserved.
+ * -------------------------------------------------------------------------
+***/
+
+#ifndef _LWPMUDRV_ECB_UTILS_H_
+#define _LWPMUDRV_ECB_UTILS_H_
+
+#if defined(DRV_OS_WINDOWS)
+#pragma warning (disable:4200)
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// control register types
+#define CCCR                1   // counter configuration control register
+#define ESCR                2   // event selection control register
+#define DATA                4   // collected as snapshot of current value
+#define DATA_RO_DELTA       8   // read-only counter collected as current-previous
+#define DATA_RO_SS          16  // read-only counter collected as snapshot of current value
+#define METRICS             32  // hardware metrics
+
+// event multiplexing modes
+#define EM_DISABLED                -1
+#define EM_TIMER_BASED              0
+#define EM_EVENT_BASED_PROFILING    1
+#define EM_TRIGGER_BASED            2
+
+// ***************************************************************************
+
+/*!\struct EVENT_DESC_NODE
+ * \var    sample_size                   - size of buffer in bytes to hold the sample + extras
+ * \var    max_gp_events                 - max number of General Purpose events per EM group
+ * \var    pebs_offset                   - offset in the sample to locate the pebs capture information
+ * \var    lbr_offset                    - offset in the sample to locate the lbr information
+ * \var    lbr_num_regs                  - offset in the sample to locate the number of lbr register information
+ * \var    latency_offset_in_sample      - offset in the sample to locate the latency information
+ * \var    latency_size_in_sample        - size of latency records in the sample
+ * \var    latency_size_from_pebs_record - size of the latency data from pebs record in the sample
+ * \var    latency_offset_in_pebs_record - offset in the sample to locate the latency information
+ *                                         in pebs record
+ * \var    power_offset_in_sample        - offset in the sample to locate the power information
+ * \var    ebc_offset                    - offset in the sample to locate the ebc count information
+ * \var    uncore_ebc_offset             - offset in the sample to locate the uncore ebc count information
+ *
+ * \var    ro_offset                     - offset of RO data in the sample
+ * \var    ro_count                      - total number of RO entries (including all of IEAR/DEAR/BTB/IPEAR)
+ * \var    iear_offset                   - offset into RO data at which IEAR entries begin
+ * \var    dear_offset                   - offset into RO data at which DEAR entries begin
+ * \var    btb_offset                    - offset into RO data at which BTB entries begin (these use the same PMDs)
+ * \var    ipear_offset                  - offset into RO data at which IPEAR entries begin (these use the same PMDs)
+ * \var    iear_count                    - number of IEAR entries
+ * \var    dear_count                    - number of DEAR entries
+ * \var    btb_count                     - number of BTB entries
+ * \var    ipear_count                   - number of IPEAR entries
+ *
+ * \var    pwr_offset                    - offset in the sample to locate the pwr count information
+ * \var    p_state_offset                - offset in the sample to locate the p_state information (APERF/MPERF)
+ *
+ * \brief  Data structure to describe the events and the mode
+ *
+ */
+
+typedef struct EVENT_DESC_NODE_S  EVENT_DESC_NODE;
+typedef        EVENT_DESC_NODE   *EVENT_DESC;
+
+struct EVENT_DESC_NODE_S {
+    U32     sample_size;
+    U32     pebs_offset;
+    U32     pebs_size;
+    U32     lbr_offset;
+    U32     lbr_num_regs;
+    U32     latency_offset_in_sample;
+    U32     latency_size_in_sample;
+    U32     latency_size_from_pebs_record;
+    U32     latency_offset_in_pebs_record;
+    U32     power_offset_in_sample;
+    U32     ebc_offset;
+    U32     uncore_ebc_offset;
+    U32     eventing_ip_offset;
+    U32     hle_offset;
+    U32     pwr_offset;
+    U32     callstack_offset;
+    U32     callstack_size;
+    U32     p_state_offset;
+    U32     pebs_tsc_offset;
+    U32     perfmetrics_offset;
+    U32     perfmetrics_size;
+    /* ----------ADAPTIVE PEBS FIELDS --------- */
+    U16     applicable_counters_offset;
+    U16     gpr_info_offset;
+    U16     gpr_info_size;
+    U16     xmm_info_offset;
+    U16     xmm_info_size;
+    U16     lbr_info_size;
+    /*------------------------------------------*/
+    U32     reserved2;
+    U64     reserved3;
+};
+
+//
+// Accessor macros for EVENT_DESC node
+//
+#define EVENT_DESC_sample_size(ec)                        (ec)->sample_size
+#define EVENT_DESC_pebs_offset(ec)                        (ec)->pebs_offset
+#define EVENT_DESC_pebs_size(ec)                          (ec)->pebs_size
+#define EVENT_DESC_lbr_offset(ec)                         (ec)->lbr_offset
+#define EVENT_DESC_lbr_num_regs(ec)                       (ec)->lbr_num_regs
+#define EVENT_DESC_latency_offset_in_sample(ec)           (ec)->latency_offset_in_sample
+#define EVENT_DESC_latency_size_from_pebs_record(ec)      (ec)->latency_size_from_pebs_record
+#define EVENT_DESC_latency_offset_in_pebs_record(ec)      (ec)->latency_offset_in_pebs_record
+#define EVENT_DESC_latency_size_in_sample(ec)             (ec)->latency_size_in_sample
+#define EVENT_DESC_power_offset_in_sample(ec)             (ec)->power_offset_in_sample
+#define EVENT_DESC_ebc_offset(ec)                         (ec)->ebc_offset
+#define EVENT_DESC_uncore_ebc_offset(ec)                  (ec)->uncore_ebc_offset
+#define EVENT_DESC_eventing_ip_offset(ec)                 (ec)->eventing_ip_offset
+#define EVENT_DESC_hle_offset(ec)                         (ec)->hle_offset
+#define EVENT_DESC_pwr_offset(ec)                         (ec)->pwr_offset
+#define EVENT_DESC_callstack_offset(ec)                   (ec)->callstack_offset
+#define EVENT_DESC_callstack_size(ec)                     (ec)->callstack_size
+#define EVENT_DESC_perfmetrics_offset(ec)                 (ec)->perfmetrics_offset
+#define EVENT_DESC_perfmetrics_size(ec)                   (ec)->perfmetrics_size
+#define EVENT_DESC_p_state_offset(ec)                     (ec)->p_state_offset
+#define EVENT_DESC_pebs_tsc_offset(ec)                    (ec)->pebs_tsc_offset
+#define EVENT_DESC_applicable_counters_offset(ec)         (ec)->applicable_counters_offset
+#define EVENT_DESC_gpr_info_offset(ec)                    (ec)->gpr_info_offset
+#define EVENT_DESC_gpr_info_size(ec)                      (ec)->gpr_info_size
+#define EVENT_DESC_xmm_info_offset(ec)                    (ec)->xmm_info_offset
+#define EVENT_DESC_xmm_info_size(ec)                      (ec)->xmm_info_size
+#define EVENT_DESC_lbr_info_size(ec)                      (ec)->lbr_info_size
+
+// ***************************************************************************
+
+/*!\struct EVENT_CONFIG_NODE
+ * \var    num_groups      -  The number of groups being programmed
+ * \var    em_mode         -  Is EM valid?  If so how?
+ * \var    em_time_slice   -  EM valid?  time slice in milliseconds
+ * \var    sample_size     -  size of buffer in bytes to hold the sample + extras
+ * \var    max_gp_events   -  Max number of General Purpose events per EM group
+ * \var    pebs_offset     -  offset in the sample to locate the pebs capture information
+ * \var    lbr_offset      -  offset in the sample to locate the lbr information
+ * \var    lbr_num_regs    -  offset in the sample to locate the lbr information
+ * \var    latency_offset_in_sample      -  offset in the sample to locate the latency information
+ * \var    latency_size_in_sample        -  size of latency records in the sample
+ * \var    latency_size_from_pebs_record -  offset in the sample to locate the latency
+ *                                          size from pebs record
+ * \var    latency_offset_in_pebs_record -  offset in the sample to locate the latency information
+ *                                          in pebs record
+ * \var    power_offset_in_sample        -  offset in the sample to locate the power information
+ * \var    ebc_offset                    -  offset in the sample to locate the ebc count information
+ *
+ * \var    pwr_offset                    -  offset in the sample to locate the pwr count information
+ * \var    p_state_offset                -  offset in the sample to locate the p_state information (APERF/MPERF)
+ *
+ * \brief  Data structure to describe the events and the mode
+ *
+ */
+
+typedef struct EVENT_CONFIG_NODE_S  EVENT_CONFIG_NODE;
+typedef        EVENT_CONFIG_NODE   *EVENT_CONFIG;
+
+struct EVENT_CONFIG_NODE_S {
+    U32     num_groups;
+    S32     em_mode;
+    S32     em_factor;
+    S32     em_event_num;
+    U32     sample_size;
+    U32     max_gp_events;
+    U32     max_fixed_counters;
+    U32     max_ro_counters;    // maximum read-only counters
+    U32     pebs_offset;
+    U32     pebs_size;
+    U32     lbr_offset;
+    U32     lbr_num_regs;
+    U32     latency_offset_in_sample;
+    U32     latency_size_in_sample;
+    U32     latency_size_from_pebs_record;
+    U32     latency_offset_in_pebs_record;
+    U32     power_offset_in_sample;
+    U32     ebc_offset;
+    U32     num_groups_unc;
+    U32     ebc_offset_unc;
+    U32     sample_size_unc;
+    U32     eventing_ip_offset;
+    U32     hle_offset;
+    U32     pwr_offset;
+    U32     callstack_offset;
+    U32     callstack_size;
+    U32     p_state_offset;
+    U32     pebs_tsc_offset;
+    U16     unc_timer_interval;
+    U16     unc_em_factor;
+    U32     reserved1;
+    U64     reserved2;
+    U64     reserved3;
+    U64     reserved4;
+};
+
+//
+// Accessor macros for EVENT_CONFIG node
+//
+#define EVENT_CONFIG_num_groups(ec)                         (ec)->num_groups
+#define EVENT_CONFIG_mode(ec)                               (ec)->em_mode
+#define EVENT_CONFIG_em_factor(ec)                          (ec)->em_factor
+#define EVENT_CONFIG_em_event_num(ec)                       (ec)->em_event_num
+#define EVENT_CONFIG_sample_size(ec)                        (ec)->sample_size
+#define EVENT_CONFIG_max_gp_events(ec)                      (ec)->max_gp_events
+#define EVENT_CONFIG_max_fixed_counters(ec)                 (ec)->max_fixed_counters
+#define EVENT_CONFIG_max_ro_counters(ec)                    (ec)->max_ro_counters
+#define EVENT_CONFIG_pebs_offset(ec)                        (ec)->pebs_offset
+#define EVENT_CONFIG_pebs_size(ec)                          (ec)->pebs_size
+#define EVENT_CONFIG_lbr_offset(ec)                         (ec)->lbr_offset
+#define EVENT_CONFIG_lbr_num_regs(ec)                       (ec)->lbr_num_regs
+#define EVENT_CONFIG_latency_offset_in_sample(ec)           (ec)->latency_offset_in_sample
+#define EVENT_CONFIG_latency_size_from_pebs_record(ec)      (ec)->latency_size_from_pebs_record
+#define EVENT_CONFIG_latency_offset_in_pebs_record(ec)      (ec)->latency_offset_in_pebs_record
+#define EVENT_CONFIG_latency_size_in_sample(ec)             (ec)->latency_size_in_sample
+#define EVENT_CONFIG_power_offset_in_sample(ec)             (ec)->power_offset_in_sample
+#define EVENT_CONFIG_ebc_offset(ec)                         (ec)->ebc_offset
+#define EVENT_CONFIG_num_groups_unc(ec)                     (ec)->num_groups_unc
+#define EVENT_CONFIG_ebc_offset_unc(ec)                     (ec)->ebc_offset_unc
+#define EVENT_CONFIG_sample_size_unc(ec)                    (ec)->sample_size_unc
+#define EVENT_CONFIG_eventing_ip_offset(ec)                 (ec)->eventing_ip_offset
+#define EVENT_CONFIG_hle_offset(ec)                         (ec)->hle_offset
+#define EVENT_CONFIG_pwr_offset(ec)                         (ec)->pwr_offset
+#define EVENT_CONFIG_callstack_offset(ec)                   (ec)->callstack_offset
+#define EVENT_CONFIG_callstack_size(ec)                     (ec)->callstack_size
+#define EVENT_CONFIG_p_state_offset(ec)                     (ec)->p_state_offset
+#define EVENT_CONFIG_pebs_tsc_offset(ec)                    (ec)->pebs_tsc_offset
+#define EVENT_CONFIG_unc_timer_interval(ec)                 (ec)->unc_timer_interval
+#define EVENT_CONFIG_unc_em_factor(ec)                      (ec)->unc_em_factor
+
+typedef enum {
+    UNC_MUX = 1,
+    UNC_COUNTER
+} UNC_SA_PROG_TYPE;
+
+typedef enum {
+    UNC_PCICFG = 1,
+    UNC_MMIO,
+    UNC_STOP,
+    UNC_MEMORY,
+    UNC_STATUS
+} UNC_SA_CONFIG_TYPE;
+
+typedef enum {
+    UNC_MCHBAR = 1,
+    UNC_DMIBAR,
+    UNC_PCIEXBAR,
+    UNC_GTTMMADR,
+    UNC_GDXCBAR,
+    UNC_CHAPADR,
+    UNC_SOCPCI,
+    UNC_NPKBAR
+} UNC_SA_BAR_TYPE;
+
+typedef enum {
+    UNC_OP_READ =  1,
+    UNC_OP_WRITE,
+    UNC_OP_RMW
+} UNC_SA_OPERATION;
+
+
+typedef enum {
+    STATIC_COUNTER = 1,
+    FREERUN_COUNTER,
+    PROG_FREERUN_COUNTER
+} COUNTER_TYPES;
+
+typedef enum {
+    PACKAGE_EVENT = 1,
+    MODULE_EVENT,
+    THREAD_EVENT,
+    SYSTEM_EVENT
+} EVENT_SCOPE_TYPES;
+
+typedef enum {
+    DEVICE_CORE          = 1,         // CORE DEVICE
+    DEVICE_UNC_CBO       = 10,        // UNCORE DEVICES START
+    DEVICE_UNC_HA,
+    DEVICE_UNC_IMC,
+    DEVICE_UNC_IRP,
+    DEVICE_UNC_NCU,
+    DEVICE_UNC_PCU,
+    DEVICE_UNC_POWER,
+    DEVICE_UNC_QPI,
+    DEVICE_UNC_R2PCIE,
+    DEVICE_UNC_R3QPI,
+    DEVICE_UNC_SBOX,
+    DEVICE_UNC_GT,
+    DEVICE_UNC_UBOX,
+    DEVICE_UNC_WBOX,
+    DEVICE_UNC_COREI7,
+    DEVICE_UNC_CHA,
+    DEVICE_UNC_EDC,
+    DEVICE_UNC_IIO,
+    DEVICE_UNC_M2M,
+    DEVICE_UNC_EDRAM,
+    DEVICE_UNC_FPGA_CACHE,
+    DEVICE_UNC_FPGA_FAB,
+    DEVICE_UNC_FPGA_THERMAL,
+    DEVICE_UNC_FPGA_POWER,
+    DEVICE_UNC_FPGA_GB,
+    DEVICE_UNC_KNC_SBOX  = 100,       // KNC UNCORE DEVICES START
+    DEVICE_UNC_KNC_GBOX_FBOX,
+    DEVICE_UNC_KNC_GBOX_MBOX,
+    DEVICE_UNC_KNC_SMC,
+    DEVICE_UNC_TELEMETRY  = 150,      // TELEMETRY DEVICE
+    DEVICE_UNC_CHAP       = 200,      // CHIPSET DEVICES START
+    DEVICE_UNC_GMCH,
+    DEVICE_UNC_GFX,
+    DEVICE_UNC_SOCPERF    = 300,      // UNCORE VISA DEVICES START
+    DEVICE_UNC_HFI_RXE    = 400,      // STL HFI
+    DEVICE_UNC_HFI_TXE,
+} DEVICE_TYPES;
+
+typedef enum {
+    LBR_ENTRY_TOS = 0,
+    LBR_ENTRY_FROM_IP,
+    LBR_ENTRY_TO_IP,
+    LBR_ENTRY_INFO
+} LBR_ENTRY_TYPE;
+
+// ***************************************************************************
+
+/*!\struct PCI_ID_NODE
+ * \var    offset      -  PCI offset to start the read/write
+ * \var    data size      Number of bytes to operate on
+ */
+
+typedef struct PCI_ID_NODE_S    PCI_ID_NODE;
+typedef        PCI_ID_NODE      *PCI_ID;
+
+struct PCI_ID_NODE_S {
+    U32        offset;
+    U32        data_size;
+};
+#define PCI_ID_offset(x)      (x)->offset
+#define PCI_ID_data_size(x)   (x)->data_size
+
+// ***************************************************************************
+
+/*!\struct EVENT_REG_ID_NODE
+ * \var    reg_id      -  MSR index to r/w
+ * \var    pci_id     PCI based register and its details to operate on
+ */
+typedef union EVENT_REG_ID_NODE_S EVENT_REG_ID_NODE;
+typedef       EVENT_REG_ID_NODE  *EVENT_REG_ID;
+
+ union EVENT_REG_ID_NODE_S {
+   U32            reg_id;
+   U32            reserved2;
+   PCI_ID_NODE    pci_id;
+} ;
+
+
+// ***************************************************************************
+
+typedef enum {
+    PMU_REG_RW_READ = 1,
+    PMU_REG_RW_WRITE,
+    PMU_REG_RW_READ_WRITE,
+} PMU_REG_RW_TYPES;
+
+typedef enum {
+    PMU_REG_PROG_MSR = 1,
+    PMU_REG_PROG_PCI,
+    PMU_REG_PROG_MMIO,
+} PMU_REG_PROG_TYPES;
+
+typedef enum {
+    PMU_REG_GLOBAL_CTRL = 1,
+    PMU_REG_UNIT_CTRL,
+    PMU_REG_UNIT_STATUS,
+    PMU_REG_DATA,
+    PMU_REG_EVENT_SELECT,
+    PMU_REG_FILTER,
+    PMU_REG_FIXED_CTRL,
+} PMU_REG_TYPES;
+
+/*!\struct EVENT_REG_NODE
+ * \var    reg_type             - register type
+ * \var    event_id_index       - event ID index
+ * \var    event_id_index_local - event ID index within the device
+ * \var    event_reg_id         - register ID/pci register details
+ * \var    desc_id              - desc ID
+ * \var    flags                - flags
+ * \var    reg_value            - register value
+ * \var    max_bits             - max bits
+ * \var    scheduled            - boolean to specify if this event node has been scheduled already
+ * \var    bus_no               - PCI bus number
+ * \var    dev_no               - PCI device number
+ * \var    func_no              - PCI function number
+ * \var    counter_type         - Event counter type - static/freerun
+ * \var    event_scope          - Event scope - package/module/thread
+ * \var    reg_prog_type        - Register Programming type
+ * \var    reg_rw_type          - Register Read/Write type
+ * \var    reg_order            - Register order in the programming sequence
+ * \var
+ * \brief  Data structure to describe the event registers
+ *
+ */
+
+typedef struct EVENT_REG_NODE_S  EVENT_REG_NODE;
+typedef        EVENT_REG_NODE   *EVENT_REG;
+
+struct EVENT_REG_NODE_S {
+    U8                   reg_type;
+    U8                   event_id_index;       // U8 must be changed if MAX_EVENTS > 256
+    U8                   event_id_index_local; // U8 must be changed if MAX_EVENTS > 256
+    U8                   emon_event_id_index_local;
+    U8                   group_index;
+    U8                   reserved0;
+    U16                  counter_event_offset;
+    EVENT_REG_ID_NODE    event_reg_id;
+    U16                  desc_id;
+    U16                  flags;
+    U32                  reserved1;
+    U64                  reg_value;
+    U64                  max_bits;
+    U8                   scheduled;
+    // PCI config-specific fields
+    S8                   secondary_pci_offset_shift;
+    U16                  secondary_pci_offset_offset; // offset of the offset...
+    U32                  bus_no;
+    U32                  dev_no;
+    U32                  func_no;
+    U32                  counter_type;
+    U32                  event_scope;
+    U8                   reg_prog_type;
+    U8                   reg_rw_type;
+    U8                   reg_order;
+    U8                   bit_position;
+    U32                  reserved5;
+    U64                  secondary_pci_offset_mask;
+    U64                  reserved7;
+    U64                  reserved8;
+    U64                  reserved9;
+};
+
+//
+// Accessor macros for EVENT_REG node
+// Note: the flags field is not directly addressible to prevent hackery
+//
+#define EVENT_REG_reg_type(x,i)                    (x)[(i)].reg_type
+#define EVENT_REG_event_id_index(x,i)              (x)[(i)].event_id_index
+#define EVENT_REG_event_id_index_local(x,i)        (x)[(i)].event_id_index_local
+#define EVENT_REG_emon_event_id_index_local(x,i)   (x)[(i)].emon_event_id_index_local
+#define EVENT_REG_counter_event_offset(x,i)        (x)[(i)].counter_event_offset
+#define EVENT_REG_group_index(x,i)                 (x)[(i)].group_index
+#define EVENT_REG_counter_event_offset(x,i)        (x)[(i)].counter_event_offset
+#define EVENT_REG_reg_id(x,i)                      (x)[(i)].event_reg_id.reg_id
+#define EVENT_REG_pci_id(x,i)                      (x)[(i)].event_reg_id.pci_id
+#define EVENT_REG_pci_id_offset(x,i)               (x)[(i)].event_reg_id.pci_id.offset
+#define EVENT_REG_pci_id_size(x,i)                 (x)[(i)].event_reg_id.pci_id.data_size
+#define EVENT_REG_desc_id(x,i)                     (x)[(i)].desc_id
+#define EVENT_REG_flags(x,i)                       (x)[(i)].flags
+#define EVENT_REG_reg_value(x,i)                   (x)[(i)].reg_value
+#define EVENT_REG_max_bits(x,i)                    (x)[(i)].max_bits
+#define EVENT_REG_scheduled(x,i)                   (x)[(i)].scheduled
+// PCI config-specific fields
+#define EVENT_REG_bus_no(x,i)                      (x)[(i)].bus_no
+#define EVENT_REG_dev_no(x,i)                      (x)[(i)].dev_no
+#define EVENT_REG_func_no(x,i)                     (x)[(i)].func_no
+#define EVENT_REG_secondary_pci_offset_shift(x,i)  (x)[(i)].secondary_pci_offset_shift
+#define EVENT_REG_secondary_pci_offset_offset(x,i) (x)[(i)].secondary_pci_offset_offset
+#define EVENT_REG_secondary_pci_offset_mask(x,i)   (x)[(i)].secondary_pci_offset_mask
+
+#define EVENT_REG_counter_type(x,i)                (x)[(i)].counter_type
+#define EVENT_REG_event_scope(x,i)                 (x)[(i)].event_scope
+#define EVENT_REG_reg_prog_type(x,i)               (x)[(i)].reg_prog_type
+#define EVENT_REG_reg_rw_type(x,i)                 (x)[(i)].reg_rw_type
+#define EVENT_REG_reg_order(x,i)                   (x)[(i)].reg_order
+#define EVENT_REG_bit_position(x,i)                (x)[(i)].bit_position
+
+//
+// Config bits
+//
+#define EVENT_REG_precise_bit               0x00000001
+#define EVENT_REG_global_bit                0x00000002
+#define EVENT_REG_uncore_bit                0x00000004
+#define EVENT_REG_uncore_q_rst_bit          0x00000008
+#define EVENT_REG_latency_bit               0x00000010
+#define EVENT_REG_is_gp_reg_bit             0x00000020
+#define EVENT_REG_clean_up_bit              0x00000040
+#define EVENT_REG_em_trigger_bit            0x00000080
+#define EVENT_REG_lbr_value_bit             0x00000100
+#define EVENT_REG_fixed_reg_bit             0x00000200
+#define EVENT_REG_multi_pkg_evt_bit         0x00001000
+#define EVENT_REG_branch_evt_bit            0x00002000
+
+//
+// Accessor macros for config bits
+//
+#define EVENT_REG_precise_get(x,i)          ((x)[(i)].flags &   EVENT_REG_precise_bit)
+#define EVENT_REG_precise_set(x,i)          ((x)[(i)].flags |=  EVENT_REG_precise_bit)
+#define EVENT_REG_precise_clear(x,i)        ((x)[(i)].flags &= ~EVENT_REG_precise_bit)
+
+#define EVENT_REG_global_get(x,i)           ((x)[(i)].flags &   EVENT_REG_global_bit)
+#define EVENT_REG_global_set(x,i)           ((x)[(i)].flags |=  EVENT_REG_global_bit)
+#define EVENT_REG_global_clear(x,i)         ((x)[(i)].flags &= ~EVENT_REG_global_bit)
+
+#define EVENT_REG_uncore_get(x,i)           ((x)[(i)].flags &   EVENT_REG_uncore_bit)
+#define EVENT_REG_uncore_set(x,i)           ((x)[(i)].flags |=  EVENT_REG_uncore_bit)
+#define EVENT_REG_uncore_clear(x,i)         ((x)[(i)].flags &= ~EVENT_REG_uncore_bit)
+
+#define EVENT_REG_uncore_q_rst_get(x,i)     ((x)[(i)].flags &   EVENT_REG_uncore_q_rst_bit)
+#define EVENT_REG_uncore_q_rst_set(x,i)     ((x)[(i)].flags |=  EVENT_REG_uncore_q_rst_bit)
+#define EVENT_REG_uncore_q_rst_clear(x,i)   ((x)[(i)].flags &= ~EVENT_REG_uncore_q_rst_bit)
+
+#define EVENT_REG_latency_get(x,i)          ((x)[(i)].flags &   EVENT_REG_latency_bit)
+#define EVENT_REG_latency_set(x,i)          ((x)[(i)].flags |=  EVENT_REG_latency_bit)
+#define EVENT_REG_latency_clear(x,i)        ((x)[(i)].flags &= ~EVENT_REG_latency_bit)
+
+#define EVENT_REG_is_gp_reg_get(x,i)        ((x)[(i)].flags &   EVENT_REG_is_gp_reg_bit)
+#define EVENT_REG_is_gp_reg_set(x,i)        ((x)[(i)].flags |=  EVENT_REG_is_gp_reg_bit)
+#define EVENT_REG_is_gp_reg_clear(x,i)      ((x)[(i)].flags &= ~EVENT_REG_is_gp_reg_bit)
+
+#define EVENT_REG_lbr_value_get(x,i)        ((x)[(i)].flags &   EVENT_REG_lbr_value_bit)
+#define EVENT_REG_lbr_value_set(x,i)        ((x)[(i)].flags |=  EVENT_REG_lbr_value_bit)
+#define EVENT_REG_lbr_value_clear(x,i)      ((x)[(i)].flags &= ~EVENT_REG_lbr_value_bit)
+
+#define EVENT_REG_fixed_reg_get(x,i)        ((x)[(i)].flags &   EVENT_REG_fixed_reg_bit)
+#define EVENT_REG_fixed_reg_set(x,i)        ((x)[(i)].flags |=  EVENT_REG_fixed_reg_bit)
+#define EVENT_REG_fixed_reg_clear(x,i)      ((x)[(i)].flags &= ~EVENT_REG_fixed_reg_bit)
+
+#define EVENT_REG_multi_pkg_evt_bit_get(x,i)   ((x)[(i)].flags &   EVENT_REG_multi_pkg_evt_bit)
+#define EVENT_REG_multi_pkg_evt_bit_set(x,i)   ((x)[(i)].flags |=  EVENT_REG_multi_pkg_evt_bit)
+#define EVENT_REG_multi_pkg_evt_bit_clear(x,i) ((x)[(i)].flags &= ~EVENT_REG_multi_pkg_evt_bit)
+
+#define EVENT_REG_clean_up_get(x,i)         ((x)[(i)].flags &   EVENT_REG_clean_up_bit)
+#define EVENT_REG_clean_up_set(x,i)         ((x)[(i)].flags |=  EVENT_REG_clean_up_bit)
+#define EVENT_REG_clean_up_clear(x,i)       ((x)[(i)].flags &= ~EVENT_REG_clean_up_bit)
+
+#define EVENT_REG_em_trigger_get(x,i)       ((x)[(i)].flags &   EVENT_REG_em_trigger_bit)
+#define EVENT_REG_em_trigger_set(x,i)       ((x)[(i)].flags |=  EVENT_REG_em_trigger_bit)
+#define EVENT_REG_em_trigger_clear(x,i)     ((x)[(i)].flags &= ~EVENT_REG_em_trigger_bit)
+
+#define EVENT_REG_branch_evt_get(x,i)       ((x)[(i)].flags &   EVENT_REG_branch_evt_bit)
+#define EVENT_REG_branch_evt_set(x,i)       ((x)[(i)].flags |=  EVENT_REG_branch_evt_bit)
+#define EVENT_REG_branch_evt_clear(x,i)     ((x)[(i)].flags &= ~EVENT_REG_branch_evt_bit)
+
+// ***************************************************************************
+
+/*!\struct DRV_PCI_DEVICE_ENTRY_NODE_S
+ * \var    bus_no          -  PCI bus no to read
+ * \var    dev_no          -  PCI device no to read
+ * \var    func_no            PCI device no to read
+ * \var    bar_offset         BASE Address Register offset of the PCI based PMU
+ * \var    bit_offset         Bit offset of the same
+ * \var    size               size of read/write
+ * \var    bar_address        the actual BAR present
+ * \var    enable_offset      Offset info to enable/disable
+ * \var    enabled            Status of enable/disable
+ * \brief  Data structure to describe the PCI Device
+ *
+ */
+
+typedef struct DRV_PCI_DEVICE_ENTRY_NODE_S  DRV_PCI_DEVICE_ENTRY_NODE;
+typedef        DRV_PCI_DEVICE_ENTRY_NODE   *DRV_PCI_DEVICE_ENTRY;
+
+struct DRV_PCI_DEVICE_ENTRY_NODE_S {
+    U32        bus_no;
+    U32        dev_no;
+    U32        func_no;
+    U32        bar_offset;
+    U64        bar_mask;
+    U32        bit_offset;
+    U32        size;
+    U64        bar_address;
+    U32        enable_offset;
+    U32        enabled;
+    U32        base_offset_for_mmio;
+    U32        operation;
+    U32        bar_name;
+    U32        prog_type;
+    U32        config_type;
+    S8         bar_shift;     // positive shifts right, negative shifts left
+    U8         reserved0;
+    U16        reserved1;
+    U64        value;
+    U64        mask;
+    U64        virtual_address;
+    U32        port_id;
+    U32        op_code;
+    U32        device_id;
+    U16        bar_num;
+    U16        feature_id;
+    U64        reserved2;
+    U64        reserved3;
+    U64        reserved4;
+};
+
+//
+// Accessor macros for DRV_PCI_DEVICE_NODE node
+//
+#define DRV_PCI_DEVICE_ENTRY_bus_no(x)                (x)->bus_no
+#define DRV_PCI_DEVICE_ENTRY_dev_no(x)                (x)->dev_no
+#define DRV_PCI_DEVICE_ENTRY_func_no(x)               (x)->func_no
+#define DRV_PCI_DEVICE_ENTRY_bar_offset(x)            (x)->bar_offset
+#define DRV_PCI_DEVICE_ENTRY_bar_mask(x)              (x)->bar_mask
+#define DRV_PCI_DEVICE_ENTRY_bit_offset(x)            (x)->bit_offset
+#define DRV_PCI_DEVICE_ENTRY_size(x)                  (x)->size
+#define DRV_PCI_DEVICE_ENTRY_bar_address(x)           (x)->bar_address
+#define DRV_PCI_DEVICE_ENTRY_enable_offset(x)         (x)->enable_offset
+#define DRV_PCI_DEVICE_ENTRY_enable(x)                (x)->enabled
+#define DRV_PCI_DEVICE_ENTRY_base_offset_for_mmio(x)  (x)->base_offset_for_mmio
+#define DRV_PCI_DEVICE_ENTRY_operation(x)             (x)->operation
+#define DRV_PCI_DEVICE_ENTRY_bar_name(x)              (x)->bar_name
+#define DRV_PCI_DEVICE_ENTRY_prog_type(x)             (x)->prog_type
+#define DRV_PCI_DEVICE_ENTRY_config_type(x)           (x)->config_type
+#define DRV_PCI_DEVICE_ENTRY_bar_shift(x)             (x)->bar_shift
+#define DRV_PCI_DEVICE_ENTRY_value(x)                 (x)->value
+#define DRV_PCI_DEVICE_ENTRY_mask(x)                  (x)->mask
+#define DRV_PCI_DEVICE_ENTRY_virtual_address(x)       (x)->virtual_address
+#define DRV_PCI_DEVICE_ENTRY_port_id(x)               (x)->port_id
+#define DRV_PCI_DEVICE_ENTRY_op_code(x)               (x)->op_code
+#define DRV_PCI_DEVICE_ENTRY_device_id(x)             (x)->device_id
+#define DRV_PCI_DEVICE_ENTRY_bar_num(x)               (x)->bar_num
+#define DRV_PCI_DEVICE_ENTRY_feature_id(x)            (x)->feature_id
+
+// ***************************************************************************
+typedef enum {
+    PMU_OPERATION_INITIALIZE = 0,
+    PMU_OPERATION_WRITE,
+    PMU_OPERATION_ENABLE,
+    PMU_OPERATION_DISABLE,
+    PMU_OPERATION_READ,
+    PMU_OPERATION_CLEANUP,
+    PMU_OPERATION_READ_LBRS,
+} PMU_OPERATION_TYPES;
+#define MAX_OPERATION_TYPES   16
+
+/*!\struct PMU_OPERATIONS_NODE
+ * \var    operation_type -    Type of operation from enumeration PMU_OPERATION_TYPES
+ * \var    register_start -    Start index of the registers for a specific operation
+ * \var    register_len   -    Number of registers for a specific operation
+ *
+ * \brief
+ * Structure for defining start and end indices in the ECB entries array for
+ * each type of operation performed in the driver
+ * initialize, write, read, enable, disable, etc.
+ */
+typedef struct PMU_OPERATIONS_NODE_S  PMU_OPERATIONS_NODE;
+typedef        PMU_OPERATIONS_NODE   *PMU_OPERATIONS;
+struct PMU_OPERATIONS_NODE_S {
+    U32 operation_type;
+    U32 register_start;
+    U32 register_len;
+    U32 reserved1;
+    U32 reserved2;
+    U32 reserved3;
+};
+#define PMU_OPERATIONS_operation_type(x)             (x)->operation_type
+#define PMU_OPERATIONS_register_start(x)             (x)->register_start
+#define PMU_OPERATIONS_register_len(x)               (x)->register_len
+#define PMU_OPER_operation_type(x,i)                 (x)[(i)].operation_type
+#define PMU_OPER_register_start(x,i)                 (x)[(i)].register_start
+#define PMU_OPER_register_len(x,i)                   (x)[(i)].register_len
+
+/*!\struct ECB_NODE_S
+ * \var    num_entries -       Total number of entries in "entries".
+ * \var    group_id    -       Group ID.
+ * \var    num_events  -       Number of events in this group.
+ * \var    cccr_start  -       Starting index of counter configuration control registers in "entries".
+ * \var    cccr_pop    -       Number of counter configuration control registers in "entries".
+ * \var    escr_start  -       Starting index of event selection control registers in "entries".
+ * \var    escr_pop    -       Number of event selection control registers in "entries".
+ * \var    data_start  -       Starting index of data registers in "entries".
+ * \var    data_pop    -       Number of data registers in "entries".
+ * \var    pcidev_entry_node   PCI device details for one device
+ * \var    entries     - .     All the register nodes required for programming
+ *
+ * \brief
+ */
+
+typedef struct ECB_NODE_S  ECB_NODE;
+typedef        ECB_NODE   *ECB;
+
+struct ECB_NODE_S {
+    U16                          version;
+    U16                          reserved1;
+    U32                          reserved2;
+    U32                          num_entries;
+    U32                          group_id;
+    U32                          num_events;
+    U32                          cccr_start;
+    U32                          cccr_pop;
+    U32                          escr_start;
+    U32                          escr_pop;
+    U32                          data_start;
+    U32                          data_pop;
+    U16                          flags;
+    U8                           pmu_timer_interval;
+    U8                           reserved0;
+    U32                          size_of_allocation;
+    U32                          group_offset;
+    DRV_PCI_DEVICE_ENTRY_NODE    pcidev_entry_node;
+    U32                          num_pci_devices;
+    U32                          pcidev_list_offset;
+    DRV_PCI_DEVICE_ENTRY         pcidev_entry_list;
+#if defined(DRV_IA32)
+    U32                          reserved3;
+#endif
+    U32                          device_type;
+    U32                          dev_node;
+    PMU_OPERATIONS_NODE          operations[MAX_OPERATION_TYPES];
+    U32                          descriptor_id;
+    U32                          reserved4;
+    U32                          metric_start;
+    U32                          metric_pop;
+    U64                          reserved6;
+    EVENT_REG_NODE               entries[];
+};
+
+//
+// Accessor macros for ECB node
+//
+#define ECB_version(x)                    (x)->version
+#define ECB_num_entries(x)                (x)->num_entries
+#define ECB_group_id(x)                   (x)->group_id
+#define ECB_num_events(x)                 (x)->num_events
+#define ECB_cccr_start(x)                 (x)->cccr_start
+#define ECB_cccr_pop(x)                   (x)->cccr_pop
+#define ECB_escr_start(x)                 (x)->escr_start
+#define ECB_escr_pop(x)                   (x)->escr_pop
+#define ECB_data_start(x)                 (x)->data_start
+#define ECB_data_pop(x)                   (x)->data_pop
+#define ECB_metric_start(x)               (x)->metric_start
+#define ECB_metric_pop(x)                 (x)->metric_pop
+#define ECB_pcidev_entry_node(x)          (x)->pcidev_entry_node
+#define ECB_num_pci_devices(x)            (x)->num_pci_devices
+#define ECB_pcidev_list_offset(x)         (x)->pcidev_list_offset
+#define ECB_pcidev_entry_list(x)          (x)->pcidev_entry_list
+#define ECB_flags(x)                      (x)->flags
+#define ECB_pmu_timer_interval(x)         (x)->pmu_timer_interval
+#define ECB_size_of_allocation(x)         (x)->size_of_allocation
+#define ECB_group_offset(x)               (x)->group_offset
+#define ECB_device_type(x)                (x)->device_type
+#define ECB_dev_node(x)                   (x)->dev_node
+#define ECB_operations(x)                 (x)->operations
+#define ECB_descriptor_id(x)              (x)->descriptor_id
+#define ECB_entries(x)                    (x)->entries
+
+// for flag bit field
+#define ECB_direct2core_bit                0x0001
+#define ECB_bl_bypass_bit                  0x0002
+#define ECB_pci_id_offset_bit              0x0003
+#define ECB_pcu_ccst_debug                 0x0004
+
+#define ECB_VERSION                        1
+
+#define ECB_CONSTRUCT(x,num_entries,group_id,cccr_start,escr_start,data_start, size_of_allocation)    \
+                                           ECB_num_entries((x)) = (num_entries);  \
+                                           ECB_group_id((x)) = (group_id);        \
+                                           ECB_cccr_start((x)) = (cccr_start);    \
+                                           ECB_cccr_pop((x)) = 0;                 \
+                                           ECB_escr_start((x)) = (escr_start);    \
+                                           ECB_escr_pop((x)) = 0;                 \
+                                           ECB_data_start((x)) = (data_start);    \
+                                           ECB_data_pop((x)) = 0;                 \
+                                           ECB_metric_start((x)) = 0;             \
+                                           ECB_metric_pop((x)) = 0;               \
+                                           ECB_num_pci_devices((x)) = 0;          \
+                                           ECB_version((x)) = ECB_VERSION;        \
+                                           ECB_size_of_allocation((x)) = (size_of_allocation);
+
+#define ECB_CONSTRUCT2(x, num_entries, group_id, size_of_allocation)    \
+                                           ECB_num_entries((x)) = (num_entries);  \
+                                           ECB_group_id((x)) = (group_id);        \
+                                           ECB_num_pci_devices((x)) = 0;          \
+                                           ECB_version((x)) = ECB_VERSION;        \
+                                           ECB_size_of_allocation((x)) = (size_of_allocation);
+
+#define ECB_CONSTRUCT1(x,num_entries,group_id,cccr_start,escr_start,data_start,num_pci_devices, size_of_allocation)    \
+                                           ECB_num_entries((x)) = (num_entries);  \
+                                           ECB_group_id((x)) = (group_id);        \
+                                           ECB_cccr_start((x)) = (cccr_start);    \
+                                           ECB_cccr_pop((x)) = 0;                 \
+                                           ECB_escr_start((x)) = (escr_start);    \
+                                           ECB_escr_pop((x)) = 0;                 \
+                                           ECB_data_start((x)) = (data_start);    \
+                                           ECB_data_pop((x)) = 0;                 \
+                                           ECB_metric_start((x)) = 0;             \
+                                           ECB_metric_pop((x)) = 0;               \
+                                           ECB_num_pci_devices((x)) = (num_pci_devices);  \
+                                           ECB_version((x)) = ECB_VERSION;        \
+                                           ECB_size_of_allocation((x)) = (size_of_allocation);
+
+//
+// Accessor macros for ECB node entries
+//
+#define ECB_entries_reg_type(x,i)                    EVENT_REG_reg_type((ECB_entries(x)),(i))
+#define ECB_entries_event_id_index(x,i)              EVENT_REG_event_id_index((ECB_entries(x)),(i))
+#define ECB_entries_event_id_index_local(x,i)        EVENT_REG_event_id_index_local((ECB_entries(x)),(i))
+#define ECB_entries_emon_event_id_index_local(x,i)   EVENT_REG_emon_event_id_index_local((ECB_entries(x)),(i))
+#define ECB_entries_counter_event_offset(x,i)        EVENT_REG_counter_event_offset((ECB_entries(x)),(i))
+#define ECB_entries_reg_id(x,i)                      EVENT_REG_reg_id((ECB_entries(x)),(i))
+#define ECB_entries_reg_prog_type(x,i)               EVENT_REG_reg_prog_type((ECB_entries(x)),(i))
+#define ECB_entries_pci_id(x,i)                      EVENT_REG_pci_id((ECB_entries(x)),(i))
+#define ECB_entries_pci_id_offset(x,i)               EVENT_REG_pci_id_offset((ECB_entries(x)),(i))
+#define ECB_entries_pci_id_data_size(x,i)            EVENT_REG_pci_id_size((ECB_entries(x)),(i))
+#define ECB_entries_desc_id(x,i)                     EVENT_REG_desc_id((ECB_entries(x)),i)
+#define ECB_entries_flags(x,i)                       EVENT_REG_flags((ECB_entries(x)),i)
+#define ECB_entries_reg_order(x,i)                   EVENT_REG_reg_order((ECB_entries(x)),i)
+#define ECB_entries_reg_value(x,i)                   EVENT_REG_reg_value((ECB_entries(x)),(i))
+#define ECB_entries_max_bits(x,i)                    EVENT_REG_max_bits((ECB_entries(x)),(i))
+#define ECB_entries_scheduled(x,i)                   EVENT_REG_scheduled((ECB_entries(x)),(i))
+#define ECB_entries_group_index(x,i)                 EVENT_REG_group_index((ECB_entries(x)),(i))
+#define ECB_entries_counter_event_offset(x,i)        EVENT_REG_counter_event_offset((ECB_entries(x)),(i))
+#define ECB_entries_bit_position(x,i)                EVENT_REG_bit_position((ECB_entries(x)),(i))
+// PCI config-specific fields
+#define ECB_entries_bus_no(x,i)                      EVENT_REG_bus_no((ECB_entries(x)),(i))
+#define ECB_entries_dev_no(x,i)                      EVENT_REG_dev_no((ECB_entries(x)),(i))
+#define ECB_entries_func_no(x,i)                     EVENT_REG_func_no((ECB_entries(x)),(i))
+#define ECB_entries_counter_type(x,i)                EVENT_REG_counter_type((ECB_entries(x)),(i))
+#define ECB_entries_event_scope(x,i)                 EVENT_REG_event_scope((ECB_entries(x)),(i))
+#define ECB_entries_precise_get(x,i)                 EVENT_REG_precise_get((ECB_entries(x)),(i))
+#define ECB_entries_global_get(x,i)                  EVENT_REG_global_get((ECB_entries(x)),(i))
+#define ECB_entries_uncore_get(x,i)                  EVENT_REG_uncore_get((ECB_entries(x)),(i))
+#define ECB_entries_uncore_q_rst_get(x,i)            EVENT_REG_uncore_q_rst_get((ECB_entries(x)),(i))
+#define ECB_entries_is_gp_reg_get(x,i)               EVENT_REG_is_gp_reg_get((ECB_entries(x)),(i))
+#define ECB_entries_lbr_value_get(x,i)               EVENT_REG_lbr_value_get((ECB_entries(x)),(i))
+#define ECB_entries_fixed_reg_get(x,i)               EVENT_REG_fixed_reg_get((ECB_entries(x)),(i))
+#define ECB_entries_is_multi_pkg_bit_set(x,i)        EVENT_REG_multi_pkg_evt_bit_get((ECB_entries(x)),(i))
+#define ECB_entries_clean_up_get(x,i)                EVENT_REG_clean_up_get((ECB_entries(x)),(i))
+#define ECB_entries_em_trigger_get(x,i)              EVENT_REG_em_trigger_get((ECB_entries(x)),(i))
+#define ECB_entries_branch_evt_get(x,i)              EVENT_REG_branch_evt_get((ECB_entries(x)),(i))
+#define ECB_entries_reg_rw_type(x,i)                 EVENT_REG_reg_rw_type((ECB_entries(x)),(i))
+#define ECB_entries_secondary_pci_offset_offset(x,i) EVENT_REG_secondary_pci_offset_offset((ECB_entries(x)),(i))
+#define ECB_entries_secondary_pci_offset_shift(x,i)  EVENT_REG_secondary_pci_offset_shift((ECB_entries(x)),(i))
+#define ECB_entries_secondary_pci_offset_mask(x,i)   EVENT_REG_secondary_pci_offset_mask((ECB_entries(x)),(i))
+#define ECB_operations_operation_type(x,i)           PMU_OPER_operation_type((ECB_operations(x)),(i))
+#define ECB_operations_register_start(x,i)           PMU_OPER_register_start((ECB_operations(x)),(i))
+#define ECB_operations_register_len(x,i)             PMU_OPER_register_len((ECB_operations(x)),(i))
+
+#define ECB_SET_OPERATIONS(x, operation_type, start, len)                                \
+                     ECB_operations_operation_type(x, operation_type) = operation_type;  \
+                     ECB_operations_register_start(x, operation_type) = start;           \
+                     ECB_operations_register_len(x, operation_type)   = len;             \
+
+// ***************************************************************************
+
+/*!\struct  LBR_ENTRY_NODE_S
+ * \var     etype       TOS = 0; FROM = 1; TO = 2
+ * \var     type_index
+ * \var     reg_id
+ */
+
+typedef struct LBR_ENTRY_NODE_S  LBR_ENTRY_NODE;
+typedef        LBR_ENTRY_NODE   *LBR_ENTRY;
+
+struct LBR_ENTRY_NODE_S {
+    U16    etype;
+    U16    type_index;
+    U32    reg_id;
+};
+
+//
+// Accessor macros for LBR entries
+//
+#define LBR_ENTRY_NODE_etype(lentry)          (lentry).etype
+#define LBR_ENTRY_NODE_type_index(lentry)     (lentry).type_index
+#define LBR_ENTRY_NODE_reg_id(lentry)         (lentry).reg_id
+
+// ***************************************************************************
+
+/*!\struct LBR_NODE_S
+ * \var    num_entries     -  The number of entries
+ * \var    entries         -  The entries in the list
+ *
+ * \brief  Data structure to describe the LBR registers that need to be read
+ *
+ */
+
+typedef struct LBR_NODE_S  LBR_NODE;
+typedef        LBR_NODE   *LBR;
+
+struct LBR_NODE_S {
+    U32               size;
+    U32               num_entries;
+    LBR_ENTRY_NODE    entries[];
+};
+
+//
+// Accessor macros for LBR node
+//
+#define LBR_size(lbr)                      (lbr)->size
+#define LBR_num_entries(lbr)               (lbr)->num_entries
+#define LBR_entries_etype(lbr,idx)         (lbr)->entries[idx].etype
+#define LBR_entries_type_index(lbr,idx)    (lbr)->entries[idx].type_index
+#define LBR_entries_reg_id(lbr,idx)        (lbr)->entries[idx].reg_id
+
+// ***************************************************************************
+
+/*!\struct  PWR_ENTRY_NODE_S
+ * \var     etype       none as yet
+ * \var     type_index
+ * \var     reg_id
+ */
+
+typedef struct PWR_ENTRY_NODE_S  PWR_ENTRY_NODE;
+typedef        PWR_ENTRY_NODE   *PWR_ENTRY;
+
+struct PWR_ENTRY_NODE_S {
+    U16    etype;
+    U16    type_index;
+    U32    reg_id;
+};
+
+//
+// Accessor macros for PWR entries
+//
+#define PWR_ENTRY_NODE_etype(lentry)          (lentry).etype
+#define PWR_ENTRY_NODE_type_index(lentry)     (lentry).type_index
+#define PWR_ENTRY_NODE_reg_id(lentry)         (lentry).reg_id
+
+// ***************************************************************************
+
+/*!\struct PWR_NODE_S
+ * \var    num_entries     -  The number of entries
+ * \var    entries         -  The entries in the list
+ *
+ * \brief  Data structure to describe the PWR registers that need to be read
+ *
+ */
+
+typedef struct PWR_NODE_S  PWR_NODE;
+typedef        PWR_NODE   *PWR;
+
+struct PWR_NODE_S {
+    U32               size;
+    U32               num_entries;
+    PWR_ENTRY_NODE    entries[];
+};
+
+//
+// Accessor macros for PWR node
+//
+#define PWR_size(lbr)                      (lbr)->size
+#define PWR_num_entries(lbr)               (lbr)->num_entries
+#define PWR_entries_etype(lbr,idx)         (lbr)->entries[idx].etype
+#define PWR_entries_type_index(lbr,idx)    (lbr)->entries[idx].type_index
+#define PWR_entries_reg_id(lbr,idx)        (lbr)->entries[idx].reg_id
+
+// ***************************************************************************
+
+/*!\struct  RO_ENTRY_NODE_S
+ * \var     type       - DEAR, IEAR, BTB.
+ */
+
+typedef struct RO_ENTRY_NODE_S  RO_ENTRY_NODE;
+typedef        RO_ENTRY_NODE   *RO_ENTRY;
+
+struct RO_ENTRY_NODE_S {
+    U32    reg_id;
+};
+
+//
+// Accessor macros for RO entries
+//
+#define RO_ENTRY_NODE_reg_id(lentry)       (lentry).reg_id
+
+// ***************************************************************************
+
+/*!\struct RO_NODE_S
+ * \var    size            - The total size including header and entries.
+ * \var    num_entries     - The number of entries.
+ * \var    entries         - The entries in the list.
+ *
+ * \brief  Data structure to describe the RO registers that need to be read.
+ *
+ */
+
+typedef struct RO_NODE_S  RO_NODE;
+typedef        RO_NODE   *RO;
+
+struct RO_NODE_S {
+    U32              size;
+    U32              num_entries;
+    RO_ENTRY_NODE    entries[];
+};
+
+//
+// Accessor macros for RO node
+//
+#define RO_size(ro)                      (ro)->size
+#define RO_num_entries(ro)               (ro)->num_entries
+#define RO_entries_reg_id(ro,idx)        (ro)->entries[idx].reg_id
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif
+

--- a/perftools-external/soc_perf_driver/include/lwpmudrv_ioctl.h
+++ b/perftools-external/soc_perf_driver/include/lwpmudrv_ioctl.h
@@ -1,0 +1,302 @@
+/* ***********************************************************************************************
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or 
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(C) 2007-2018 Intel Corporation. All rights reserved.
+
+  This program is free software; you can redistribute it and/or modify 
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but 
+  WITHOUT ANY WARRANTY; without even the implied warranty of 
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License 
+  along with this program; if not, write to the Free Software 
+  Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+  The full GNU General Public License is included in this distribution 
+  in the file called LICENSE.GPL.
+
+  BSD LICENSE 
+
+  Copyright(C) 2007-2018 Intel Corporation. All rights reserved.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+    * Redistributions of source code must retain the above copyright 
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright 
+      notice, this list of conditions and the following disclaimer in 
+      the documentation and/or other materials provided with the 
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its 
+      contributors may be used to endorse or promote products derived 
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ***********************************************************************************************
+*/
+
+#ifndef _LWPMUDRV_IOCTL_H_
+#define _LWPMUDRV_IOCTL_H_
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+
+//SEP Driver Operation defines
+//
+#define DRV_OPERATION_START                          1
+#define DRV_OPERATION_STOP                           2
+#define DRV_OPERATION_INIT_PMU                       3
+#define DRV_OPERATION_GET_NORMALIZED_TSC             4
+#define DRV_OPERATION_TSC_SKEW_INFO                  5
+#define DRV_OPERATION_PAUSE                          6
+#define DRV_OPERATION_RESUME                         7
+#define DRV_OPERATION_TERMINATE                      8
+#define DRV_OPERATION_RESERVE                        9
+#define DRV_OPERATION_VERSION                        10
+#define DRV_OPERATION_SWITCH_GROUP                   11
+#define DRV_OPERATION_GET_DRIVER_STATE               12
+#define DRV_OPERATION_INIT_UNCORE                    13
+#define DRV_OPERATION_EM_GROUPS_UNCORE               14
+#define DRV_OPERATION_EM_CONFIG_NEXT_UNCORE          15
+#define DRV_OPERATION_READ_UNCORE_DATA               16
+#define DRV_OPERATION_STOP_MEM                       17
+#define DRV_OPERATION_CREATE_MEM                     18
+#define DRV_OPERATION_READ_MEM                       19
+#define DRV_OPERATION_CHECK_STATUS                   20
+#define DRV_OPERATION_TIMER_TRIGGER_READ             21
+
+// IOCTL_SETUP
+//
+
+#if defined(DRV_OS_WINDOWS)
+
+//
+// NtDeviceIoControlFile IoControlCode values for this device.
+//
+// Warning:  Remember that the low two bits of the code specify how the
+//           buffers are passed to the driver!
+//
+// 16 bit device type. 12 bit function codes
+#define LWPMUDRV_IOCTL_DEVICE_TYPE  0xA000   // values 0-32768 reserved for Microsoft
+#define LWPMUDRV_IOCTL_FUNCTION     0x0A00   // values 0-2047  reserved for Microsoft
+
+//
+// Basic CTL CODE macro to reduce typographical errors
+// Use for FILE_READ_ACCESS
+//
+#define LWPMUDRV_CTL_READ_CODE(x)    CTL_CODE(LWPMUDRV_IOCTL_DEVICE_TYPE,  \
+                                              LWPMUDRV_IOCTL_FUNCTION+(x), \
+                                              METHOD_BUFFERED,             \
+                                              FILE_READ_ACCESS)
+
+#define LWPMUDRV_IOCTL_START                        LWPMUDRV_CTL_READ_CODE(DRV_OPERATION_START)
+#define LWPMUDRV_IOCTL_STOP                         LWPMUDRV_CTL_READ_CODE(DRV_OPERATION_STOP)
+#define LWPMUDRV_IOCTL_INIT_PMU                     LWPMUDRV_CTL_READ_CODE(DRV_OPERATION_INIT_PMU)
+#define LWPMUDRV_IOCTL_GET_NORMALIZED_TSC           LWPMUDRV_CTL_READ_CODE(DRV_OPERATION_GET_NORMALIZED_TSC)
+#define LWPMUDRV_IOCTL_TSC_SKEW_INFO                LWPMUDRV_CTL_READ_CODE(DRV_OPERATION_TSC_SKEW_INFO)
+#define LWPMUDRV_IOCTL_PAUSE                        LWPMUDRV_CTL_READ_CODE(DRV_OPERATION_PAUSE)
+#define LWPMUDRV_IOCTL_RESUME                       LWPMUDRV_CTL_READ_CODE(DRV_OPERATION_RESUME)
+#define LWPMUDRV_IOCTL_TERMINATE                    LWPMUDRV_CTL_READ_CODE(DRV_OPERATION_TERMINATE)
+#define LWPMUDRV_IOCTL_RESERVE                      LWPMUDRV_CTL_READ_CODE(DRV_OPERATION_RESERVE)
+#define LWPMUDRV_IOCTL_VERSION                      LWPMUDRV_CTL_READ_CODE(DRV_OPERATION_VERSION)
+#define LWPMUDRV_IOCTL_SWITCH_GROUP                 LWPMUDRV_CTL_READ_CODE(DRV_OPERATION_SWITCH_GROUP)
+#define LWPMUDRV_IOCTL_GET_DRIVER_STATE             LWPMUDRV_CTL_READ_CODE(DRV_OPERATION_GET_DRIVER_STATE)
+#define LWPMUDRV_IOCTL_INIT_UNCORE                  LWPMUDRV_CTL_READ_CODE(DRV_OPERATION_INIT_UNCORE)
+#define LWPMUDRV_IOCTL_EM_GROUPS_UNCORE             LWPMUDRV_CTL_READ_CODE(DRV_OPERATION_EM_GROUPS_UNCORE)
+#define LWPMUDRV_IOCTL_EM_CONFIG_NEXT_UNCORE        LWPMUDRV_CTL_READ_CODE(DRV_OPERATION_EM_CONFIG_NEXT_UNCORE)
+#define LWPMUDRV_IOCTL_READ_UNCORE_DATA             LWPMUDRV_CTL_READ_CODE(DRV_OPERATION_READ_UNCORE_DATA)
+#define LWPMUDRV_IOCTL_STOP_MEM                     LWPMUDRV_CTL_READ_CODE(DRV_OPERATION_STOP_MEM)
+#define LWPMUDRV_IOCTL_CREATE_MEM                   LWPMUDRV_CTL_READ_CODE(DRV_OPERATION_CREATE_MEM)
+#define LWPMUDRV_IOCTL_READ_MEM                     LWPMUDRV_CTL_READ_CODE(DRV_OPERATION_READ_MEM)
+#define LWPMUDRV_IOCTL_CHECK_STATUS                 LWPMUDRV_CTL_READ_CODE(DRV_OPERATION_CHECK_STATUS)
+#define LWPMUDRV_IOCTL_TIMER_TRIGGER_READ           LWPMUDRV_CTL_READ_CODE(DRV_OPERATION_TIMER_TRIGGER_READ)
+
+#elif defined(DRV_OS_LINUX) || defined(DRV_OS_SOLARIS) || defined (DRV_OS_ANDROID)
+// IOCTL_ARGS
+typedef struct IOCTL_ARGS_NODE_S  IOCTL_ARGS_NODE;
+typedef        IOCTL_ARGS_NODE   *IOCTL_ARGS;
+struct IOCTL_ARGS_NODE_S {
+    U64    r_len;
+    U64    w_len;
+    char  *r_buf;
+    char  *w_buf;
+};
+
+// COMPAT IOCTL_ARGS
+#if defined (CONFIG_COMPAT) && defined(DRV_EM64T)
+typedef struct IOCTL_COMPAT_ARGS_NODE_S  IOCTL_COMPAT_ARGS_NODE;
+typedef        IOCTL_COMPAT_ARGS_NODE   *IOCTL_COMPAT_ARGS;
+struct IOCTL_COMPAT_ARGS_NODE_S {
+    U64            r_len;
+    U64            w_len;
+    compat_uptr_t  r_buf;
+    compat_uptr_t  w_buf;
+};
+#endif
+
+#define LWPMU_IOC_MAGIC   99
+
+// IOCTL_SETUP
+//
+#define LWPMUDRV_IOCTL_START                  _IO (LWPMU_IOC_MAGIC, DRV_OPERATION_START)
+#define LWPMUDRV_IOCTL_STOP                   _IO (LWPMU_IOC_MAGIC, DRV_OPERATION_STOP)
+#define LWPMUDRV_IOCTL_INIT_PMU               _IOW(LWPMU_IOC_MAGIC, DRV_OPERATION_INIT_PMU, IOCTL_ARGS)
+#define LWPMUDRV_IOCTL_GET_NORMALIZED_TSC     _IOW(LWPMU_IOC_MAGIC, DRV_OPERATION_GET_NORMALIZED_TSC, int)
+#define LWPMUDRV_IOCTL_TSC_SKEW_INFO          _IOW(LWPMU_IOC_MAGIC, DRV_OPERATION_TSC_SKEW_INFO, IOCTL_ARGS)
+#define LWPMUDRV_IOCTL_PAUSE                  _IO (LWPMU_IOC_MAGIC, DRV_OPERATION_PAUSE)
+#define LWPMUDRV_IOCTL_RESUME                 _IO (LWPMU_IOC_MAGIC, DRV_OPERATION_RESUME)
+#define LWPMUDRV_IOCTL_TERMINATE              _IO (LWPMU_IOC_MAGIC, DRV_OPERATION_TERMINATE)
+#define LWPMUDRV_IOCTL_RESERVE                _IOR(LWPMU_IOC_MAGIC, DRV_OPERATION_RESERVE, IOCTL_ARGS)
+#define LWPMUDRV_IOCTL_VERSION                _IOR(LWPMU_IOC_MAGIC, DRV_OPERATION_VERSION, IOCTL_ARGS)
+#define LWPMUDRV_IOCTL_SWITCH_GROUP           _IO (LWPMU_IOC_MAGIC, DRV_OPERATION_SWITCH_GROUP)
+#define LWPMUDRV_IOCTL_GET_DRIVER_STATE       _IOW(LWPMU_IOC_MAGIC, DRV_OPERATION_GET_DRIVER_STATE, IOCTL_ARGS)
+#define LWPMUDRV_IOCTL_INIT_UNCORE            _IOW(LWPMU_IOC_MAGIC, DRV_OPERATION_INIT_UNCORE, IOCTL_ARGS)
+#define LWPMUDRV_IOCTL_EM_GROUPS_UNCORE       _IOW(LWPMU_IOC_MAGIC, DRV_OPERATION_EM_GROUPS_UNCORE, IOCTL_ARGS)
+#define LWPMUDRV_IOCTL_EM_CONFIG_NEXT_UNCORE  _IOW(LWPMU_IOC_MAGIC, DRV_OPERATION_EM_CONFIG_NEXT_UNCORE, IOCTL_ARGS)
+#define LWPMUDRV_IOCTL_READ_UNCORE_DATA       _IOR(LWPMU_IOC_MAGIC, DRV_OPERATION_READ_UNCORE_DATA, IOCTL_ARGS)
+#define LWPMUDRV_IOCTL_STOP_MEM               _IO (LWPMU_IOC_MAGIC, DRV_OPERATION_STOP_MEM)
+#define LWPMUDRV_IOCTL_CREATE_MEM             _IOW(LWPMU_IOC_MAGIC, DRV_OPERATION_CREATE_MEM, IOCTL_ARGS)
+#define LWPMUDRV_IOCTL_READ_MEM               _IOW(LWPMU_IOC_MAGIC, DRV_OPERATION_READ_MEM, IOCTL_ARGS)
+#define LWPMUDRV_IOCTL_CHECK_STATUS           _IOR(LWPMU_IOC_MAGIC, DRV_OPERATION_CHECK_STATUS, IOCTL_ARGS)
+#define LWPMUDRV_IOCTL_TIMER_TRIGGER_READ     _IO (LWPMU_IOC_MAGIC, DRV_OPERATION_TIMER_TRIGGER_READ)
+
+#elif defined(DRV_OS_FREEBSD)
+
+// IOCTL_ARGS
+typedef struct IOCTL_ARGS_NODE_S  IOCTL_ARGS_NODE;
+typedef        IOCTL_ARGS_NODE   *IOCTL_ARGS;
+struct IOCTL_ARGS_NODE_S {
+    U64    r_len;
+    char  *r_buf;
+    U64    w_len;
+    char  *w_buf;
+};
+
+// IOCTL_SETUP
+//
+#define LWPMU_IOC_MAGIC   99
+
+/* FreeBSD is very strict about IOR/IOW/IOWR specifications on IOCTLs.
+ * Since these IOCTLs all pass down the real read/write buffer lengths
+ *  and addresses inside of an IOCTL_ARGS_NODE data structure, we
+ *  need to specify all of these as _IOW so that the kernel will
+ *  view it as userspace passing the data to the driver, rather than
+ *  the reverse.  There are also some cases where Linux is passing
+ *  a smaller type than IOCTL_ARGS_NODE, even though its really
+ *  passing an IOCTL_ARGS_NODE.  These needed to be fixed for FreeBSD.
+ */
+#define LWPMUDRV_IOCTL_START                  _IO (LWPMU_IOC_MAGIC, DRV_OPERATION_START)
+#define LWPMUDRV_IOCTL_STOP                   _IO (LWPMU_IOC_MAGIC, DRV_OPERATION_STOP)
+#define LWPMUDRV_IOCTL_INIT_PMU               _IO (LWPMU_IOC_MAGIC, DRV_OPERATION_INIT_PMU)
+#define LWPMUDRV_IOCTL_GET_NORMALIZED_TSC     _IOW(LWPMU_IOC_MAGIC, DRV_OPERATION_GET_NORMALIZED_TSC, IOCTL_ARGS_NODE)
+#define LWPMUDRV_IOCTL_TSC_SKEW_INFO          _IOW(LWPMU_IOC_MAGIC, DRV_OPERATION_TSC_SKEW_INFO, IOCTL_ARGS_NODE)
+#define LWPMUDRV_IOCTL_PAUSE                  _IO (LWPMU_IOC_MAGIC, DRV_OPERATION_PAUSE)
+#define LWPMUDRV_IOCTL_RESUME                 _IO (LWPMU_IOC_MAGIC, DRV_OPERATION_RESUME)
+#define LWPMUDRV_IOCTL_TERMINATE              _IO (LWPMU_IOC_MAGIC, DRV_OPERATION_TERMINATE)
+#define LWPMUDRV_IOCTL_RESERVE                _IOW(LWPMU_IOC_MAGIC, DRV_OPERATION_RESERVE, IOCTL_ARGS_NODE)
+#define LWPMUDRV_IOCTL_VERSION                _IOW(LWPMU_IOC_MAGIC, DRV_OPERATION_VERSION, IOCTL_ARGS_NODE)
+#define LWPMUDRV_IOCTL_SWITCH_GROUP           _IO (LWPMU_IOC_MAGIC, DRV_OPERATION_SWITCH_GROUP)
+#define LWPMUDRV_IOCTL_GET_DRIVER_STATE       _IOW(LWPMU_IOC_MAGIC, DRV_OPERATION_GET_DRIVER_STATE, IOCTL_ARGS_NODE)
+#define LWPMUDRV_IOCTL_INIT_UNCORE            _IOW (LWPMU_IOC_MAGIC, DRV_OPERATION_INIT_UNCORE, IOCTL_ARGS)
+#define LWPMUDRV_IOCTL_EM_GROUPS_UNCORE       _IOW (LWPMU_IOC_MAGIC, DRV_OPERATION_EM_GROUPS_UNCORE, IOCTL_ARGS)
+#define LWPMUDRV_IOCTL_EM_CONFIG_NEXT_UNCORE  _IOW (LWPMU_IOC_MAGIC, DRV_OPERATION_EM_CONFIG_NEXT_UNCORE, IOCTL_ARGS)
+#define LWPMUDRV_IOCTL_READ_UNCORE_DATA       _IOR(LWPMU_IOC_MAGIC, DRV_OPERATION_READ_UNCORE_DATA, IOCTL_ARGS)
+#define LWPMUDRV_IOCTL_STOP_MEM               _IO (LWPMU_IOC_MAGIC, DRV_OPERATION_STOP_MEM)
+#define LWPMUDRV_IOCTL_CREATE_MEM             _IOW(LWPMU_IOC_MAGIC, DRV_OPERATION_CREATE_MEM, IOCTL_ARGS_NODE)
+#define LWPMUDRV_IOCTL_READ_MEM               _IOW(LWPMU_IOC_MAGIC, DRV_OPERATION_READ_MEM, IOCTL_ARGS_NODE)
+#define LWPMUDRV_IOCTL_CHECK_STATUS           _IOR(LWPMU_IOC_MAGIC, DRV_OPERATION_CHECK_STATUS, IOCTL_ARGS_NODE)
+#define LWPMUDRV_IOCTL_TIMER_TRIGGER_READ     _IO (LWPMU_IOC_MAGIC, DRV_OPERATION_TIMER_TRIGGER_READ)
+
+#elif defined(DRV_OS_MAC)
+
+// IOCTL_ARGS
+typedef struct IOCTL_ARGS_NODE_S  IOCTL_ARGS_NODE;
+typedef        IOCTL_ARGS_NODE   *IOCTL_ARGS;
+struct IOCTL_ARGS_NODE_S {
+	U64    r_len;
+	char  *r_buf;
+	U64    w_len;
+	char  *w_buf;
+	U32	  command;
+};
+
+typedef struct CPU_ARGS_NODE_S  CPU_ARGS_NODE;
+typedef        CPU_ARGS_NODE   *CPU_ARGS;
+struct CPU_ARGS_NODE_S {
+	U64    r_len;
+	char  *r_buf;
+	U32	  command;
+	U32	  CPU_ID;
+	U32	  BUCKET_ID;
+};
+
+// IOCTL_SETUP
+//
+#define LWPMU_IOC_MAGIC    99
+#define OS_SUCCESS         0
+#define OS_STATUS          int
+#define OS_ILLEGAL_IOCTL  -ENOTTY
+#define OS_NO_MEM         -ENOMEM
+#define OS_FAULT          -EFAULT
+
+// Task file Opcodes.
+// keeping the definitions as IOCTL but in MAC OSX
+// these are really OpCodes consumed by Execute command.
+#define LWPMUDRV_IOCTL_START                  DRV_OPERATION_START
+#define LWPMUDRV_IOCTL_STOP                   DRV_OPERATION_STOP
+#define LWPMUDRV_IOCTL_INIT_PMU               DRV_OPERATION_INIT_PMU
+#define LWPMUDRV_IOCTL_GET_NORMALIZED_TSC     DRV_OPERATION_GET_NORMALIZED_TSC
+#define LWPMUDRV_IOCTL_TSC_SKEW_INFO          DRV_OPERATION_TSC_SKEW_INFO
+#define LWPMUDRV_IOCTL_PAUSE                  DRV_OPERATION_PAUSE
+#define LWPMUDRV_IOCTL_RESUME                 DRV_OPERATION_RESUME
+#define LWPMUDRV_IOCTL_TERMINATE              DRV_OPERATION_TERMINATE
+#define LWPMUDRV_IOCTL_RESERVE                DRV_OPERATION_RESERVE
+#define LWPMUDRV_IOCTL_VERSION                DRV_OPERATION_VERSION
+#define LWPMUDRV_IOCTL_SWITCH_GROUP           DRV_OPERATION_SWITCH_GROUP
+#define LWPMUDRV_IOCTL_GET_DRIVER_STATE       DRV_OPERATION_GET_DRIVER_STATE
+#define LWPMUDRV_IOCTL_INIT_UNCORE            DRV_OPERATION_INIT_UNCORE
+#define LWPMUDRV_IOCTL_EM_GROUPS_UNCORE       DRV_OPERATION_EM_GROUPS_UNCORE
+#define LWPMUDRV_IOCTL_EM_CONFIG_NEXT_UNCORE  DRV_OPERATION_EM_CONFIG_NEXT_UNCORE
+#define LWPMUDRV_IOCTL_READ_UNCORE_DATA       DRV_OPERATION_READ_UNCORE_DATA
+#define LWPMUDRV_IOCTL_STOP_MEM               DRV_OPERATION_STOP_MEM
+#define LWPMUDRV_IOCTL_CREATE_MEM             DRV_OPERATION_CREATE_MEM
+#define LWPMUDRV_IOCTL_READ_MEM               DRV_OPERATION_READ_MEM
+#define LWPMUDRV_IOCTL_CHECK_STATUS           DRV_OPERATION_CHECK_STATUS
+#define LWPMUDRV_IOCTL_TIMER_TRIGGER_READ     DRV_OPERATION_TIMER_TRIGGER_READ
+
+// This is only for MAC OSX
+#define LWPMUDRV_IOCTL_SET_OSX_VERSION        998
+#define LWPMUDRV_IOCTL_PROVIDE_FUNCTION_PTRS  999
+
+#else
+#error "unknown OS in lwpmudrv_ioctl.h"
+#endif
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif
+

--- a/perftools-external/soc_perf_driver/include/lwpmudrv_struct.h
+++ b/perftools-external/soc_perf_driver/include/lwpmudrv_struct.h
@@ -1,0 +1,1723 @@
+/***
+ * -------------------------------------------------------------------------
+ *               INTEL CORPORATION PROPRIETARY INFORMATION
+ *  This software is supplied under the terms of the accompanying license
+ *  agreement or nondisclosure agreement with Intel Corporation and may not
+ *  be copied or disclosed except in accordance with the terms of that
+ *  agreement.
+ *        Copyright(C) 2007-2018 Intel Corporation.  All Rights Reserved.
+ * -------------------------------------------------------------------------
+***/
+
+#ifndef _LWPMUDRV_STRUCT_UTILS_H_
+#define _LWPMUDRV_STRUCT_UTILS_H_
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// processor execution modes
+#define MODE_UNKNOWN    99
+// the following defines must start at 0
+#define MODE_64BIT      3
+#define MODE_32BIT      2
+#define MODE_16BIT      1
+#define MODE_V86        0
+
+// sampling methods
+#define SM_RTC          2020     // real time clock
+#define SM_VTD          2021     // OS Virtual Timer Device
+#define SM_NMI          2022     // non-maskable interrupt time based
+#define SM_EBS          2023     // event based sampling
+#define SM_EBC          2024     // event based counting
+
+// sampling mechanism bitmap definitions
+#define INTERRUPT_RTC   0x1
+#define INTERRUPT_VTD   0x2
+#define INTERRUPT_NMI   0x4
+#define INTERRUPT_EBS   0x8
+
+// Device types
+#define DEV_CORE        0x01
+#define DEV_UNC         0x02
+
+// eflags defines
+#define EFLAGS_VM             0x00020000  // V86 mode
+#define EFLAGS_IOPL0          0
+#define EFLAGS_IOPL1          0x00001000
+#define EFLAGS_IOPL2          0x00002000
+#define EFLAGS_IOPL3          0x00003000
+#define MAX_EMON_GROUPS       1000
+#define MAX_PCI_BUSNO         256
+#define MAX_DEVICES           30
+#define MAX_REGS              64
+#define MAX_EMON_GROUPS       1000
+#define MAX_PCI_DEVNO         32
+#define MAX_PCI_FUNCNO        8
+#define MAX_PCI_DEVUNIT       16
+#define MAX_TURBO_VALUES      32
+#define REG_BIT_MASK          0xFFFFFFFFFFFFFFFFULL
+
+extern float freq_multiplier;
+
+// Enumeration for invoking dispatch on multiple cpus or not
+typedef enum {
+    DRV_MULTIPLE_INSTANCE = 0,
+    DRV_SINGLE_INSTANCE
+} DRV_PROG_TYPE;
+
+
+typedef struct DRV_CONFIG_NODE_S  DRV_CONFIG_NODE;
+typedef        DRV_CONFIG_NODE   *DRV_CONFIG;
+
+struct DRV_CONFIG_NODE_S {
+    U32          size;
+    U16          version;
+    U16          reserved1;
+    U32          reserved2;
+    U32          num_events;
+    DRV_BOOL     start_paused;
+    DRV_BOOL     counting_mode;
+    U32          dispatch_id;
+    DRV_BOOL     enable_chipset;
+    U32          num_chipset_events;
+    U32          chipset_offset;
+    DRV_BOOL     enable_gfx;
+    DRV_BOOL     enable_pwr;
+    DRV_BOOL     emon_mode;
+    U32          pebs_mode;
+    U32          pebs_capture;
+    DRV_BOOL     collect_lbrs;
+    DRV_BOOL     collect_callstacks;
+    DRV_BOOL     debug_inject;
+    DRV_BOOL     virt_phys_translation;
+    DRV_BOOL     latency_capture;
+    U32          max_gp_counters;
+    DRV_BOOL     htoff_mode;
+    DRV_BOOL     power_capture;
+    U32          results_offset;   // this is to store the offset for this device's results
+    DRV_BOOL     eventing_ip_capture;
+    DRV_BOOL     hle_capture;
+    U32          emon_unc_offset[MAX_EMON_GROUPS];
+    DRV_BOOL     enable_p_state;   // adding MPERF and APERF values at the end of the samples
+    DRV_BOOL     enable_cp_mode;   // enabling continuous profiling mode
+    S32          seed_name_len;
+    DRV_BOOL     read_pstate_msrs;
+    U64          target_pid;
+    DRV_BOOL     use_pcl;
+    DRV_BOOL     enable_ebc;
+    DRV_BOOL     enable_tbc;
+    U32          ebc_group_id_offset;
+    union {
+        S8      *seed_name;
+        U64      dummy1;
+    } u1;
+    union {
+        S8      *cpu_mask;
+        U64      dummy2;
+    } u2;
+    U32          device_type;
+    DRV_BOOL     ds_area_available;
+    DRV_BOOL     precise_ip_lbrs;
+    DRV_BOOL     store_lbrs;
+    DRV_BOOL     tsc_capture;
+    U32          os_of_interest;
+    U32          pebs_record_num;
+    DRV_BOOL     per_cpu_tsc;
+    DRV_BOOL     collect_kernel_callstacks;
+    union {
+        U32 enable_bit_fields;
+        struct {
+            U32 enable_perf_metrics        : 1;
+            U32 enable_adaptive_pebs       : 1;
+            U32 apebs_collect_mem_info     : 1;
+            U32 apebs_collect_gpr          : 1;
+            U32 apebs_collect_xmm          : 1;
+            U32 apebs_collect_lbrs         : 1;
+            U32 collect_fixed_counter_pebs : 1;
+            U32 collect_os_callstacks      : 1;
+            U32 reserved_field1            : 24;
+        } s1;
+    } u3;
+    U8           num_perf_metrics;
+    U8           apebs_num_lbr_entries;
+    U16          emon_perf_metrics_offset;
+    S32          p_state_trigger_index;
+    U64          reserved5;
+};
+
+#define DRV_CONFIG_size(cfg)                       (cfg)->size
+#define DRV_CONFIG_version(cfg)                    (cfg)->version
+#define DRV_CONFIG_num_events(cfg)                 (cfg)->num_events
+#define DRV_CONFIG_start_paused(cfg)               (cfg)->start_paused
+#define DRV_CONFIG_counting_mode(cfg)              (cfg)->counting_mode
+#define DRV_CONFIG_dispatch_id(cfg)                (cfg)->dispatch_id
+#define DRV_CONFIG_enable_chipset(cfg)             (cfg)->enable_chipset
+#define DRV_CONFIG_num_chipset_events(cfg)         (cfg)->num_chipset_events
+#define DRV_CONFIG_chipset_offset(cfg)             (cfg)->chipset_offset
+#define DRV_CONFIG_enable_gfx(cfg)                 (cfg)->enable_gfx
+#define DRV_CONFIG_enable_pwr(cfg)                 (cfg)->enable_pwr
+#define DRV_CONFIG_emon_mode(cfg)                  (cfg)->emon_mode
+#define DRV_CONFIG_pebs_mode(cfg)                  (cfg)->pebs_mode
+#define DRV_CONFIG_pebs_capture(cfg)               (cfg)->pebs_capture
+#define DRV_CONFIG_collect_lbrs(cfg)               (cfg)->collect_lbrs
+#define DRV_CONFIG_collect_callstacks(cfg)         (cfg)->collect_callstacks
+#define DRV_CONFIG_collect_kernel_callstacks(cfg)  (cfg)->collect_kernel_callstacks
+#define DRV_CONFIG_debug_inject(cfg)               (cfg)->debug_inject
+#define DRV_CONFIG_virt_phys_translation(cfg)      (cfg)->virt_phys_translation
+#define DRV_CONFIG_latency_capture(cfg)            (cfg)->latency_capture
+#define DRV_CONFIG_max_gp_counters(cfg)            (cfg)->max_gp_counters
+#define DRV_CONFIG_htoff_mode(cfg)                 (cfg)->htoff_mode
+#define DRV_CONFIG_power_capture(cfg)              (cfg)->power_capture
+#define DRV_CONFIG_results_offset(cfg)             (cfg)->results_offset
+#define DRV_CONFIG_eventing_ip_capture(cfg)        (cfg)->eventing_ip_capture
+#define DRV_CONFIG_hle_capture(cfg)                (cfg)->hle_capture
+#define DRV_CONFIG_emon_unc_offset(cfg,grp_num)    (cfg)->emon_unc_offset[grp_num]
+#define DRV_CONFIG_enable_p_state(cfg)             (cfg)->enable_p_state
+#define DRV_CONFIG_enable_cp_mode(cfg)             (cfg)->enable_cp_mode
+#define DRV_CONFIG_seed_name(cfg)                  (cfg)->u1.seed_name
+#define DRV_CONFIG_seed_name_len(cfg)              (cfg)->seed_name_len
+#define DRV_CONFIG_read_pstate_msrs(cfg)           (cfg)->read_pstate_msrs
+#define DRV_CONFIG_cpu_mask(cfg)                   (cfg)->u2.cpu_mask
+#define DRV_CONFIG_target_pid(cfg)                 (cfg)->target_pid
+#define DRV_CONFIG_use_pcl(cfg)                    (cfg)->use_pcl
+#define DRV_CONFIG_event_based_counts(cfg)         (cfg)->enable_ebc
+#define DRV_CONFIG_ebc_group_id_offset(cfg)        (cfg)->ebc_group_id_offset
+#define DRV_CONFIG_timer_based_counts(cfg)         (cfg)->enable_tbc
+#define DRV_CONFIG_device_type(cfg)                (cfg)->device_type
+#define DRV_CONFIG_ds_area_available(cfg)          (cfg)->ds_area_available
+#define DRV_CONFIG_precise_ip_lbrs(cfg)            (cfg)->precise_ip_lbrs
+#define DRV_CONFIG_store_lbrs(cfg)                 (cfg)->store_lbrs
+#define DRV_CONFIG_tsc_capture(cfg)                (cfg)->tsc_capture
+#define DRV_CONFIG_os_of_interest(cfg)             (cfg)->os_of_interest
+#define DRV_CONFIG_pebs_record_num(cfg)            (cfg)->pebs_record_num
+#define DRV_CONFIG_per_cpu_tsc(cfg)                (cfg)->per_cpu_tsc
+#define DRV_CONFIG_enable_bit_fields(cfg)          (cfg)->u3.enable_bit_fields
+#define DRV_CONFIG_enable_perf_metrics(cfg)        (cfg)->u3.s1.enable_perf_metrics
+#define DRV_CONFIG_num_perf_metrics(cfg)           (cfg)->num_perf_metrics
+#define DRV_CONFIG_emon_perf_metrics_offset(cfg)   (cfg)->emon_perf_metrics_offset
+#define DRV_CONFIG_enable_adaptive_pebs(cfg)       (cfg)->u3.s1.enable_adaptive_pebs
+#define DRV_CONFIG_apebs_collect_mem_info(cfg)     (cfg)->u3.s1.apebs_collect_mem_info
+#define DRV_CONFIG_apebs_collect_gpr(cfg)          (cfg)->u3.s1.apebs_collect_gpr
+#define DRV_CONFIG_apebs_collect_xmm(cfg)          (cfg)->u3.s1.apebs_collect_xmm
+#define DRV_CONFIG_apebs_collect_lbrs(cfg)         (cfg)->u3.s1.apebs_collect_lbrs
+#define DRV_CONFIG_apebs_num_lbr_entries(cfg)      (cfg)->apebs_num_lbr_entries
+#define DRV_CONFIG_collect_fixed_counter_pebs(cfg) (cfg)->u3.s1.collect_fixed_counter_pebs
+#define DRV_CONFIG_collect_os_callstacks(cfg)      (cfg)->u3.s1.collect_os_callstacks
+#define DRV_CONFIG_p_state_trigger_index(cfg)      (cfg)->p_state_trigger_index
+
+#define DRV_CONFIG_VERSION                        1
+/*
+ *    X86 processor code descriptor
+ */
+typedef struct CodeDescriptor_s {
+    union {
+        U32 lowWord;                   // low dword of descriptor
+        struct {                       // low broken out by fields
+            U16 limitLow;              // segment limit 15:00
+            U16 baseLow;               // segment base 15:00
+        } s1;
+    } u1;
+    union {
+        U32   highWord;               // high word of descriptor
+        struct {                      // high broken out by bit fields
+            U32   baseMid      : 8;   // base 23:16
+            U32   accessed     : 1;   // accessed
+            U32   readable     : 1;   // readable
+            U32   conforming   : 1;   // conforming code segment
+            U32   oneOne       : 2;   // always 11
+            U32   dpl          : 2;   // Dpl
+            U32   pres         : 1;   // present bit
+            U32   limitHi      : 4;   // limit 19:16
+            U32   sys          : 1;   // available for use by system
+            U32   reserved_0   : 1;   // reserved, always 0
+            U32   default_size : 1;   // default operation size (1=32bit, 0=16bit)
+            U32   granularity  : 1;   // granularity (1=32 bit, 0=20 bit)
+            U32   baseHi       : 8;   // base hi 31:24
+        } s2;
+    } u2;
+} CodeDescriptor;
+
+/*
+ *  Module record.  These are emitted whenever a DLL or EXE is loaded or unloaded.
+ *  The filename fields may be 0 on an unload.  The records reperesent a module for a
+ *  certain span of time, delineated by the load / unload samplecounts.
+ *  Note:
+ *  The structure contains 64 bit fields which may cause the compiler to pad the
+ *  length of the structure to an 8 byte boundary.
+ */
+typedef struct ModuleRecord_s {
+   U16    recLength;          // total length of this record (including this length,
+                              // always U32 multiple)  output from sampler is variable
+                              // length (pathname at end of record) sampfile builder moves
+                              // path names to a separate "literal pool" area
+                              // so that these records become fixed length, and can be treated
+                              // as an array see modrecFixedLen in header
+
+   U16    segmentType :  2;   // V86, 16, 32, 64 (see MODE_ defines), maybe inaccurate for Win95
+                              // .. a 16 bit module may become a 32 bit module, inferred by
+                              // ..looking at 1st sample record that matches the module selector
+   U16    loadEvent   :  1;   // 0 for load, 1 for unload
+   U16    processed   :  1;   // 0 for load, 1 for unload
+   U16    reserved0   : 12;
+
+   U16    selector;           // code selector or V86 segment
+   U16    segmentNameLength;  // length of the segment name if the segmentNameSet bit is set
+   U32    segmentNumber;      // segment number, Win95 (and now Java) can have multiple pieces for one module
+   union {
+      U32 flags;                            // all the flags as one dword
+      struct {
+         U32 exe                     : 1;   // this module is an exe
+         U32 globalModule            : 1;   // globally loaded module.  There may be multiple
+                                            // module records for a global module, but the samples
+                                            // will only point to the 1st one, the others will be
+                                            // ignored.  NT's Kernel32 is an example of this.
+                                            // REVISIT this??
+         U32 bogusWin95              : 1;   // "bogus" win95 module.  By bogus, we mean a
+                                            // module that has a pid of 0, no length and no base.
+                                            // Selector actually used as a 32 bit module.
+         U32 pidRecIndexRaw          : 1;   // pidRecIndex is raw OS pid
+         U32 sampleFound             : 1;   // at least one sample referenced this module
+         U32 tscUsed                 : 1;   // tsc set when record written
+         U32 duplicate               : 1;   // 1st pass analysis has determined this is a
+                                            // duplicate load
+         U32 globalModuleTB5         : 1;   // module mapped into all processes on system
+         U32 segmentNameSet          : 1;   // set if the segment name was collected
+                                            // (initially done for xbox collections)
+         U32 firstModuleRecInProcess : 1;   // if the pidCreatesTrackedInModuleRecs flag is set
+                                            //  in the SampleHeaderEx struct and this flag
+                                            //  is set, the associated module indicates
+                                            //  the beginning of a new process
+         U32  source                 : 1;   // 0 for path in target system, 1 for path in host system (offloaded)
+         U32  unknownLoadAddress     : 1;   // for 0 valid loadAddr64 value, 1 for invalid loadAddr64 value
+         U32  reserved1              : 20;
+      } s1;
+   } u2;
+   U64   length64;         // module length
+   U64   loadAddr64;       // load address
+   U32   pidRecIndex;      // process ID rec index (index into  start of pid record section).
+                           // .. (see pidRecIndexRaw).  If pidRecIndex == 0 and pidRecIndexRaw == 1
+                           // ..then this is a kernel or global module.  Can validly
+                           // ..be 0 if not raw (array index).  Use ReturnPid() to access this
+                           // ..field
+   U32   osid;             // OS identifier
+   U64   unloadTsc;        // TSC collected on an unload event
+   U32   path;             // module path name (section offset on disk)
+                           // ..when initally written by sampler name is at end of this
+                           // ..struct, when merged with main file names are pooled at end
+                           // ..of ModuleRecord Section so ModulesRecords can be
+                           // ..fixed length
+   U16   pathLength;       // path name length (inludes terminating \0)
+   U16   filenameOffset;   // offset into path name of base filename
+   U32   segmentName;      // offset to the segmentName from the beginning of the
+                           //  module section in a processed module section
+                           //  (s/b 0 in a raw module record)
+                           // in a raw module record, the segment name will follow the
+                           //  module name and the module name's terminating NULL char
+   U32   page_offset_high;
+   U64   tsc;              // time stamp counter module event occurred
+   U32   parent_pid;       // Parent PID of the process
+   U32   page_offset_low;
+} ModuleRecord;
+
+#define MR_unloadTscSet(x,y)        (x)->unloadTsc = (y)
+#define MR_unloadTscGet(x)          (x)->unloadTsc
+
+#define MR_page_offset_Set(x,y)   (x)->page_offset_low = (y)&0xFFFFFFFF; (x)->page_offset_high=((y)>>32)&0xFFFFFFFF;
+#define MR_page_offset_Get(x)     ((((U64)(x)->page_offset_high)<<32) | (x)->page_offset_low)
+
+// Accessor macros for ModuleRecord
+#define MODULE_RECORD_rec_length(x)                     (x)->recLength
+#define MODULE_RECORD_segment_type(x)                   (x)->segmentType
+#define MODULE_RECORD_load_event(x)                     (x)->loadEvent
+#define MODULE_RECORD_processed(x)                      (x)->processed
+#define MODULE_RECORD_selector(x)                       (x)->selector
+#define MODULE_RECORD_segment_name_length(x)            (x)->segmentNameLength
+#define MODULE_RECORD_segment_number(x)                 (x)->segmentNumber
+#define MODULE_RECORD_flags(x)                          (x)->u2.flags
+#define MODULE_RECORD_exe(x)                            (x)->u2.s1.exe
+#define MODULE_RECORD_global_module(x)                  (x)->u2.s1.globalModule
+#define MODULE_RECORD_bogus_win95(x)                    (x)->u2.s1.bogusWin95
+#define MODULE_RECORD_pid_rec_index_raw(x)              (x)->u2.s1.pidRecIndexRaw
+#define MODULE_RECORD_sample_found(x)                   (x)->u2.s1.sampleFound
+#define MODULE_RECORD_tsc_used(x)                       (x)->u2.s1.tscUsed
+#define MODULE_RECORD_duplicate(x)                      (x)->u2.s1.duplicate
+#define MODULE_RECORD_global_module_tb5(x)              (x)->u2.s1.globalModuleTB5
+#define MODULE_RECORD_segment_name_set(x)               (x)->u2.s1.segmentNameSet
+#define MODULE_RECORD_first_module_rec_in_process(x)    (x)->u2.s1.firstModuleRecInProcess
+#define MODULE_RECORD_source(x)                         (x)->u2.s1.source
+#define MODULE_RECORD_unknown_load_address(x)           (x)->u2.s1.unknownLoadAddress
+#define MODULE_RECORD_length64(x)                       (x)->length64
+#define MODULE_RECORD_load_addr64(x)                    (x)->loadAddr64
+#define MODULE_RECORD_pid_rec_index(x)                  (x)->pidRecIndex
+#define MODULE_RECORD_load_sample_count(x)              (x)->u5.s2.loadSampleCount
+#define MODULE_RECORD_unload_sample_count(x)            (x)->u5.s2.unloadSampleCount
+#define MODULE_RECORD_unload_tsc(x)                     (x)->unloadTsc
+#define MODULE_RECORD_path(x)                           (x)->path
+#define MODULE_RECORD_path_length(x)                    (x)->pathLength
+#define MODULE_RECORD_filename_offset(x)                (x)->filenameOffset
+#define MODULE_RECORD_segment_name(x)                   (x)->segmentName
+#define MODULE_RECORD_tsc(x)                            (x)->tsc
+#define MODULE_RECORD_parent_pid(x)                     (x)->parent_pid
+#define MODULE_RECORD_osid(x)                           (x)->osid
+
+/*
+ *  Sample record.  Size can be determined by looking at the header record.
+ *  There can be up to 3 sections.  The SampleFileHeader defines the presence
+ *  of sections and their offsets. Within a sample file, all of the sample
+ *  records have the same number of sections and the same size.  However,
+ *  different sample record sections and sizes can exist in different
+ *  sample files.  Since recording counters and the time stamp counter for
+ *  each sample can be space consuming, the user can determine whether or not
+ *  this information is kept at sample collection time.
+ */
+
+typedef struct SampleRecordPC_s {   // Program Counter section
+    U32   descriptor_id;
+    U32   osid;                 // OS identifier
+    union {
+        struct {
+            U64 iip;            // IA64 interrupt instruction pointer
+            U64 ipsr;           // IA64 interrupt processor status register
+        } s1;
+        struct {
+            U32  eip;           // IA32 instruction pointer
+            U32  eflags;        // IA32 eflags
+            CodeDescriptor csd; // IA32 code seg descriptor (8 bytes)
+        } s2;
+    } u1;
+    U16    cs;                  // IA32 cs (0 for IA64)
+    union {
+        U16 cpuAndOS;                  // cpu and OS info as one word
+        struct {                       // cpu and OS info broken out
+            U16 cpuNum          : 12;  // cpu number (0 - 4096)
+            U16 notVmid0        : 1;   // win95, vmid0 flag (1 means NOT vmid 0)
+            U16 codeMode        : 2;   // processor mode, see MODE_ defines
+            U16 uncore_valid    : 1;   // identifies if the uncore count is valid
+        } s3;
+    } u2;
+    U32   tid;            // OS thread ID  (may get reused, see tidIsRaw)
+    U32   pidRecIndex;    // process ID rec index (index into start of pid
+                          // record section) .. can validly be 0 if not raw
+                          // (array index).  Use ReturnPid() to
+                          // ..access this field .. (see pidRecIndexRaw)
+    union {
+        U32 bitFields2;
+        struct {
+            U32   mrIndex        : 20;   // module record index (index into start of
+                                         // module rec section) .. (see mrIndexNone)
+            U32   eventIndex     : 8;    // index into the Events section
+            U32   tidIsRaw       : 1;    // tid is raw OS tid
+            U32   IA64PC         : 1;    // TRUE=this is a IA64 PC sample record
+            U32   pidRecIndexRaw : 1;    // pidRecIndex is raw OS pid
+            U32   mrIndexNone    : 1;    // no mrIndex (unknown module)
+        } s4;
+    } u3;
+    U64 tsc;                          // processor timestamp counter
+} SampleRecordPC, *PSampleRecordPC;
+
+#define SAMPLE_RECORD_descriptor_id(x)       (x)->descriptor_id
+#define SAMPLE_RECORD_osid(x)                (x)->osid
+#define SAMPLE_RECORD_iip(x)                 (x)->u1.s1.iip
+#define SAMPLE_RECORD_ipsr(x)                (x)->u1.s1.ipsr
+#define SAMPLE_RECORD_eip(x)                 (x)->u1.s2.eip
+#define SAMPLE_RECORD_eflags(x)              (x)->u1.s2.eflags
+#define SAMPLE_RECORD_csd(x)                 (x)->u1.s2.csd
+#define SAMPLE_RECORD_cs(x)                  (x)->cs
+#define SAMPLE_RECORD_cpu_and_os(x)          (x)->u2.cpuAndOS
+#define SAMPLE_RECORD_cpu_num(x)             (x)->u2.s3.cpuNum
+#define SAMPLE_RECORD_uncore_valid(x)        (x)->u2.s3.uncore_valid
+#define SAMPLE_RECORD_not_vmid0(x)           (x)->u2.s3.notVmid0
+#define SAMPLE_RECORD_code_mode(x)           (x)->u2.s3.codeMode
+#define SAMPLE_RECORD_tid(x)                 (x)->tid
+#define SAMPLE_RECORD_pid_rec_index(x)       (x)->pidRecIndex
+#define SAMPLE_RECORD_bit_fields2(x)         (x)->u3.bitFields2
+#define SAMPLE_RECORD_mr_index(x)            (x)->u3.s4.mrIndex
+#define SAMPLE_RECORD_event_index(x)         (x)->u3.s4.eventIndex
+#define SAMPLE_RECORD_tid_is_raw(x)          (x)->u3.s4.tidIsRaw
+#define SAMPLE_RECORD_ia64_pc(x)             (x)->u3.s4.IA64PC
+#define SAMPLE_RECORD_pid_rec_index_raw(x)   (x)->u3.s4.pidRecIndexRaw
+#define SAMPLE_RECORD_mr_index_none(x)       (x)->u3.s4.mrIndexNone
+#define SAMPLE_RECORD_tsc(x)                 (x)->tsc
+
+// end of SampleRecord sections
+
+/* Uncore Sample Record definition. This is a skinny sample record used by uncore boxes
+   to record samples. The sample record consists of a descriptor id, cpu info and timestamp.*/
+
+typedef struct UncoreSampleRecordPC_s {
+    U32   descriptor_id;
+    U32   osid;
+    U16   cpuNum;
+    U16   pkgNum;
+    union {
+        U32 flags;
+        struct {
+            U32 uncore_valid    : 1;   // identifies if the uncore count is valid
+            U32 reserved1       : 31;
+        } s1;
+    } u1;
+    U64 reserved2;
+    U64 tsc;                          // processor timestamp counter
+} UncoreSampleRecordPC, *PUnocreSampleRecordPC;
+
+#define UNCORE_SAMPLE_RECORD_descriptor_id(x)       (x)->descriptor_id
+#define UNCORE_SAMPLE_RECORD_osid(x)                (x)->osid
+#define UNCORE_SAMPLE_RECORD_cpu_num(x)             (x)->cpuNum
+#define UNCORE_SAMPLE_RECORD_pkg_num(x)             (x)->pkgNum
+#define UNCORE_SAMPLE_RECORD_uncore_valid(x)        (x)->u1.s1.uncore_valid
+#define UNCORE_SAMPLE_RECORD_tsc(x)                 (x)->tsc
+
+// end of UncoreSampleRecord section
+
+// Definitions for user markers data
+// The instances of these structures will be written to the user markers temp file.
+#define MARKER_DEFAULT_TYPE   "Default_Marker"
+#define MARKER_DEFAULT_ID     0
+#define MAX_MARKER_LENGTH     136
+
+#define MARK_ID     4
+#define MARK_DATA   2
+#define THREAD_INFO 8
+
+/* do not use it at ths moment
+typedef enum {
+        SMRK_USER_DEFINED = 0,
+        SMRK_THREAD_NAME,
+        SMRK_WALLCLOCK,
+        SMRK_TEXT,
+        SMRK_TYPE_ID
+}  SMRK_TYPE;
+*/
+
+/*
+ *  Common Register descriptions
+ */
+
+
+/*
+ *  Bits used in the debug control register
+ */
+#define DEBUG_CTL_LBR                          0x0000001
+#define DEBUG_CTL_BTF                          0x0000002
+#define DEBUG_CTL_TR                           0x0000040
+#define DEBUG_CTL_BTS                          0x0000080
+#define DEBUG_CTL_BTINT                        0x0000100
+#define DEBUG_CTL_BT_OFF_OS                    0x0000200
+#define DEBUG_CTL_BTS_OFF_USR                  0x0000400
+#define DEBUG_CTL_FRZ_LBR_ON_PMI               0x0000800
+#define DEBUG_CTL_FRZ_PMON_ON_PMI              0x0001000
+#define DEBUG_CTL_ENABLE_UNCORE_PMI_BIT        0x0002000
+
+
+#define DEBUG_CTL_NODE_lbr_get(reg)                   (reg) &   DEBUG_CTL_LBR
+#define DEBUG_CTL_NODE_lbr_set(reg)                   (reg) |=  DEBUG_CTL_LBR
+#define DEBUG_CTL_NODE_lbr_clear(reg)                 (reg) &= ~DEBUG_CTL_LBR
+
+#define DEBUG_CTL_NODE_btf_get(reg)                   (reg) &   DEBUG_CTL_BTF
+#define DEBUG_CTL_NODE_btf_set(reg)                   (reg) |=  DEBUG_CTL_BTF
+#define DEBUG_CTL_NODE_btf_clear(reg)                 (reg) &= ~DEBUG_CTL_BTF
+
+#define DEBUG_CTL_NODE_tr_get(reg)                    (reg) &   DEBUG_CTL_TR
+#define DEBUG_CTL_NODE_tr_set(reg)                    (reg) |=  DEBUG_CTL_TR
+#define DEBUG_CTL_NODE_tr_clear(reg)                  (reg) &= ~DEBUG_CTL_TR
+
+#define DEBUG_CTL_NODE_bts_get(reg)                   (reg) &   DEBUG_CTL_BTS
+#define DEBUG_CTL_NODE_bts_set(reg)                   (reg) |=  DEBUG_CTL_BTS
+#define DEBUG_CTL_NODE_bts_clear(reg)                 (reg) &= ~DEBUG_CTL_BTS
+
+#define DEBUG_CTL_NODE_btint_get(reg)                 (reg) &   DEBUG_CTL_BTINT
+#define DEBUG_CTL_NODE_btint_set(reg)                 (reg) |=  DEBUG_CTL_BTINT
+#define DEBUG_CTL_NODE_btint_clear(reg)               (reg) &= ~DEBUG_CTL_BTINT
+
+#define DEBUG_CTL_NODE_bts_off_os_get(reg)            (reg) &   DEBUG_CTL_BTS_OFF_OS
+#define DEBUG_CTL_NODE_bts_off_os_set(reg)            (reg) |=  DEBUG_CTL_BTS_OFF_OS
+#define DEBUG_CTL_NODE_bts_off_os_clear(reg)          (reg) &= ~DEBUG_CTL_BTS_OFF_OS
+
+#define DEBUG_CTL_NODE_bts_off_usr_get(reg)           (reg) &   DEBUG_CTL_BTS_OFF_USR
+#define DEBUG_CTL_NODE_bts_off_usr_set(reg)           (reg) |=  DEBUG_CTL_BTS_OFF_USR
+#define DEBUG_CTL_NODE_bts_off_usr_clear(reg)         (reg) &= ~DEBUG_CTL_BTS_OFF_USR
+
+#define DEBUG_CTL_NODE_frz_lbr_on_pmi_get(reg)        (reg) &   DEBUG_CTL_FRZ_LBR_ON_PMI
+#define DEBUG_CTL_NODE_frz_lbr_on_pmi_set(reg)        (reg) |=  DEBUG_CTL_FRZ_LBR_ON_PMI
+#define DEBUG_CTL_NODE_frz_lbr_on_pmi_clear(reg)      (reg) &= ~DEBUG_CTL_FRZ_LBR_ON_PMI
+
+#define DEBUG_CTL_NODE_frz_pmon_on_pmi_get(reg)       (reg) &   DEBUG_CTL_FRZ_PMON_ON_PMI
+#define DEBUG_CTL_NODE_frz_pmon_on_pmi_set(reg)       (reg) |=  DEBUG_CTL_FRZ_PMON_ON_PMI
+#define DEBUG_CTL_NODE_frz_pmon_on_pmi_clear(reg)     (reg) &= ~DEBUG_CTL_FRZ_PMON_ON_PMI
+
+#define DEBUG_CTL_NODE_enable_uncore_pmi_get(reg)     (reg) &   DEBUG_CTL_ENABLE_UNCORE_PMI
+#define DEBUG_CTL_NODE_enable_uncore_pmi_set(reg)     (reg) |=  DEBUG_CTL_ENABLE_UNCORE_PMI
+#define DEBUG_CTL_NODE_enable_uncore_pmi_clear(reg)   (reg) &= ~DEBUG_CTL_ENABLE_UNCORE_PMI
+
+/*
+ * @macro SEP_VERSION_NODE_S
+ * @brief
+ * This structure supports versioning in Sep. The field major indicates the major version,
+ * minor indicates the minor version and api indicates the api version for the current
+ * sep build. This structure is initialized at the time when the driver is loaded.
+ */
+
+typedef struct SEP_VERSION_NODE_S  SEP_VERSION_NODE;
+typedef        SEP_VERSION_NODE   *SEP_VERSION;
+
+struct SEP_VERSION_NODE_S {
+    union {
+        U32      sep_version;
+        struct {
+            S32  major :8;
+            S32  minor :8;
+            S32  api   :8;
+            S32  update:8;
+        }s1;
+    }u1;
+};
+
+#define SEP_VERSION_NODE_sep_version(version) (version)->u1.sep_version
+#define SEP_VERSION_NODE_major(version)       (version)->u1.s1.major
+#define SEP_VERSION_NODE_minor(version)       (version)->u1.s1.minor
+#define SEP_VERSION_NODE_api(version)         (version)->u1.s1.api
+#define SEP_VERSION_NODE_update(version)      (version)->u1.s1.update
+
+/*
+ *  The VTSA_SYS_INFO_STRUCT information that is shared across kernel mode
+ *  and user mode code, very specifically for tb5 file generation
+ */
+
+typedef enum {
+    GT_UNK     = 0,
+    GT_PER_CPU,
+    GT_PER_CHIPSET,
+    GT_CPUID,
+    GT_NODE,
+    GT_SYSTEM,
+    GT_SAMPLE_RECORD_INFO
+} GEN_ENTRY_TYPES;
+
+typedef enum {
+    GST_UNK = 0,
+    GST_X86,
+    GST_ITANIUM,
+    GST_SA,//strong arm
+    GST_XSC,
+    GST_EM64T,
+    GST_CS860
+} GEN_ENTRY_SUBTYPES;
+
+typedef struct __fixed_size_pointer {
+    union  {
+        U64     fs_force_alignment;
+        struct {
+            U32     fs_unused;
+            U32     is_ptr:1;
+        } s1;
+    } u1;
+    union {
+        U64     fs_offset;
+        void   *fs_ptr;
+    } u2;
+} VTSA_FIXED_SIZE_PTR;
+
+#define VTSA_FIXED_SIZE_PTR_is_ptr(fsp)     (fsp)->u1.s1.is_ptr
+#define VTSA_FIXED_SIZE_PTR_fs_offset(fsp)  (fsp)->u2.fs_offset
+#define VTSA_FIXED_SIZE_PTR_fs_ptr(fsp)     (fsp)->u2.fs_ptr
+
+
+typedef struct __generic_array_header {
+    //
+    // Information realted to the generic header
+    //
+    U32 hdr_size;       // size of this generic header
+                        // (for versioning and real data starts
+                        //  after the header)
+
+    U32 next_field_hdr_padding;    // make sure the next field is 8-byte aligned
+
+    //
+    // VTSA_FIXED_SIZE_PTR should always be on an 8-byte boundary...
+    //
+    // pointer to the next generic header if there is one
+    //
+    VTSA_FIXED_SIZE_PTR hdr_next_gen_hdr;
+
+    U32 hdr_reserved[7];     // padding for future use - force to 64 bytes...
+
+    //
+    // Information related to the array this header is describing
+    //
+    U32 array_num_entries;
+    U32 array_entry_size;
+    U16 array_type;         // from the GEN_ENTRY_TYPES enumeration
+    U16 array_subtype;      // from the GEN_ENTRY_SUBTYPES enumeration
+} VTSA_GEN_ARRAY_HDR;
+
+#define VTSA_GEN_ARRAY_HDR_hdr_size(gah)            (gah)->hdr_size
+#define VTSA_GEN_ARRAY_HDR_hdr_next_gen_hdr(gah)    (gah)->hdr_next_gen_hdr
+#define VTSA_GEN_ARRAY_HDR_array_num_entries(gah)   (gah)->array_num_entries
+#define VTSA_GEN_ARRAY_HDR_array_entry_size(gah)    (gah)->array_entry_size
+#define VTSA_GEN_ARRAY_HDR_array_type(gah)          (gah)->array_type
+#define VTSA_GEN_ARRAY_HDR_array_subtype(gah)       (gah)->array_subtype
+
+typedef struct __cpuid_x86 {
+    U32 cpuid_eax_input;
+    U32 cpuid_eax;
+    U32 cpuid_ebx;
+    U32 cpuid_ecx;
+    U32 cpuid_edx;
+} VTSA_CPUID_X86;
+
+#define VTSA_CPUID_X86_cpuid_eax_input(cid) (cid)->cpuid_eax_input
+#define VTSA_CPUID_X86_cpuid_eax(cid)       (cid)->cpuid_eax
+#define VTSA_CPUID_X86_cpuid_ebx(cid)       (cid)->cpuid_ebx
+#define VTSA_CPUID_X86_cpuid_ecx(cid)       (cid)->cpuid_ecx
+#define VTSA_CPUID_X86_cpuid_edx(cid)       (cid)->cpuid_edx
+
+typedef struct __cpuid_ipf {
+    U64 cpuid_select;
+    U64 cpuid_val;
+} VTSA_CPUID_IPF;
+
+#define VTSA_CPUID_IPF_cpuid_select(cid)    (cid)->cpuid_select
+#define VTSA_CPUID_IPF_cpuid_val(cid)       (cid)->cpuid_val
+
+typedef struct __generic_per_cpu {
+    //
+    // per cpu information
+    //
+    U32 cpu_number;             // cpu number (as defined by the OS)
+    U32 cpu_speed_mhz;          // cpu speed (in Mhz)
+    U32 cpu_fsb_mhz;            // Front Side Bus speed (in Mhz) (if known)
+    U32 cpu_cache_L2;           // ??? USER: cpu L2 (marketing definition) cache size (if known)
+
+    //
+    // And pointer to other structures. Keep this on an 8-byte boundary
+    //
+    // "pointer" to generic array header that should contain
+    // cpuid information for this cpu
+    //
+    VTSA_FIXED_SIZE_PTR cpu_cpuid_array;
+
+    S64 cpu_tsc_offset;         // TSC offset from CPU 0 computed as (TSC CPU N - TSC CPU 0)
+    //
+    // intel processor number (from mkting).
+    // Currently 3 decimal digits (3xx, 5xx and 7xx)
+    //
+    U32 cpu_intel_processor_number;
+
+    U32 cpu_cache_L3;           // ??? USER: cpu L3 (marketing definition) cache size (if known)
+
+    U64 platform_id;
+
+    //
+    // package/mapping information
+    //
+    // The hierarchy for uniquely identifying a logical processor
+    // in a system is node number/id (from the node structure),
+    // package number, core number, and thread number.
+    // Core number is for identifying a core within a package.
+    //
+    // Actually, on Itanium getting all this information is
+    // pretty involved with complicated algorithm using PAL calls.
+    // I don't know how important all this stuff is to the user.
+    // Maybe we can just have the place holder now and figure out
+    // how to fill them later.
+    //
+    U16 cpu_package_num;             // package number for this cpu (if known)
+    U16 cpu_core_num;                // core number (if known)
+    U16 cpu_hw_thread_num;           // hw thread number inside the core (if known)
+
+    U16 cpu_threads_per_core;        // total number of h/w threads per core (if known)
+    U16 cpu_module_id;               // Processor module number
+    U16 cpu_num_modules;             // Number of processor modules
+    U32 reserved;
+
+} VTSA_GEN_PER_CPU;
+
+#define VTSA_GEN_PER_CPU_cpu_number(p_cpu)                  (p_cpu)->cpu_number
+#define VTSA_GEN_PER_CPU_cpu_speed_mhz(p_cpu)               (p_cpu)->cpu_speed_mhz
+#define VTSA_GEN_PER_CPU_cpu_fsb_mhz(p_cpu)                 (p_cpu)->cpu_fsb_mhz
+#define VTSA_GEN_PER_CPU_cpu_cache_L2(p_cpu)                (p_cpu)->cpu_cache_L2
+#define VTSA_GEN_PER_CPU_cpu_cpuid_array(p_cpu)             (p_cpu)->cpu_cpuid_array
+#define VTSA_GEN_PER_CPU_cpu_tsc_offset(p_cpu)              (p_cpu)->cpu_tsc_offset
+#define VTSA_GEN_PER_CPU_cpu_intel_processor_number(p_cpu)  (p_cpu)->cpu_intel_processor_number
+#define VTSA_GEN_PER_CPU_cpu_cache_L3(p_cpu)                (p_cpu)->cpu_cache_L3
+#define VTSA_GEN_PER_CPU_platform_id(p_cpu)                 (p_cpu)->platform_id
+#define VTSA_GEN_PER_CPU_cpu_package_num(p_cpu)             (p_cpu)->cpu_package_num
+#define VTSA_GEN_PER_CPU_cpu_core_num(p_cpu)                (p_cpu)->cpu_core_num
+#define VTSA_GEN_PER_CPU_cpu_hw_thread_num(p_cpu)           (p_cpu)->cpu_hw_thread_num
+#define VTSA_GEN_PER_CPU_cpu_threads_per_core(p_cpu)        (p_cpu)->cpu_threads_per_core
+#define VTSA_GEN_PER_CPU_cpu_module_num(p_cpu)              (p_cpu)->cpu_module_id
+#define VTSA_GEN_PER_CPU_cpu_num_modules(p_cpu)             (p_cpu)->cpu_num_modules
+
+
+typedef struct __node_info {
+    U32 node_type_from_shell;
+    U32 node_id;                   // The node number/id (if known)
+
+    U32 node_num_available;        // total number cpus on this node
+    U32 node_num_used;             // USER: number used based on cpu mask at time of run
+
+    U64 node_physical_memory;      // amount of physical memory (bytes) on this node
+
+    //
+    // pointer to the first generic header that
+    // contains the per-cpu information
+    //
+    // Keep the VTSA_FIXED_SIZE_PTR on an 8-byte boundary...
+    //
+    VTSA_FIXED_SIZE_PTR node_percpu_array;
+
+    U32 node_reserved[2];           // leave some space
+
+} VTSA_NODE_INFO;
+
+#define VTSA_NODE_INFO_node_type_from_shell(vni)    (vni)->node_type_from_shell
+#define VTSA_NODE_INFO_node_id(vni)                 (vni)->node_id
+#define VTSA_NODE_INFO_node_num_available(vni)      (vni)->node_num_available
+#define VTSA_NODE_INFO_node_num_used(vni)           (vni)->node_num_used
+#define VTSA_NODE_INFO_node_physical_memory(vni)    (vni)->node_physical_memory
+#define VTSA_NODE_INFO_node_percpu_array(vni)       (vni)->node_percpu_array
+
+
+typedef struct __sys_info {
+    //
+    // Keep this on an 8-byte boundary
+    //
+    VTSA_FIXED_SIZE_PTR node_array;  // the per-node information
+
+    U64 min_app_address;         // USER: lower allowed user space address (if known)
+    U64 max_app_address;         // USER: upper allowed user space address (if known)
+    U32 page_size;               // Current page size
+    U32 allocation_granularity;  // USER: Granularity of allocation requests (if known)
+    U32 reserved1;               // added for future fields
+    U32 reserved2;               // alignment purpose
+    U64 reserved3[3];            // added for future fields
+
+} VTSA_SYS_INFO;
+
+#define VTSA_SYS_INFO_node_array(sys_info)                (sys_info)->node_array
+#define VTSA_SYS_INFO_min_app_address(sys_info)           (sys_info)->min_app_address
+#define VTSA_SYS_INFO_max_app_address(sys_info)           (sys_info)->max_app_address
+#define VTSA_SYS_INFO_page_size(sys_info)                 (sys_info)->page_size
+#define VTSA_SYS_INFO_allocation_granularity(sys_info)    (sys_info)->allocation_granularity
+
+typedef struct DRV_TOPOLOGY_INFO_NODE_S DRV_TOPOLOGY_INFO_NODE;
+typedef        DRV_TOPOLOGY_INFO_NODE  *DRV_TOPOLOGY_INFO;
+
+struct DRV_TOPOLOGY_INFO_NODE_S {
+    U32 cpu_number;                 // cpu number (as defined by the OS)
+    U16 cpu_package_num;            // package number for this cpu (if known)
+    U16 cpu_core_num;               // core number (if known)
+    U16 cpu_hw_thread_num;          // T0 or T1 if HT enabled
+    S32 socket_master;
+    S32 core_master;
+    S32 thr_master;
+    U32 cpu_module_num;
+    U32 cpu_module_master;
+    U32 cpu_num_modules;
+} ;
+
+#define DRV_TOPOLOGY_INFO_cpu_number(dti)          (dti)->cpu_number
+#define DRV_TOPOLOGY_INFO_cpu_package_num(dti)     (dti)->cpu_package_num
+#define DRV_TOPOLOGY_INFO_cpu_core_num(dti)        (dti)->cpu_core_num
+#define DRV_TOPOLOGY_INFO_socket_master(dti)       (dti)->socket_master
+#define DRV_TOPOLOGY_INFO_core_master(dti)         (dti)->core_master
+#define DRV_TOPOLOGY_INFO_thr_master(dti)          (dti)->thr_master
+#define DRV_TOPOLOGY_INFO_cpu_hw_thread_num(dti)   (dti)->cpu_hw_thread_num
+#define DRV_TOPOLOGY_INFO_cpu_module_num(dti)      (dti)->cpu_module_num
+#define DRV_TOPOLOGY_INFO_cpu_module_master(dti)   (dti)->cpu_module_master
+#define DRV_TOPOLOGY_INFO_cpu_num_modules(dti)     (dti)->cpu_num_modules
+
+#define VALUE_TO_BE_DISCOVERED                     0
+
+// dimm information
+typedef struct DRV_DIMM_INFO_NODE_S DRV_DIMM_INFO_NODE;
+typedef        DRV_DIMM_INFO_NODE  *DRV_DIMM_INFO;
+
+struct DRV_DIMM_INFO_NODE_S {
+  U32 platform_id;
+  U32 channel_num;
+  U32 rank_num;
+  U32 value;
+  U8  mc_num;
+  U8  dimm_valid;
+  U8  valid_value;
+  U8  rank_value;
+  U8  density_value;
+  U8  width_value;
+  U16 socket_num;
+  U64 reserved;
+};
+
+#define DRV_DIMM_INFO_platform_id(di)   (di)->platform_id
+#define DRV_DIMM_INFO_channel_num(di)   (di)->channel_num
+#define DRV_DIMM_INFO_rank_num(di)      (di)->rank_num
+#define DRV_DIMM_INFO_value(di)         (di)->value
+#define DRV_DIMM_INFO_mc_num(di)        (di)->mc_num
+#define DRV_DIMM_INFO_dimm_valid(di)    (di)->dimm_valid
+#define DRV_DIMM_INFO_valid_value(di)   (di)->valid_value
+#define DRV_DIMM_INFO_rank_value(di)    (di)->rank_value
+#define DRV_DIMM_INFO_density_value(di) (di)->density_value
+#define DRV_DIMM_INFO_width_value(di)   (di)->width_value
+#define DRV_DIMM_INFO_socket_num(di)    (di)->socket_num
+
+//platform information. need to get from driver
+#define MAX_PACKAGES  16
+#define MAX_CHANNELS  8
+#define MAX_RANKS     3
+
+typedef struct DRV_PLATFORM_INFO_NODE_S DRV_PLATFORM_INFO_NODE;
+typedef        DRV_PLATFORM_INFO_NODE  *DRV_PLATFORM_INFO;
+
+struct DRV_PLATFORM_INFO_NODE_S {
+    U64 info;                     // platform info
+    U64 ddr_freq_index;           // freq table index
+    U8  misc_valid;               // misc enabled valid bit
+    U8  reserved1;                // added for alignment purpose
+    U16 reserved2;
+    U32 vmm_timer_freq;           // timer frequency from VMM on SoFIA (in HZ)
+    U64 misc_info;                // misc enabled info
+    U64 ufs_freq;                 // ufs frequency (HSX only)
+    DRV_DIMM_INFO_NODE dimm_info[MAX_PACKAGES * MAX_CHANNELS * MAX_RANKS];
+    U64 energy_multiplier;        // Value of energy multiplier
+    U64 reserved3;
+    U64 reserved4;
+    U64 reserved5;
+    U64 reserved6;
+};
+
+#define DRV_PLATFORM_INFO_info(data)              (data)->info
+#define DRV_PLATFORM_INFO_ddr_freq_index(data)    (data)->ddr_freq_index
+#define DRV_PLATFORM_INFO_misc_valid(data)        (data)->misc_valid
+#define DRV_PLATFORM_INFO_misc_info(data)         (data)->misc_info
+#define DRV_PLATFORM_INFO_ufs_freq(data)          (data)->ufs_freq
+#define DRV_PLATFORM_INFO_dimm_info(data)         (data)->dimm_info
+#define DRV_PLATFORM_INFO_energy_multiplier(data) (data)->energy_multiplier
+#define DRV_PLATFORM_INFO_vmm_timer_freq(data)    (data)->vmm_timer_freq
+
+//platform information. need to get from Platform picker
+typedef struct PLATFORM_FREQ_INFO_NODE_S PLATFORM_FREQ_INFO_NODE;
+typedef        PLATFORM_FREQ_INFO_NODE  *PLATFORM_FREQ_INFO;
+
+struct PLATFORM_FREQ_INFO_NODE_S {
+    float   multiplier;          // freq multiplier
+    double *table;               // freq table
+    U32     table_size;          // freq table size
+    U64     reserved1;
+    U64     reserved2;
+    U64     reserved3;
+    U64     reserved4;
+};
+#define PLATFORM_FREQ_INFO_multiplier(data)       (data)->multiplier
+#define PLATFORM_FREQ_INFO_table(data)            (data)->table
+#define PLATFORM_FREQ_INFO_table_size(data)       (data)->table_size
+
+typedef struct DEVICE_INFO_NODE_S  DEVICE_INFO_NODE;
+typedef        DEVICE_INFO_NODE   *DEVICE_INFO; //NEEDED in PP
+
+struct DEVICE_INFO_NODE_S {
+    S8                 *dll_name;
+    PVOID               dll_handle;
+    S8                 *cpu_name;
+    S8                 *pmu_name;
+    S8                 *event_db_file_name;
+    //PLATFORM_IDENTITY plat_identity;  // this is undefined right now. Please take this as structure containing U64
+    U32                 plat_type;      // device type (e.g., DEVICE_INFO_CORE, etc. ... see enum below)
+    U32                 plat_sub_type;  // cti_type (e.g., CTI_Sandybridge, etc., ... see env_info_types.h)
+    S32                 dispatch_id;    // this will be set in user mode dlls and will be unique across all IPF, IA32 (including MIDS).
+    ECB                *ecb;
+    EVENT_CONFIG        ec;
+    DRV_CONFIG          pcfg;
+    U32                 num_of_groups;
+    U32                 size_of_alloc;  // size of each event control block
+    PVOID               drv_event;
+    U32                 num_events;
+    U32                 event_id_index; // event id index of device (basically how many events processed before this device)
+    U32                 num_counters;
+    U32                 group_index;
+    U32                 num_packages;
+    U32                 num_units;
+    U32                 device_type;
+    U64                 reserved1;
+    U32                 pmu_clone_id;   // cti_type of platform to impersonate in device DLLs
+    U32                 reserved2;
+    U64                 reserved3;
+    U64                 reserved4;
+};
+
+#define MAX_EVENT_NAME_LENGTH 64
+
+#define DEVICE_INFO_dll_name(pdev)                  (pdev)->dll_name
+#define DEVICE_INFO_dll_handle(pdev)                (pdev)->dll_handle
+#define DEVICE_INFO_cpu_name(pdev)                  (pdev)->cpu_name
+#define DEVICE_INFO_pmu_name(pdev)                  (pdev)->pmu_name
+#define DEVICE_INFO_event_db_file_name(pdev)        (pdev)->event_db_file_name
+#define DEVICE_INFO_plat_type(pdev)                 (pdev)->plat_type
+#define DEVICE_INFO_plat_sub_type(pdev)             (pdev)->plat_sub_type
+#define DEVICE_INFO_pmu_clone_id(pdev)              (pdev)->pmu_clone_id
+#define DEVICE_INFO_dispatch_id(pdev)               (pdev)->dispatch_id
+#define DEVICE_INFO_ecb(pdev)                       (pdev)->ecb
+#define DEVICE_INFO_ec(pdev)                        (pdev)->ec
+#define DEVICE_INFO_pcfg(pdev)                      (pdev)->pcfg
+#define DEVICE_INFO_num_groups(pdev)                (pdev)->num_of_groups
+#define DEVICE_INFO_size_of_alloc(pdev)             (pdev)->size_of_alloc
+#define DEVICE_INFO_drv_event(pdev)                 (pdev)->drv_event
+#define DEVICE_INFO_num_events(pdev)                (pdev)->num_events
+#define DEVICE_INFO_event_id_index(pdev)            (pdev)->event_id_index
+#define DEVICE_INFO_num_counters(pdev)              (pdev)->num_counters
+#define DEVICE_INFO_group_index(pdev)               (pdev)->group_index
+#define DEVICE_INFO_num_packages(pdev)              (pdev)->num_packages
+#define DEVICE_INFO_num_units(pdev)                 (pdev)->num_units
+#define DEVICE_INFO_device_type(pdev)               (pdev)->device_type
+
+
+typedef struct DEVICE_INFO_DATA_NODE_S DEVICE_INFO_DATA_NODE;
+typedef        DEVICE_INFO_DATA_NODE  *DEVICE_INFO_DATA; //NEEDED in PP
+
+struct DEVICE_INFO_DATA_NODE_S {
+    DEVICE_INFO         pdev_info;
+    U32                 num_elements;
+    U32                 num_allocated;
+    U64                 reserved1;
+    U64                 reserved2;
+    U64                 reserved3;
+    U64                 reserved4;
+};
+
+#define DEVICE_INFO_DATA_pdev_info(d)           (d)->pdev_info
+#define DEVICE_INFO_DATA_num_elements(d)        (d)->num_elements
+#define DEVICE_INFO_DATA_num_allocated(d)       (d)->num_allocated
+
+typedef enum
+{
+    DEVICE_INFO_CORE        =   0,
+    DEVICE_INFO_UNCORE      =   1,
+    DEVICE_INFO_CHIPSET     =   2,
+    DEVICE_INFO_GFX         =   3,
+    DEVICE_INFO_PWR         =   4,
+    DEVICE_INFO_TELEMETRY   =   5
+}   DEVICE_INFO_TYPE;
+
+typedef enum {
+    INVALID_TERMINATE_TYPE = 0,
+    STOP_TERMINATE,
+    CANCEL_TERMINATE
+} ABNORMAL_TERMINATE_TYPE;
+
+#if defined(__cplusplus)
+}
+#endif
+
+typedef struct EMON_SCHED_INFO_NODE_S   EMON_SCHED_INFO_NODE;
+typedef        EMON_SCHED_INFO_NODE     *EMON_SCHED_INFO;
+
+struct EMON_SCHED_INFO_NODE_S {
+     U32   max_counters_for_all_pmus;
+     U32   num_cpus;
+     U32   group_index[MAX_EMON_GROUPS];
+     U32   offset_for_next_device[MAX_EMON_GROUPS];
+     U32   device_id;
+     U32   num_packages;
+     U32   num_units;
+     U32   user_scheduled;
+     U64   reserved1;
+     U64   reserved2;
+     U64   reserved3;
+     U64   reserved4;
+};
+
+#define EMON_SCHED_INFO_max_counters_for_all_pmus(x)           (x)->max_counters_for_all_pmus
+#define EMON_SCHED_INFO_num_cpus(x)                            (x)->num_cpus
+#define EMON_SCHED_INFO_group_index(x,grp_num)                 (x)->group_index[grp_num]
+#define EMON_SCHED_INFO_offset_for_next_device(x, grp_num)     (x)->offset_for_next_device[grp_num]
+#define EMON_SCHED_INFO_device_id(x)                           (x)->device_id
+#define EMON_SCHED_INFO_num_packages(x)                        (x)->num_packages
+#define EMON_SCHED_INFO_num_units(x)                           (x)->num_units
+#define EMON_SCHED_INFO_user_scheduled(x)                      (x)->user_scheduled
+
+#define INITIALIZE_Emon_Sched_Info(x,j)                                                            \
+    for((j) =0; (j) < MAX_EMON_GROUPS; (j)++) {                                                    \
+        EMON_SCHED_INFO_group_index((x),(j))             = 0;                                      \
+        EMON_SCHED_INFO_offset_for_next_device((x), (j)) = 0;                                      \
+    }
+
+typedef struct PCIFUNC_INFO_NODE_S   PCIFUNC_INFO_NODE;
+typedef        PCIFUNC_INFO_NODE     *PCIFUNC_INFO;
+
+struct PCIFUNC_INFO_NODE_S {
+     U32   valid;
+     U32   num_entries;			// the number of entries found with same <dev_no, func_no> but difference bus_no.
+     U64   deviceId;
+     U64   reserved1;
+     U64   reserved2;
+};
+
+#define PCIFUNC_INFO_NODE_funcno(x)             (x)->funcno
+#define PCIFUNC_INFO_NODE_valid(x)              (x)->valid
+#define PCIFUNC_INFO_NODE_deviceId(x)           (x)->deviceId
+#define PCIFUNC_INFO_NODE_num_entries(x)        (x)->num_entries
+
+typedef struct PCIDEV_INFO_NODE_S   PCIDEV_INFO_NODE;
+typedef        PCIDEV_INFO_NODE     *PCIDEV_INFO;
+
+struct PCIDEV_INFO_NODE_S {
+     PCIFUNC_INFO_NODE   func_info[MAX_PCI_FUNCNO];
+     U32                 valid;
+     U32                 dispatch_id;
+     U64                 reserved1;
+     U64                 reserved2;
+};
+
+#define PCIDEV_INFO_NODE_func_info(x,i)        (x).func_info[i]
+#define PCIDEV_INFO_NODE_valid(x)              (x).valid
+
+
+typedef struct UNCORE_PCIDEV_NODE_S   UNCORE_PCIDEV_NODE;
+
+struct UNCORE_PCIDEV_NODE_S {
+    PCIDEV_INFO_NODE   pcidev[MAX_PCI_DEVNO];
+    U32                dispatch_id;
+    U32                scan;
+    U32                num_uncore_units;
+    U32                num_deviceid_entries;
+    U8                 dimm_device1;
+    U8                 dimm_device2;
+    U16                reserved1;
+    U32                reserved2;
+    U64                reserved3;
+    U64                reserved4;
+    U32                deviceid_list[MAX_PCI_DEVNO];
+};
+
+// Structure used to perform uncore device discovery
+
+typedef struct UNCORE_TOPOLOGY_INFO_NODE_S   UNCORE_TOPOLOGY_INFO_NODE;
+typedef        UNCORE_TOPOLOGY_INFO_NODE     *UNCORE_TOPOLOGY_INFO;
+
+struct UNCORE_TOPOLOGY_INFO_NODE_S {
+     UNCORE_PCIDEV_NODE              device[MAX_DEVICES];
+};
+
+#define UNCORE_TOPOLOGY_INFO_device(x, dev_index)                                             (x)->device[dev_index]
+#define UNCORE_TOPOLOGY_INFO_device_dispatch_id(x, dev_index)                                 (x)->device[dev_index].dispatch_id
+#define UNCORE_TOPOLOGY_INFO_device_scan(x, dev_index)                                        (x)->device[dev_index].scan
+#define UNCORE_TOPOLOGY_INFO_pcidev_valid(x, dev_index, devno)                                (x)->device[dev_index].pcidev[devno].valid
+#define UNCORE_TOPOLOGY_INFO_pcidev_dispatch_id(x, dev_index, devno)                          (x)->device[dev_index].pcidev[devno].dispatch_id
+#define UNCORE_TOPOLOGY_INFO_pcidev(x, dev_index, devno)                                      (x)->device[dev_index].pcidev[devno]
+#define UNCORE_TOPOLOGY_INFO_num_uncore_units(x, dev_index)                                   (x)->device[dev_index].num_uncore_units
+#define UNCORE_TOPOLOGY_INFO_num_deviceid_entries(x, dev_index)                               (x)->device[dev_index].num_deviceid_entries
+#define UNCORE_TOPOLOGY_INFO_dimm_device1(x, dev_index)                                       (x)->device[dev_index].dimm_device1
+#define UNCORE_TOPOLOGY_INFO_dimm_device2(x, dev_index)                                       (x)->device[dev_index].dimm_device2
+#define UNCORE_TOPOLOGY_INFO_deviceid(x, dev_index, deviceid_idx)                             (x)->device[dev_index].deviceid_list[deviceid_idx]
+#define UNCORE_TOPOLOGY_INFO_pcidev_set_funcno_valid(x, dev_index, devno, funcno)             ((x)->device[dev_index].pcidev[devno].func_info[funcno].valid = 1)
+#define UNCORE_TOPOLOGY_INFO_pcidev_is_found_in_platform(x, dev_index, devno, funcno)         ((x)->device[dev_index].pcidev[devno].func_info[funcno].num_entries)
+#define UNCORE_TOPOLOGY_INFO_pcidev_is_devno_funcno_valid(x, dev_index, devno, funcno)        ((x)->device[dev_index].pcidev[devno].func_info[funcno].valid ? TRUE : FALSE)
+#define UNCORE_TOPOLOGY_INFO_pcidev_is_device_found(x, dev_index, devno, funcno)              ((x)->device[dev_index].pcidev[devno].func_info[funcno].num_entries > 0)
+
+#define UNCORE_TOPOLOGY_INFO_pcidev_num_entries_found(x, dev_index, devno, funcno)              ((x)->device[dev_index].pcidev[devno].func_info[funcno].num_entries)
+
+typedef enum
+{
+    CORE_TOPOLOGY_NODE                = 0,
+    UNCORE_TOPOLOGY_NODE_IMC          = 1,
+    UNCORE_TOPOLOGY_NODE_UBOX         = 2,
+    UNCORE_TOPOLOGY_NODE_QPI          = 3,
+    MAX_TOPOLOGY_DEV                  = 4, // When you adding new topo node to this enum, make sue MAX_TOPOLOGY_DEV is always the last one.
+}   UNCORE_TOPOLOGY_NODE_INDEX_TYPE;
+
+typedef struct PLATFORM_TOPOLOGY_REG_NODE_S    PLATFORM_TOPOLOGY_REG_NODE;
+typedef        PLATFORM_TOPOLOGY_REG_NODE     *PLATFORM_TOPOLOGY_REG;
+
+struct PLATFORM_TOPOLOGY_REG_NODE_S {
+    U32 bus;
+    U32 device;
+    U32 function;
+    U32 reg_id;
+    U64 reg_mask;
+    U64 reg_value[MAX_PACKAGES];
+    U8  reg_type;
+    U8  device_valid;
+    U16 reserved1;
+    U32 reserved2;
+    U64 reserved3;
+    U64 reserved4;
+};
+
+#define PLATFORM_TOPOLOGY_REG_bus(x,i)                     (x)[(i)].bus
+#define PLATFORM_TOPOLOGY_REG_device(x,i)                  (x)[(i)].device
+#define PLATFORM_TOPOLOGY_REG_function(x,i)                (x)[(i)].function
+#define PLATFORM_TOPOLOGY_REG_reg_id(x,i)                  (x)[(i)].reg_id
+#define PLATFORM_TOPOLOGY_REG_reg_mask(x,i)                (x)[(i)].reg_mask
+#define PLATFORM_TOPOLOGY_REG_reg_type(x,i)                (x)[(i)].reg_type
+#define PLATFORM_TOPOLOGY_REG_device_valid(x,i)            (x)[(i)].device_valid
+#define PLATFORM_TOPOLOGY_REG_reg_value(x,i,package_no)    (x)[(i)].reg_value[package_no]
+
+typedef struct PLATFORM_TOPOLOGY_DISCOVERY_NODE_S    PLATFORM_TOPOLOGY_DISCOVERY_NODE;
+typedef        PLATFORM_TOPOLOGY_DISCOVERY_NODE     *PLATFORM_TOPOLOGY_DISCOVERY;
+
+struct PLATFORM_TOPOLOGY_DISCOVERY_NODE_S {
+    U32                         device_index;
+    U32                         device_id;
+    U32                         num_registers;
+    U8                          scope;
+    U8                          prog_valid;
+    U16                         reserved2;
+    U64                         reserved3;
+    U64                         reserved4;
+    U64                         reserved5;
+    PLATFORM_TOPOLOGY_REG_NODE  topology_regs[MAX_REGS];
+};
+
+//Structure used to discover the uncore device topology_device
+
+typedef struct PLATFORM_TOPOLOGY_PROG_NODE_S    PLATFORM_TOPOLOGY_PROG_NODE;
+typedef        PLATFORM_TOPOLOGY_PROG_NODE     *PLATFORM_TOPOLOGY_PROG;
+
+struct PLATFORM_TOPOLOGY_PROG_NODE_S {
+    U32                                  num_devices;
+    PLATFORM_TOPOLOGY_DISCOVERY_NODE     topology_device[MAX_TOPOLOGY_DEV];
+};
+
+#define PLATFORM_TOPOLOGY_PROG_num_devices(x)                                            (x)->num_devices
+#define PLATFORM_TOPOLOGY_PROG_topology_device(x, dev_index)                             (x)->topology_device[dev_index]
+#define PLATFORM_TOPOLOGY_PROG_topology_device_device_index(x, dev_index)                (x)->topology_device[dev_index].device_index
+#define PLATFORM_TOPOLOGY_PROG_topology_device_device_id(x, dev_index)                   (x)->topology_device[dev_index].device_id
+#define PLATFORM_TOPOLOGY_PROG_topology_device_scope(x, dev_index)                       (x)->topology_device[dev_index].scope
+#define PLATFORM_TOPOLOGY_PROG_topology_device_num_registers(x, dev_index)               (x)->topology_device[dev_index].num_registers
+#define PLATFORM_TOPOLOGY_PROG_topology_device_prog_valid(x, dev_index)                  (x)->topology_device[dev_index].prog_valid
+#define PLATFORM_TOPOLOGY_PROG_topology_topology_regs(x, dev_index)                      (x)->topology_device[dev_index].topology_regs
+
+typedef struct FPGA_GB_DISCOVERY_NODE_S         FPGA_GB_DISCOVERY_NODE;
+
+struct FPGA_GB_DISCOVERY_NODE_S {
+    U16                bar_num;
+    U16                feature_id;
+    U32                device_id;
+    U64                afu_id_l;
+    U64                afu_id_h;
+    U32                feature_offset;
+    U32                feature_len;
+    U8                 scan;
+    U8                 valid;
+    U16                reserved1;
+    U32                reserved2;
+};
+
+typedef struct FPGA_GB_DEV_NODE_S    FPGA_GB_DEV_NODE;
+typedef        FPGA_GB_DEV_NODE     *FPGA_GB_DEV;
+
+struct FPGA_GB_DEV_NODE_S {
+    U32                        num_devices;
+    FPGA_GB_DISCOVERY_NODE     fpga_gb_device[MAX_DEVICES];
+};
+
+#define FPGA_GB_DEV_num_devices(x)                                            (x)->num_devices
+#define FPGA_GB_DEV_device(x, dev_index)                                      (x)->fpga_gb_device[dev_index]
+#define FPGA_GB_DEV_bar_num(x, dev_index)                                     (x)->fpga_gb_device[dev_index].bar_num
+#define FPGA_GB_DEV_feature_id(x, dev_index)                                  (x)->fpga_gb_device[dev_index].feature_id
+#define FPGA_GB_DEV_device_id(x, dev_index)                                   (x)->fpga_gb_device[dev_index].device_id
+#define FPGA_GB_DEV_afu_id_low(x, dev_index)                                  (x)->fpga_gb_device[dev_index].afu_id_l
+#define FPGA_GB_DEV_afu_id_high(x, dev_index)                                 (x)->fpga_gb_device[dev_index].afu_id_h
+#define FPGA_GB_DEV_feature_offset(x, dev_index)                              (x)->fpga_gb_device[dev_index].feature_offset
+#define FPGA_GB_DEV_feature_len(x, dev_index)                                 (x)->fpga_gb_device[dev_index].feature_len
+#define FPGA_GB_DEV_scan(x, dev_index)                                        (x)->fpga_gb_device[dev_index].scan
+#define FPGA_GB_DEV_valid(x, dev_index)                                       (x)->fpga_gb_device[dev_index].valid
+
+typedef enum
+{
+    UNCORE_TOPOLOGY_INFO_NODE_IMC        =   0,
+    UNCORE_TOPOLOGY_INFO_NODE_QPILL      =   1,
+    UNCORE_TOPOLOGY_INFO_NODE_HA         =   2,
+    UNCORE_TOPOLOGY_INFO_NODE_R3         =   3,
+    UNCORE_TOPOLOGY_INFO_NODE_R2         =   4,
+    UNCORE_TOPOLOGY_INFO_NODE_IRP        =   5,
+    UNCORE_TOPOLOGY_INFO_NODE_IMC_UCLK   =   6,
+    UNCORE_TOPOLOGY_INFO_NODE_EDC_ECLK   =   7,
+    UNCORE_TOPOLOGY_INFO_NODE_EDC_UCLK   =   8,
+    UNCORE_TOPOLOGY_INFO_NODE_M2M        =   9,
+    UNCORE_TOPOLOGY_INFO_NODE_HFI_RXE    =   10,
+    UNCORE_TOPOLOGY_INFO_NODE_HFI_TXE    =   11,
+    UNCORE_TOPOLOGY_INFO_NODE_FPGA_CACHE =   12,
+    UNCORE_TOPOLOGY_INFO_NODE_FPGA_FAB   =   13,
+    UNCORE_TOPOLOGY_INFO_NODE_FPGA_THERMAL = 14,
+    UNCORE_TOPOLOGY_INFO_NODE_FPGA_POWER =   15,
+}   UNCORE_TOPOLOGY_INFO_NODE_INDEX_TYPE;
+
+
+typedef struct SIDEBAND_INFO_NODE_S  SIDEBAND_INFO_NODE;
+typedef        SIDEBAND_INFO_NODE   *SIDEBAND_INFO;
+
+struct SIDEBAND_INFO_NODE_S {
+    U32   tid;
+    U32   pid;
+    U64   tsc;
+};
+
+#define SIDEBAND_INFO_pid(x)              (x)->pid
+#define SIDEBAND_INFO_tid(x)              (x)->tid
+#define SIDEBAND_INFO_tsc(x)              (x)->tsc
+
+typedef struct SAMPLE_DROP_NODE_S   SAMPLE_DROP_NODE;
+typedef        SAMPLE_DROP_NODE     *SAMPLE_DROP;
+
+struct SAMPLE_DROP_NODE_S {
+     U32 os_id;
+     U32 cpu_id;
+     U32 sampled;
+     U32 dropped;
+};
+
+#define SAMPLE_DROP_os_id(x)                                            (x)->os_id
+#define SAMPLE_DROP_cpu_id(x)                                           (x)->cpu_id
+#define SAMPLE_DROP_sampled(x)                                          (x)->sampled
+#define SAMPLE_DROP_dropped(x)                                          (x)->dropped
+
+#define MAX_SAMPLE_DROP_NODES   20
+
+typedef struct SAMPLE_DROP_INFO_NODE_S   SAMPLE_DROP_INFO_NODE;
+typedef        SAMPLE_DROP_INFO_NODE     *SAMPLE_DROP_INFO;
+
+struct SAMPLE_DROP_INFO_NODE_S {
+    U32 size;
+    SAMPLE_DROP_NODE drop_info[MAX_SAMPLE_DROP_NODES];
+};
+
+#define SAMPLE_DROP_INFO_size(x)                                        (x)->size
+#define SAMPLE_DROP_INFO_drop_info(x, index)                            (x)->drop_info[index]
+
+#define IS_PEBS_SAMPLE_RECORD(sample_record)                     \
+    ((SAMPLE_RECORD_pid_rec_index(sample_record) == (U32)-1) &&  \
+     (SAMPLE_RECORD_tid(sample_record) == (U32)-1))
+
+typedef struct DRV_EVENT_MASK_NODE_S  DRV_EVENT_MASK_NODE;
+typedef        DRV_EVENT_MASK_NODE    *DRV_EVENT_MASK;
+
+struct DRV_EVENT_MASK_NODE_S {
+    U8 event_idx;    // 0 <= index < MAX_EVENTS
+    union {
+        U8 bitFields1;
+        struct {
+            U8 precise        : 1;
+            U8 lbr_capture    : 1;
+            U8 dear_capture   : 1;  // Indicates which events need to have additional registers read
+                                    // because they are DEAR events.
+            U8 iear_capture   : 1;  // Indicates which events need to have additional registers read
+                                    // because they are IEAR events.
+            U8 btb_capture    : 1;  // Indicates which events need to have additional registers read
+                                    // because they are BTB events.
+            U8 ipear_capture  : 1;  // Indicates which events need to have additional registers read
+                                    // because they are IPEAR events.
+            U8 uncore_capture : 1;
+            U8 branch         : 1;  // Indicates whether the event is related to branch opertion or
+                                    // not
+        } s1;
+    } u1;
+};
+
+#define DRV_EVENT_MASK_event_idx(d)             (d)->event_idx
+#define DRV_EVENT_MASK_bitFields1(d)            (d)->u1.bitFields1
+#define DRV_EVENT_MASK_precise(d)               (d)->u1.s1.precise
+#define DRV_EVENT_MASK_lbr_capture(d)           (d)->u1.s1.lbr_capture
+#define DRV_EVENT_MASK_dear_capture(d)          (d)->u1.s1.dear_capture
+#define DRV_EVENT_MASK_iear_capture(d)          (d)->u1.s1.iear_capture
+#define DRV_EVENT_MASK_btb_capture(d)           (d)->u1.s1.btb_capture
+#define DRV_EVENT_MASK_ipear_capture(d)         (d)->u1.s1.ipear_capture
+#define DRV_EVENT_MASK_uncore_capture(d)        (d)->u1.s1.uncore_capture
+#define DRV_EVENT_MASK_branch(d)                (d)->u1.s1.branch
+
+#define MAX_OVERFLOW_EVENTS 11    // This defines the maximum number of overflow events per interrupt.
+                                  // In order to reduce memory footprint, the value should be at least
+                                  // the number of fixed and general PMU registers.
+                                  // Sandybridge with HT off has 11 PMUs(3 fixed and 8 generic)
+
+typedef struct DRV_MASKS_NODE_S  DRV_MASKS_NODE;
+typedef        DRV_MASKS_NODE    *DRV_MASKS;
+
+/*
+ * @macro DRV_EVENT_MASK_NODE_S
+ * @brief
+ * The structure is used to store overflow events when handling PMU interrupt.
+ * This approach should be more efficient than checking all event masks
+ * if there are many events to be monitored
+ * and only a few events among them have overflow per interrupt.
+ */
+struct DRV_MASKS_NODE_S {
+    DRV_EVENT_MASK_NODE eventmasks[MAX_OVERFLOW_EVENTS];
+    U8 masks_num;               // 0 <= mask_num <= MAX_OVERFLOW_EVENTS
+    U8 padding;                 // data structure alignment
+};
+
+#define DRV_MASKS_masks_num(d)           (d)->masks_num
+#define DRV_MASKS_eventmasks(d)          (d)->eventmasks
+
+
+/*
+ *  VMM vendor information
+ */
+#define  KVM_SIGNATURE              "KVMKVMKVM\0\0\0"
+#define  XEN_SIGNATURE              "XenVMMXenVMM"
+#define  VMWARE_SIGNATURE           "VMwareVMware"
+#define  HYPERV_SIGNATURE           "Microsoft Hv"
+
+#define  DRV_VMM_UNKNOWN            0
+#define  DRV_VMM_INTEL              1
+#define  DRV_VMM_KVM                2
+#define  DRV_VMM_XEN                3
+#define  DRV_VMM_HYPERV             4
+#define  DRV_VMM_VMWARE             5
+
+/*
+ * @macro DRV_SETUP_INFO_NODE_S
+ * @brief
+ * This structure supports driver information such as NMI profiling mode.
+ */
+
+typedef struct DRV_SETUP_INFO_NODE_S  DRV_SETUP_INFO_NODE;
+typedef        DRV_SETUP_INFO_NODE   *DRV_SETUP_INFO;
+
+struct DRV_SETUP_INFO_NODE_S {
+    union {
+        U32      modes;
+        struct {
+            U32  nmi_mode            :1;
+            U32  vmm_mode            :1;
+            U32  vmm_vendor          :8;
+            U32  vmm_guest_vm        :1;
+            U32  pebs_accessible     :1;
+            U32  cpu_hotplug_mode    :1;
+            U32  matrix_inaccessible :1;
+            U32  page_table_isolation:2;
+            U32  pebs_ignored_by_pti :1;
+            U32  reserved1           :15;
+        }s1;
+    }u1;
+    U32 reserved2;
+    U64 reserved3;
+    U64 reserved4;
+};
+
+#define DRV_SETUP_INFO_nmi_mode(info)              (info)->u1.s1.nmi_mode
+#define DRV_SETUP_INFO_vmm_mode(info)              (info)->u1.s1.vmm_mode
+#define DRV_SETUP_INFO_vmm_vendor(info)            (info)->u1.s1.vmm_vendor
+#define DRV_SETUP_INFO_vmm_guest_vm(info)          (info)->u1.s1.vmm_guest_vm
+#define DRV_SETUP_INFO_pebs_accessible(info)       (info)->u1.s1.pebs_accessible
+#define DRV_SETUP_INFO_cpu_hotplug_mode(info)      (info)->u1.s1.cpu_hotplug_mode
+#define DRV_SETUP_INFO_matrix_inaccessible(info)   (info)->u1.s1.matrix_inaccessible
+#define DRV_SETUP_INFO_page_table_isolation(info)  (info)->u1.s1.page_table_isolation
+#define DRV_SETUP_INFO_pebs_ignored_by_pti(info)   (info)->u1.s1.pebs_ignored_by_pti
+
+#define DRV_SETUP_INFO_PTI_DISABLED    0
+#define DRV_SETUP_INFO_PTI_KPTI        1
+#define DRV_SETUP_INFO_PTI_KAISER      2
+#define DRV_SETUP_INFO_PTI_VA_SHADOW   3
+#define DRV_SETUP_INFO_PTI_UNKNOWN     4
+
+/*
+  Type: task_info_t
+  Description:
+      Represents the equivalent of a Linux Thread.
+  Fields:
+      o  id: A unique identifier. May be `NULL_TASK_ID`.
+      o  name: Human-readable name for this task
+      o  executable_name: Literal path to the binary elf that this task's
+              entry point is executing from.
+      o  address_space_id: The unique ID for the address space this task is
+              running in.
+  */
+struct task_info_node_s {
+    U64   id;
+    char  name[32];
+    U64   address_space_id;
+};
+
+/*
+  Type: REMOTE_SWITCH
+  Description:
+      Collection switch set on target
+*/
+typedef struct REMOTE_SWITCH_NODE_S   REMOTE_SWITCH_NODE;
+typedef        REMOTE_SWITCH_NODE    *REMOTE_SWITCH;
+
+struct REMOTE_SWITCH_NODE_S {
+    U32   auto_mode           : 1;
+    U32   adv_hotspot         : 1;
+    U32   lbr_callstack       : 2;
+    U32   full_pebs           : 1;
+    U32   uncore_supported    : 1;
+    U32   reserved1           : 26;
+    U32   reserved2;
+};
+
+
+/*
+  Type: REMOTE_OS_INFO
+  Description:
+      Remote target OS system information
+*/
+#define OSINFOLEN    64
+typedef struct REMOTE_OS_INFO_NODE_S   REMOTE_OS_INFO_NODE;
+typedef        REMOTE_OS_INFO_NODE    *REMOTE_OS_INFO;
+
+struct REMOTE_OS_INFO_NODE_S {
+    U32  os_family;
+    U32  reserved1;
+    S8   sysname[OSINFOLEN];
+    S8   release[OSINFOLEN];
+    S8   version[OSINFOLEN];
+};
+
+
+/*
+  Type: REMOTE_HARDWARE_INFO
+  Description:
+      Remote target hardware information
+*/
+typedef struct REMOTE_HARDWARE_INFO_NODE_S   REMOTE_HARDWARE_INFO_NODE;
+typedef        REMOTE_HARDWARE_INFO_NODE    *REMOTE_HARDWARE_INFO;
+
+struct REMOTE_HARDWARE_INFO_NODE_S {
+    U32  num_cpus;
+    U32  family;
+    U32  model;
+    U32  stepping;
+    U64  tsc_freq;
+    U64  reserved2;
+    U64  reserved3;
+};
+
+
+/*
+ ************************************
+ *  DRIVER LOG BUFFER DECLARATIONS  *
+ ************************************
+ */
+
+#define DRV_MAX_NB_LOG_CATEGORIES        256   // Must be a multiple of 8
+#define DRV_NB_LOG_CATEGORIES             14
+#define DRV_LOG_CATEGORY_LOAD              0
+#define DRV_LOG_CATEGORY_INIT              1
+#define DRV_LOG_CATEGORY_DETECTION         2
+#define DRV_LOG_CATEGORY_ERROR             3
+#define DRV_LOG_CATEGORY_STATE_CHANGE      4
+#define DRV_LOG_CATEGORY_MARK              5
+#define DRV_LOG_CATEGORY_DEBUG             6
+#define DRV_LOG_CATEGORY_FLOW              7
+#define DRV_LOG_CATEGORY_ALLOC             8
+#define DRV_LOG_CATEGORY_INTERRUPT         9
+#define DRV_LOG_CATEGORY_TRACE            10
+#define DRV_LOG_CATEGORY_REGISTER         11
+#define DRV_LOG_CATEGORY_NOTIFICATION     12
+#define DRV_LOG_CATEGORY_WARNING          13
+
+#define LOG_VERBOSITY_UNSET       0xFF
+#define LOG_VERBOSITY_DEFAULT     0xFE
+#define LOG_VERBOSITY_NONE           0
+
+#define LOG_CHANNEL_MEMLOG         0x1
+#define LOG_CHANNEL_AUXMEMLOG      0x2
+#define LOG_CHANNEL_PRINTK         0x4
+#define LOG_CHANNEL_TRACEK         0x8
+#define LOG_CHANNEL_MOSTWHERE     (LOG_CHANNEL_MEMLOG    |   \
+                                   LOG_CHANNEL_AUXMEMLOG |   \
+                                   LOG_CHANNEL_PRINTK)
+#define LOG_CHANNEL_EVERYWHERE    (LOG_CHANNEL_MEMLOG    |   \
+                                   LOG_CHANNEL_AUXMEMLOG |   \
+                                   LOG_CHANNEL_PRINTK    |   \
+                                   LOG_CHANNEL_TRACEK)
+#define LOG_CHANNEL_MASK           LOG_CATEGORY_VERBOSITY_EVERYWHERE
+
+#define LOG_CONTEXT_REGULAR        0x10
+#define LOG_CONTEXT_INTERRUPT      0x20
+#define LOG_CONTEXT_NOTIFICATION   0x40
+#define LOG_CONTEXT_ALL           (LOG_CONTEXT_REGULAR     |   \
+                                   LOG_CONTEXT_INTERRUPT   |   \
+                                   LOG_CONTEXT_NOTIFICATION)
+#define LOG_CONTEXT_MASK           LOG_CONTEXT_ALL
+#define LOG_CONTEXT_SHIFT          4
+
+#define DRV_LOG_NOTHING            0
+#define DRV_LOG_FLOW_IN            1
+#define DRV_LOG_FLOW_OUT           2
+
+
+/*
+ * @macro DRV_LOG_ENTRY_NODE_S
+ * @brief
+ * This structure is used to store a log message from the driver.
+ */
+
+#define DRV_LOG_MESSAGE_LENGTH       64
+#define DRV_LOG_FUNCTION_NAME_LENGTH 32
+
+typedef struct DRV_LOG_ENTRY_NODE_S  DRV_LOG_ENTRY_NODE;
+typedef        DRV_LOG_ENTRY_NODE   *DRV_LOG_ENTRY;
+struct DRV_LOG_ENTRY_NODE_S {
+
+    char function_name[DRV_LOG_FUNCTION_NAME_LENGTH];
+    char message      [DRV_LOG_MESSAGE_LENGTH];
+
+    U16  temporal_tag;
+    U16  integrity_tag;
+
+    U8   category;
+    U8   secondary_info;          // Secondary attribute:
+                                  // former driver state for STATE category
+                                  // 'ENTER' or 'LEAVE' for FLOW and TRACE categories
+    U16  processor_id;            // NB: not guaranteed to be accurate (due to preemption / core migration)
+
+    U64  tsc;
+
+    U16  nb_active_interrupts;    // never 100% accurate, merely indicative
+    U8   active_drv_operation;    // only 100% accurate for IOCTL-called functions
+    U8   driver_state;
+
+    U16  line_number;             // as per the __LINE__ macro
+
+    U16  nb_active_notifications;
+
+    U64  reserved;               // need padding to reach 128 bytes
+}; // this structure should be exactly 128-byte long
+
+#define DRV_LOG_ENTRY_temporal_tag(ent)            (ent)->temporal_tag
+#define DRV_LOG_ENTRY_integrity_tag(ent)           (ent)->integrity_tag
+#define DRV_LOG_ENTRY_category(ent)                (ent)->category
+#define DRV_LOG_ENTRY_secondary_info(ent)          (ent)->secondary_info
+#define DRV_LOG_ENTRY_processor_id(ent)            (ent)->processor_id
+#define DRV_LOG_ENTRY_tsc(ent)                     (ent)->tsc
+#define DRV_LOG_ENTRY_driver_state(ent)            (ent)->driver_state
+#define DRV_LOG_ENTRY_active_drv_operation(ent)    (ent)->active_drv_operation
+#define DRV_LOG_ENTRY_nb_active_interrupts(ent)    (ent)->nb_active_interrupts
+#define DRV_LOG_ENTRY_nb_active_notifications(ent) (ent)->nb_active_notifications
+#define DRV_LOG_ENTRY_line_number(ent)             (ent)->line_number
+#define DRV_LOG_ENTRY_message(ent)                 (ent)->message
+#define DRV_LOG_ENTRY_function_name(ent)           (ent)->function_name
+
+
+/*
+ * @macro DRV_LOG_BUFFER_NODE_S
+ * @brief
+ * Circular buffer structure storing the latest DRV_LOG_MAX_NB_ENTRIES driver messages
+ */
+
+#define DRV_LOG_SIGNATURE_SIZE        8                    // Must be a multiple of 8
+#define DRV_LOG_SIGNATURE_0          'S'
+#define DRV_LOG_SIGNATURE_1          'e'
+#define DRV_LOG_SIGNATURE_2          'P'
+#define DRV_LOG_SIGNATURE_3          'd'
+#define DRV_LOG_SIGNATURE_4          'R'
+#define DRV_LOG_SIGNATURE_5          'v'
+#define DRV_LOG_SIGNATURE_6          '4'
+#define DRV_LOG_SIGNATURE_7          '\0'
+// The signature is "SePdRv4"; not declared as string on purpose to avoid false positives when trying to identify the log buffer in a crash dump
+
+#define DRV_LOG_VERSION               1
+#define DRV_LOG_FILLER_BYTE           1
+
+#define DRV_LOG_DRIVER_VERSION_SIZE   64                   // Must be a multiple of 8
+#define DRV_LOG_MAX_NB_PRI_ENTRIES   (8192 * 2)            // 2MB buffer [*HAS TO BE* a power of 2!] [8192 entries = 1 MB]
+#define DRV_LOG_MAX_NB_AUX_ENTRIES   (8192)                // 1MB buffer [*HAS TO BE* a power of 2!]
+#define DRV_LOG_MAX_NB_ENTRIES       (DRV_LOG_MAX_NB_PRI_ENTRIES + DRV_LOG_MAX_NB_AUX_ENTRIES)
+
+typedef struct DRV_LOG_BUFFER_NODE_S  DRV_LOG_BUFFER_NODE;
+typedef        DRV_LOG_BUFFER_NODE   *DRV_LOG_BUFFER;
+struct DRV_LOG_BUFFER_NODE_S {
+
+    char      header_signature[DRV_LOG_SIGNATURE_SIZE]; // some signature to be able to locate the log even without -g; ASCII would help
+                                                        // should we change the signature for each log's version instead of keeping it in a
+                                                        // dedicated field?
+
+    U32       log_size;                                // filled with sizeof(this structure) at init.
+    U32       max_nb_pri_entries;                      // filled with the driver's "DRV_LOG_MAX_NB_PRIM_ENTRIES" at init.
+
+    U32       max_nb_aux_entries;                      // filled with the driver's "DRV_LOG_MAX_NB_AUX_ENTRIES" at init.
+    U32       reserved1;
+
+    U64       init_time;                               // primary log disambiguator
+
+    U32       disambiguator;                           // used to differentiate the driver's version of the log when a full memory dump can contain some from userland
+    U32       log_version;                             // 0 at first, increase when format changes?
+
+    U32       pri_entry_index;                         // should be incremented *atomically* as a means to (re)allocate the next primary log entry.
+    U32       aux_entry_index;                         // should be incremented *atomically* as a means to (re)allocate the next auxiliary log entry.
+
+    char      driver_version[DRV_LOG_DRIVER_VERSION_SIZE];
+
+    U8        driver_state;
+    U8        active_drv_operation;
+    U16       reserved2;
+    U32       nb_drv_operations;
+
+    U32       nb_interrupts;
+    U16       nb_active_interrupts;
+    U16       nb_active_notifications;
+
+    U32       nb_notifications;
+    U32       nb_driver_state_transitions;
+
+    U8        contiguous_physical_memory;
+    U8        reserved3;
+    U16       reserved4;
+    U32       reserved5;
+
+    U8        verbosities[DRV_MAX_NB_LOG_CATEGORIES];
+
+    DRV_LOG_ENTRY_NODE entries[DRV_LOG_MAX_NB_ENTRIES];
+
+    char      footer_signature[DRV_LOG_SIGNATURE_SIZE];
+};
+
+#define DRV_LOG_BUFFER_pri_entry_index(log)             (log)->pri_entry_index
+#define DRV_LOG_BUFFER_aux_entry_index(log)             (log)->aux_entry_index
+#define DRV_LOG_BUFFER_header_signature(log)            (log)->header_signature
+#define DRV_LOG_BUFFER_footer_signature(log)            (log)->footer_signature
+#define DRV_LOG_BUFFER_log_size(log)                    (log)->log_size
+#define DRV_LOG_BUFFER_driver_version(log)              (log)->driver_version
+#define DRV_LOG_BUFFER_driver_state(log)                (log)->driver_state
+#define DRV_LOG_BUFFER_active_drv_operation(log)        (log)->active_drv_operation
+#define DRV_LOG_BUFFER_nb_interrupts(log)               (log)->nb_interrupts
+#define DRV_LOG_BUFFER_nb_active_interrupts(log)        (log)->nb_active_interrupts
+#define DRV_LOG_BUFFER_nb_notifications(log)            (log)->nb_notifications
+#define DRV_LOG_BUFFER_nb_active_notifications(log)     (log)->nb_active_notifications
+#define DRV_LOG_BUFFER_nb_driver_state_transitions(log) (log)->nb_driver_state_transitions
+#define DRV_LOG_BUFFER_nb_drv_operations(log)           (log)->nb_drv_operations
+#define DRV_LOG_BUFFER_max_nb_pri_entries(log)          (log)->max_nb_pri_entries
+#define DRV_LOG_BUFFER_max_nb_aux_entries(log)          (log)->max_nb_aux_entries
+#define DRV_LOG_BUFFER_init_time(log)                   (log)->init_time
+#define DRV_LOG_BUFFER_disambiguator(log)               (log)->disambiguator
+#define DRV_LOG_BUFFER_log_version(log)                 (log)->log_version
+#define DRV_LOG_BUFFER_entries(log)                     (log)->entries
+#define DRV_LOG_BUFFER_contiguous_physical_memory(log)  (log)->contiguous_physical_memory
+#define DRV_LOG_BUFFER_verbosities(log)                 (log)->verbosities
+
+
+#define DRV_LOG_CONTROL_MAX_DATA_SIZE   DRV_MAX_NB_LOG_CATEGORIES   // Must be a multiple of 8
+
+typedef struct DRV_LOG_CONTROL_NODE_S   DRV_LOG_CONTROL_NODE;
+typedef        DRV_LOG_CONTROL_NODE    *DRV_LOG_CONTROL;
+
+struct DRV_LOG_CONTROL_NODE_S {
+     U32   command;
+     U32   reserved1;
+     U8    data[DRV_LOG_CONTROL_MAX_DATA_SIZE];     // only DRV_NB_LOG_CATEGORIES elements will be used, but let's plan for backwards compatibility
+                                                    // if LOG_CATEGORY_UNSET, then READ instead of WRITE
+
+     U64   reserved2;                               // may later want to add support for resizing the buffer, or only log 100 first interrupts, etc.
+     U64   reserved3;
+     U64   reserved4;
+     U64   reserved5;
+};
+
+#define DRV_LOG_CONTROL_command(x)              (x)->command
+#define DRV_LOG_CONTROL_verbosities(x)          (x)->data
+#define DRV_LOG_CONTROL_message(x)              (x)->data   // Userland 'MARK' messages use the 'data' field too.
+#define DRV_LOG_CONTROL_log_size(x)             (*((U32*)((x)->data)))
+
+#define DRV_LOG_CONTROL_COMMAND_NONE             0
+#define DRV_LOG_CONTROL_COMMAND_ADJUST_VERBOSITY 1
+#define DRV_LOG_CONTROL_COMMAND_MARK             2
+#define DRV_LOG_CONTROL_COMMAND_QUERY_SIZE       3
+#define DRV_LOG_CONTROL_COMMAND_BENCHMARK        4
+
+
+#endif
+

--- a/perftools-external/soc_perf_driver/include/lwpmudrv_types.h
+++ b/perftools-external/soc_perf_driver/include/lwpmudrv_types.h
@@ -1,0 +1,139 @@
+/***
+ * -------------------------------------------------------------------------
+ *               INTEL CORPORATION PROPRIETARY INFORMATION
+ *  This software is supplied under the terms of the accompanying license
+ *  agreement or nondisclosure agreement with Intel Corporation and may not
+ *  be copied or disclosed except in accordance with the terms of that
+ *  agreement.
+ *        Copyright(C) 2007-2018 Intel Corporation.  All Rights Reserved.
+ * -------------------------------------------------------------------------
+***/
+
+#ifndef _LWPMUDRV_TYPES_H_
+#define _LWPMUDRV_TYPES_H_
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+
+typedef unsigned char       U8;
+typedef          char       S8;
+typedef          short      S16;
+typedef unsigned short      U16;
+typedef unsigned int        U32;
+typedef          int        S32;
+#if defined(DRV_OS_WINDOWS)
+typedef unsigned __int64    U64;
+typedef          __int64    S64;
+#elif defined (DRV_OS_LINUX) || defined(DRV_OS_SOLARIS) || defined(DRV_OS_MAC) || defined (DRV_OS_ANDROID) || defined(DRV_OS_FREEBSD)
+typedef unsigned long long  U64;
+typedef          long long  S64;
+typedef unsigned long       ULONG;
+typedef          void       VOID;
+typedef          void*      LPVOID;
+#else
+#error "Undefined OS"
+#endif
+
+#if defined(DRV_IA32)
+typedef S32                 SIOP;
+typedef U32                 UIOP;
+#elif defined(DRV_EM64T)
+typedef S64                 SIOP;
+typedef U64                 UIOP;
+#else
+#error "Unexpected Architecture seen"
+#endif
+
+typedef U32                 DRV_BOOL;
+typedef void*               PVOID;
+
+#if !defined(__DEFINE_STCHAR__)
+#define __DEFINE_STCHAR__
+#if defined(UNICODE)
+typedef wchar_t             STCHAR;
+#define VTSA_T(x)           L ## x
+#else
+typedef char                STCHAR;
+#define VTSA_T(x)           x
+#endif
+#endif
+
+#if defined(DRV_OS_WINDOWS)
+#include <wchar.h>
+typedef   wchar_t           DRV_STCHAR;
+typedef   wchar_t           VTSA_CHAR;
+#else
+typedef   char              DRV_STCHAR;
+#endif
+
+//
+// Handy Defines
+//
+typedef   U32                             DRV_STATUS;
+
+#define   MAX_STRING_LENGTH             1024
+#define   MAXNAMELEN                     256
+
+#if defined(DRV_OS_WINDOWS)
+#define   UNLINK                        _unlink
+#define   RENAME                        rename
+#define   WCSDUP                        _wcsdup
+#endif
+#if defined(DRV_OS_LINUX) || defined(DRV_OS_SOLARIS) || defined(DRV_OS_MAC) || defined (DRV_OS_ANDROID) || defined(DRV_OS_FREEBSD)
+#define   UNLINK                        unlink
+#define   RENAME                        rename
+#endif
+
+#if defined(DRV_OS_SOLARIS) && !defined(_KERNEL)
+//wcsdup is missing on Solaris
+#include <stdlib.h>
+#include <wchar.h>
+
+static inline wchar_t* solaris_wcsdup(const wchar_t *wc)
+{
+	wchar_t *tmp = (wchar_t *)malloc((wcslen(wc) + 1) * sizeof(wchar_t));
+	wcscpy(tmp, wc);
+	return tmp;
+}
+#define   WCSDUP                        solaris_wcsdup
+#endif
+
+#if defined(DRV_OS_LINUX) || defined(DRV_OS_FREEBSD) || defined(DRV_OS_MAC)
+#define   WCSDUP                        wcsdup
+#endif
+
+#if !defined(_WCHAR_T_DEFINED)
+#if defined(DRV_OS_LINUX) || defined(DRV_OS_ANDROID) || defined(DRV_OS_SOLARIS)
+#if !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
+#endif
+#endif
+
+#if (defined(DRV_OS_LINUX) || defined(DRV_OS_ANDROID)) && !defined(__KERNEL__)
+#include <wchar.h>
+typedef wchar_t VTSA_CHAR;
+#endif
+
+#if (defined(DRV_OS_MAC) || defined(DRV_OS_FREEBSD) || defined(DRV_OS_SOLARIS)) && !defined(_KERNEL)
+#include <wchar.h>
+typedef wchar_t VTSA_CHAR;
+#endif
+
+
+#define   TRUE                          1
+#define   FALSE                         0
+
+#define ALIGN_4(x)    (((x) +  3) &  ~3)
+#define ALIGN_8(x)    (((x) +  7) &  ~7)
+#define ALIGN_16(x)   (((x) + 15) & ~15)
+#define ALIGN_32(x)   (((x) + 31) & ~31)
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif
+

--- a/perftools-external/soc_perf_driver/include/lwpmudrv_version.h
+++ b/perftools-external/soc_perf_driver/include/lwpmudrv_version.h
@@ -1,0 +1,148 @@
+/* ***********************************************************************************************
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or 
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(C) 2010-2018 Intel Corporation. All rights reserved.
+
+  This program is free software; you can redistribute it and/or modify 
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but 
+  WITHOUT ANY WARRANTY; without even the implied warranty of 
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License 
+  along with this program; if not, write to the Free Software 
+  Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+  The full GNU General Public License is included in this distribution 
+  in the file called LICENSE.GPL.
+
+  BSD LICENSE 
+
+  Copyright(C) 2010-2018 Intel Corporation. All rights reserved.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+    * Redistributions of source code must retain the above copyright 
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright 
+      notice, this list of conditions and the following disclaimer in 
+      the documentation and/or other materials provided with the 
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its 
+      contributors may be used to endorse or promote products derived 
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ***********************************************************************************************
+*/
+/*
+ *  File  : lwpmudrv_version.h
+ */
+
+#ifndef _LWPMUDRV_VERSION_H_
+#define _LWPMUDRV_VERSION_H_
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*
+ * @macro SOCPERF_VERSION_NODE_S
+ * @brief
+ * This structure supports versioning in Sep. The field major indicates the major version,
+ * minor indicates the minor version and api indicates the api version for the current
+ * sep build. This structure is initialized at the time when the driver is loaded.
+ */
+
+typedef struct SOCPERF_VERSION_NODE_S  SOCPERF_VERSION_NODE;
+typedef        SOCPERF_VERSION_NODE   *SOCPERF_VERSION;
+
+struct SOCPERF_VERSION_NODE_S {
+    union {
+        U32      socperf_version;
+        struct {
+            S32  major :8;
+            S32  minor :8;
+            S32  api   :8;
+            S32  update:8;
+        }s1;
+    }u1;
+};
+
+#define SOCPERF_VERSION_NODE_socperf_version(version) (version)->u1.socperf_version
+#define SOCPERF_VERSION_NODE_major(version)           (version)->u1.s1.major
+#define SOCPERF_VERSION_NODE_minor(version)           (version)->u1.s1.minor
+#define SOCPERF_VERSION_NODE_api(version)             (version)->u1.s1.api
+#define SEP_VERSION_NODE_update(version)      (version)->u1.s1.update
+
+#if defined(__cplusplus)
+}
+#endif
+
+// SOCPERF VERSIONING
+
+#define _STRINGIFY(x)     #x
+#define STRINGIFY(x)      _STRINGIFY(x)
+#define _STRINGIFY_W(x)   L#x
+#define STRINGIFY_W(x)    _STRINGIFY_W(x)
+
+#define SOCPERF_MAJOR_VERSION  2
+#define SOCPERF_MINOR_VERSION  0
+#define SOCPERF_API_VERSION    0
+#define SOCPERF_UPDATE_VERSION 0
+#if SOCPERF_UPDATE_VERSION > 0
+#define SOCPERF_UPDATE_STRING  " Update "STRINGIFY(SOCPERF_UPDATE_VERSION)
+#else
+#define SOCPERF_UPDATE_STRING  ""
+#endif
+
+#define SOCPERF_PRODUCT_NAME  "Sampling Enabling Product"
+#define PRODUCT_VERSION_DATE    __DATE__ " at " __TIME__
+#define PRODUCT_COPYRIGHT   "Copyright (C) 2011-2018 Intel Corporation. All rights reserved."
+#define PRODUCT_DISCLAIMER  "Warning: This computer program is protected under U.S. and international\ncopyright laws, and may only be used or copied in accordance with the terms\nof the license agreement. Except as permitted by such license, no part\nof this computer program may be reproduced, stored in a retrieval system,\nor transmitted in any form or by any means without the express written consent\nof Intel Corporation."
+#define PRODUCT_VERSION     "4.1"
+
+#define SOCPERF_NAME          "socperf"
+#define SOCPERF_NAME_W        L"socperf"
+
+#define SOCPERF_MSG_PREFIX    SOCPERF_NAME""STRINGIFY(SOCPERF_MAJOR_VERSION)"_"STRINGIFY(SOCPERF_MINOR_VERSION)":"
+#define SOCPERF_VERSION_STR   STRINGIFY(SOCPERF_MAJOR_VERSION)"."STRINGIFY(SOCPERF_MINOR_VERSION)"."STRINGIFY(SOCPERF_API_VERSION)
+
+#if defined(DRV_OS_WINDOWS)
+#define SOCPERF_DRIVER_NAME   SOCPERF_NAME STRINGIFY(SOCPERF_MAJOR_VERSION)"_"STRINGIFY(SOCPERF_MINOR_VERSION)
+#define SOCPERF_DRIVER_NAME_W SOCPERF_NAME_W STRINGIFY_W(SOCPERF_MAJOR_VERSION) L"_" STRINGIFY_W(SOCPERF_MINOR_VERSION)
+#define SOCPERF_DEVICE_NAME   SOCPERF_DRIVER_NAME
+#endif
+
+#if defined(DRV_OS_LINUX) || defined(DRV_OS_SOLARIS) || defined(DRV_OS_ANDROID) || defined(DRV_OS_FREEBSD)
+#define SOCPERF_DRIVER_NAME   SOCPERF_NAME""STRINGIFY(SOCPERF_MAJOR_VERSION)"_"STRINGIFY(SOCPERF_MINOR_VERSION)
+#define SOCPERF_SAMPLES_NAME  SOCPERF_DRIVER_NAME"_s"
+#define SOCPERF_DEVICE_NAME   "/dev/"SOCPERF_DRIVER_NAME
+#endif
+
+#if defined(DRV_OS_MAC)
+#define SOCPERF_DRIVER_NAME   SOCPERF_NAME""STRINGIFY(SOCPERF_MAJOR_VERSION)"_"STRINGIFY(SOCPERF_MINOR_VERSION)
+#define SOCPERF_SAMPLES_NAME  SOCPERF_DRIVER_NAME"_s"
+#define SOCPERF_DEVICE_NAME   SOCPERF_DRIVER_NAME
+#endif
+
+#endif

--- a/perftools-external/soc_perf_driver/include/rise_errors.h
+++ b/perftools-external/soc_perf_driver/include/rise_errors.h
@@ -1,0 +1,328 @@
+/***
+ * -------------------------------------------------------------------------
+ *               INTEL CORPORATION PROPRIETARY INFORMATION
+ *  This software is supplied under the terms of the accompanying license
+ *  agreement or nondisclosure agreement with Intel Corporation and may not
+ *  be copied or disclosed except in accordance with the terms of that
+ *  agreement.
+ *        Copyright(C) 2004-2018 Intel Corporation.  All Rights Reserved.
+ * -------------------------------------------------------------------------
+***/
+
+#ifndef _RISE_ERRORS_H_
+#define _RISE_ERRORS_H_
+
+//
+// NOTE:
+//
+// 1) Before adding an error code, first make sure the error code doesn't
+// already exist. If it does, use that, don't create a new one just because...
+//
+// 2) When adding an error code, add it to the end of the list. Don't insert
+// error numbers in the middle of the list! For backwards compatibility,
+// we don't want the numbers changing unless we really need them
+// to for some reason (like we want to switch to negative error numbers)
+//
+// 3) Change the VT_LAST_ERROR_CODE macro to point to the (newly added)
+// last error. This is done so SW can verify the number of error codes
+// possible matches the number of error strings it has
+//
+// 4) Don't forget to update the error string table to include your
+// error code (rise.c). Since the goal is something human readable
+// you don't need to use abbreviations in there (ie. don't say "bad param",
+// say "bad parameter" or "illegal parameter passed in")
+//
+// 5) Compile and run the test_rise app (in the test_rise directory) to
+// verify things are still working
+//
+//
+
+#define VT_SUCCESS                             0
+
+/*************************************************************/
+
+#define VT_INVALID_MAX_SAMP                    1
+#define VT_INVALID_SAMP_PER_BUFF               2
+#define VT_INVALID_SAMP_INTERVAL               3
+#define VT_INVALID_PATH                        4
+#define VT_TB5_IN_USE                          5
+#define VT_INVALID_NUM_EVENTS                  6
+#define VT_INTERNAL_ERROR                      8
+#define VT_BAD_EVENT_NAME                      9
+#define VT_NO_SAMP_SESSION                     10
+#define VT_NO_EVENTS                           11
+#define VT_MULTIPLE_RUNS                       12
+#define VT_NO_SAM_PARAMS                       13
+#define VT_SDB_ALREADY_EXISTS                  14
+#define VT_SAMPLING_ALREADY_STARTED            15
+#define VT_TBS_NOT_SUPPORTED                   16
+#define VT_INVALID_SAMPARAMS_SIZE              17
+#define VT_INVALID_EVENT_SIZE                  18
+#define VT_ALREADY_PROCESSES                   19
+#define VT_INVALID_EVENTS_PATH                 20
+#define VT_INVALID_LICENSE                     21
+
+/******************************************************/
+//SEP error codes
+
+#define VT_SAM_ERROR                           22
+#define VT_SAMPLE_FILE_ALREADY_MAPPED          23
+#define VT_INVALID_SAMPLE_FILE                 24
+#define VT_UNKNOWN_SECTION_NUMBER              25
+#define VT_NO_MEMORY                           26
+#define VT_ENV_VAR_NOT_FOUND                   27
+#define VT_SAMPLE_FILE_NOT_MAPPED              28
+#define VT_BUFFER_OVERFLOW                     29
+#define VT_USER_OP_COMPLETED                   30
+#define VT_BINARY_NOT_FOUND                    31
+#define VT_ISM_NOT_INITIALIZED                 32
+#define VT_NO_SYMBOLS                          33
+#define VT_SAMPLE_FILE_MAPPING_ERROR           34
+#define VT_BUFFER_NULL                         35
+#define VT_UNEXPECTED_NULL_PTR                 36
+#define VT_BINARY_LOAD_FAILED                  37
+#define VT_FUNCTION_NOT_FOUND_IN_BINARY        38
+#define VT_ENTRY_NOT_FOUND                     39
+#define VT_SEP_SYNTAX_ERROR                    40
+#define VT_SEP_OPTIONS_ERROR                   41
+#define VT_BAD_EVENT_MODIFIER                  42
+#define VT_INCOMPATIBLE_PARAMS                 43
+#define VT_FILE_OPEN_FAILED                    44
+#define VT_EARLY_EXIT                          45
+#define VT_TIMEOUT_RETURN                      46
+#define VT_NO_CHILD_PROCESS                    47
+#define VT_DRIVER_RUNNING                      48
+#define VT_DRIVER_STOPPED                      49
+#define VT_MULTIPLE_RUNS_NEEDED                50
+#define VT_QUIT_IMMEDIATE                      51
+#define VT_DRIVER_INIT_FAILED                  52
+#define VT_NO_TB5_CREATED                      53
+#define VT_NO_WRITE_PERMISSION                 54
+#define VT_DSA_INIT_FAILED                     55
+#define VT_INVALID_CPU_MASK                    56
+#define VT_SAMP_IN_RUNNING_STATE               57
+#define VT_SAMP_IN_PAUSE_STATE                 58
+#define VT_SAMP_IN_STOP_STATE                  59
+#define VT_SAMP_NO_SESSION                     60
+#define VT_NOT_CONFIGURED                      61
+#define VT_LAUNCH_BUILD64_FAILED               62
+#define VT_BAD_PARAMETER                       63
+#define VT_ISM_INIT_FAILED                     64
+#define VT_INVALID_STATE_TRANS                 65
+#define VT_EARLY_EXIT_N_CANCEL                 66
+#define VT_EVT_MGR_NOT_INIT                    67
+#define VT_ISM_SECTION_ENUM_FAILED             68
+#define VT_VG_PARSER_ERROR                     69
+#define VT_MISSING_VALUE_FOR_TOKEN             70
+#define VT_EMPTY_SAMPLE_FILE_NAME              71
+#define VT_UNEXPECTED_VALUE                    72
+#define VT_NOT_IMPLEMENTED                     73
+#define VT_MISSING_COL_DEPNDNCIES              74
+#define VT_DEP_COL_NOT_LIB_DEFINED             75
+#define VT_COL_NOT_REG_WITH_LIB                76
+#define VT_SECTION_ALREADY_IN_USE              77
+#define VT_SECTION_NOT_EXIST                   78
+#define VT_STREAM_NOT_EXIST                    79
+#define VT_INVALID_STREAM                      80
+#define VT_STREAM_ALREADY_IN_USE               81
+#define VT_DATA_DESC_NOT_EXIST                 82
+#define VT_INVALID_ERROR_CODE                  83
+#define VT_INCOMPATIBLE_VERSION                84
+#define VT_LEGACY_DATA_NOT_EXIST               85
+#define VT_INVALID_READ_START                  86
+#define VT_DRIVER_OPEN_FAILED                  87
+#define VT_DRIVER_IOCTL_FAILED                 88
+#define VT_SAMP_FILE_CREATE_FAILED             89
+#define VT_MODULE_FILE_CREATE_FAILED           90
+#define VT_INVALID_SAMPLE_FILE_NAME            91
+#define VT_INVALID_MODULE_FILE_NAME            92
+#define VT_FORK_CHILD_PROCESS_FAILED           93
+#define VT_UNEXPECTED_MISMATCH_IN_STRING_TYPES 94
+#define VT_INCOMPLETE_TB5_ENCOUNTERED          95
+#define VT_ERR_CONVERSION_FROM_STRING_2_NUMBER 96
+#define VT_INVALID_STRING                      97
+#define VT_UNSUPPORTED_DATA_SIZE               98
+#define VT_TBRW_INIT_FAILED                    99
+#define VT_PLUGIN_UNLOAD                       100
+#define VT_PLUGIN_ENTRY_NULL                   101
+#define VT_UNKNOWN_PLUGIN                      102
+#define VT_BUFFER_TOO_SMALL                    103
+#define VT_CANNOT_MODIFY_COLUMN                104
+#define VT_MULT_FILTERS_NOT_ALLOWED            105
+#define VT_ADDRESS_IN_USE                      106
+#define VT_NO_MORE_MMAPS                       107
+#define VT_MAX_PAGES_IN_DS_EXCEEDED            108
+#define VT_INVALID_COL_TYPE_IN_GROUP_INFO      109
+#define VT_AGG_FN_ON_VARCHAR_NOT_SUPP          110
+#define VT_INVALID_ACCESS_PERMS                111
+#define VT_NO_DATA_TO_DISPLAY                  112
+#define VT_TB5_IS_NOT_BOUND                    113
+#define VT_MISSING_GROUP_BY_COLUMN             114
+#define VT_SMRK_MAX_STREAMS_EXCEEDED           115
+#define VT_SMRK_STREAM_NOT_CREATED             116
+#define VT_SMRK_NOT_IMPL                       117
+#define VT_SMRK_TYPE_NOT_IMPL                  118
+#define VT_SMRK_TYPE_ALREADY_SET               119
+#define VT_SMRK_NO_STREAM                      120
+#define VT_SMRK_INVALID_STREAM_TYPE            121
+#define VT_SMRK_STREAM_NOT_FOUND               122
+#define VT_SMRK_FAIL                           123
+#define VT_SECTION_NOT_READABLE                124
+#define VT_SECTION_NOT_WRITEABLE               125
+#define VT_GLOBAL_SECTION_NOT_CLOSED           126
+#define VT_STREAM_SECTION_NOT_CLOSED           127
+#define VT_STREAM_NOT_CLOSED                   128
+#define VT_STREAM_NOT_BOUND                    129
+#define VT_NO_COLS_SPECIFIED                   130
+#define VT_NOT_ALL_SECTIONS_CLOSED             131
+#define VT_SMRK_INVALID_PTR                    132
+#define VT_UNEXPECTED_BIND_MISMATCH            133
+#define VT_WIN_TIMER_ERROR                     134
+#define VT_ONLY_SNGL_DEPNDT_COL_ALLWD          135
+#define VT_BAD_MODULE                          136
+#define VT_INPUT_SOURCE_INFO_NOT_SET           137
+#define VT_UNSUPPORTED_TIME_GRAN               138
+#define VT_NO_SAMPLES_COLLECTED                139
+#define VT_INVALID_CPU_TYPE_VERSION            140
+#define VT_BIND_UNEXPECTED_1STMODREC           141
+#define VT_BIND_MODULES_NOT_SORTED             142
+#define VT_UNEXPECTED_NUM_CPUIDS               143
+#define VT_UNSUPPORTED_ARCH_TYPE               144
+#define VT_NO_DATA_TO_WRITE                    145
+#define VT_EM_TIME_SLICE_TOO_SMALL             146
+#define VT_EM_TOO_MANY_EVENT_GROUPS            147
+#define VT_EM_ZERO_GROUPS                      148
+#define VT_EM_NOT_SUPPORTED                    149
+#define VT_PMU_IN_USE                          150
+#define VT_TOO_MANY_INTERRUPTS                 151
+#define VT_MAX_SAMPLES_REACHED                 152
+#define VT_MODULE_COLLECTION_FAILED            153
+#define VT_INCOMPATIBLE_DRIVER                 154
+#define VT_UNABLE_LOCATE_TRIGGER_EVENT         155
+#define VT_COMMAND_NOT_HANDLED                 156
+#define VT_DRIVER_VERSION_MISMATCH             157
+#define VT_MAX_MARKERS                         158
+#define VT_DRIVER_COMM_FAILED                  159
+#define VT_CHIPSET_CONFIG_FAILED               160
+#define VT_BAD_DATA_BASE                       161
+#define VT_PAX_SERVICE_NOT_CONNECTED           162
+#define VT_PAX_SERVICE_ERROR                   163
+#define VT_PAX_PMU_RESERVE_FAILED              164
+#define VT_INVALID_CPU_INFO_TYPE               165
+#define VT_CACHE_DOESNT_EXIST                  166
+#define VT_UNSUPPORTED_UNCORE_ARCH_TYPE        167
+#define VT_EXCEEDED_MAX_EVENTS                 168
+#define VT_MARKER_TIMER_FAILED                 169
+#define VT_PAX_PMU_UNRESERVE_FAILED            170
+#define VT_MULTIPLE_PROCESSES_FOUND            171
+#define VT_NO_SUCH_PROCESS_FOUND               172
+#define VT_PCL_NOT_ENABLED                     173
+#define VT_PCL_UID_CHECK                       174
+#define VT_DEL_RESULTS_DIR_FAILED              175
+#define VT_NO_VALID_EVENTS                     176
+#define VT_INVALID_EVENT                       177
+#define VT_EVENTS_COUNTED                      178
+#define VT_EVENTS_COLLECTED                    179
+#define VT_UNSUPPORTED_GFX_ARCH_TYPE           180
+#define VT_GFX_CONFIG_FAILED                   181
+#define VT_UNSUPPORTED_NON_NATIVE_MODE         182
+#define VT_INVALID_DEVICE                      183
+#define VT_ENV_SETUP_FAILED                    184
+#define VT_RESUME_NOT_RECEIVED                 185
+#define VT_UNSUPPORTED_PWR_ARCH_TYPE           186
+#define VT_PWR_CONFIG_FAILED                   187
+#define VT_NMI_WATCHDOG_FOUND                  188
+#define VT_NO_PMU_RESOURCES                    189
+#define VT_MIC_CARD_NOT_ONLINE                 190
+#define VT_FREEZE_ON_PMI_NOT_AVAIL             191
+#define VT_FLUSH_FAILED                        192
+#define VT_FLUSH_SUCCESS                       193
+#define VT_WRITE_ERROR                         194
+#define VT_NO_SPACE                            195
+#define VT_MSR_ACCESS_ERROR                    196
+#define VT_PEBS_NOT_SUPPORTED                  197
+#define VT_LUA_PARSE_ERROR                     198
+#define VT_COMM_CONNECTION_CLOSED_BY_REMOTE    199
+#define VT_COMM_LISTEN_ERROR                   200
+#define VT_COMM_BIND_ERROR                     201
+#define VT_COMM_ACCEPT_ERROR                   202
+#define VT_COMM_SEND_ERROR                     203
+#define VT_COMM_RECV_ERROR                     204
+#define VT_COMM_SOCKET_ERROR                   205
+#define VT_COMM_CONNECT_ERROR                  206
+#define VT_TARGET_COLLECTION_MISMATCH          207
+#define VT_INVALID_SEP_DRIVER_LOG              208
+#define VT_COMM_PROTOCOL_VERSION_MISTMATCH     209
+#define VT_SAMP_IN_UNEXPECTED_STATE            210
+#define VT_COMM_RECV_BUF_RESIZE_ERROR          211
+
+/*
+ * define error code for checking on async marker request
+ */
+#define VT_INVALID_MARKER_ID                   -1
+
+/*
+ * ************************************************************
+ * NOTE: after adding new error code(s), remember to also
+ *       update the following:
+ *           1) VT_LAST_ERROR_CODE below
+ *           2) viewer/sampling_utils/src/rise.c
+ *           3) collector/controller/sep_msg_catalog.xmc
+ *           4) qnx_kernel/sepdk/include/rise_errors.h
+ *
+ * ************************************************************
+ */
+
+//
+// To make error checking easier, the special VT_LAST_ERROR_CODE
+// should be set to whatever is the last error on the list above
+//
+#define VT_LAST_ERROR_CODE                     VT_COMM_RECV_BUF_RESIZE_ERROR
+
+//
+// Define a macro to determine success or failure. Users of this
+// error header file should use the macros instead of direct
+// checks so that we can change the error numbers in the future
+// (such as making negative numbers be an error indication and positive
+// numbers being a success with a value indication)
+//
+#define VTSA_SUCCESS(x)                        ((x) == VT_SUCCESS)
+#define VTSA_FAILED(x)                         (!VTSA_SUCCESS(x))
+
+//
+// These should be deprecated, but we'll keep them here just in case
+//
+#define SEP_IS_SUCCESS(x)                      VTSA_SUCCESS(x)
+#define SEP_IS_FAILED(x)                       VTSA_FAILED(x)
+
+
+
+/*************************************************************
+ * API Error Codes
+ *************************************************************/
+#define VTAPI_INVALID_MAX_SAMP                 VT_INVALID_MAX_SAMP
+#define VTAPI_INVALID_SAMP_PER_BUFF            VT_INVALID_SAMP_PER_BUFF
+#define VTAPI_INVALID_SAMP_INTERVAL            VT_INVALID_SAMP_INTERVAL
+#define VTAPI_INVALID_PATH                     VT_INVALID_PATH
+#define VTAPI_TB5_IN_USE                       VT_TB5_IN_USE
+#define VTAPI_INVALID_NUM_EVENTS               VT_INVALID_NUM_EVENTS
+#define VTAPI_INTERNAL_ERROR                   VT_INTERNAL_ERROR
+#define VTAPI_BAD_EVENT_NAME                   VT_BAD_EVENT_NAME
+#define VTAPI_NO_SAMP_SESSION                  VT_NO_SAMP_SESSION
+#define VTAPI_NO_EVENTS                        VT_NO_EVENTS
+#define VTAPI_MULTIPLE_RUNS                    VT_MULTIPLE_RUNS
+#define VTAPI_NO_SAM_PARAMS                    VT_NO_SAM_PARAMS
+#define VTAPI_SDB_ALREADY_EXISTS               VT_SDB_ALREADY_EXISTS
+#define VTAPI_SAMPLING_ALREADY_STARTED         VT_SAMPLING_ALREADY_STARTED
+#define VTAPI_TBS_NOT_SUPPORTED                VT_TBS_NOT_SUPPORTED
+#define VTAPI_INVALID_SAMPARAMS_SIZE           VT_INVALID_SAMPARAMS_SIZE
+#define VTAPI_INVALID_EVENT_SIZE               VT_INVALID_EVENT_SIZE
+#define VTAPI_ALREADY_PROCESSES                VT_ALREADY_PROCESSES
+#define VTAPI_INVALID_EVENTS_PATH              VT_INVALID_EVENTS_PATH
+#define VTAPI_INVALID_LICENSE                  VT_INVALID_LICENSE
+
+typedef int RISE_ERROR;
+typedef void *RISE_PTR;
+
+#endif
+

--- a/perftools-external/soc_perf_driver/src/Makefile
+++ b/perftools-external/soc_perf_driver/src/Makefile
@@ -1,0 +1,150 @@
+#
+# Version: 1.0
+#
+#  This file is provided under a dual BSD/GPLv2 license.  When using or 
+#  redistributing this file, you may do so under either license.
+#
+#  GPL LICENSE SUMMARY
+#
+#  Copyright(C) 2008-2018 Intel Corporation. All rights reserved.
+#
+#  This program is free software; you can redistribute it and/or modify 
+#  it under the terms of version 2 of the GNU General Public License as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful, but 
+#  WITHOUT ANY WARRANTY; without even the implied warranty of 
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+#  General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License 
+#  along with this program; if not, write to the Free Software 
+#  Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+#  The full GNU General Public License is included in this distribution 
+#  in the file called LICENSE.GPL.
+#
+#  BSD LICENSE 
+#
+#  Copyright(C) 2008-2018 Intel Corporation. All rights reserved.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without 
+#  modification, are permitted provided that the following conditions 
+#  are met:
+#
+#    * Redistributions of source code must retain the above copyright 
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright 
+#      notice, this list of conditions and the following disclaimer in 
+#      the documentation and/or other materials provided with the 
+#      distribution.
+#    * Neither the name of Intel Corporation nor the names of its 
+#      contributors may be used to endorse or promote products derived 
+#      from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+# -------------------- user configurable options ------------------------
+
+# base name of SocPerf driver
+DRIVER_NAME = socperf2_0
+
+# location to install driver
+INSTALL = .
+
+# If KERNELRELEASE is defined, we've been invoked from the
+# kernel build system and can use its language.
+# Example flags are "-Werror", "-Wno-error", etc.
+#EXTRA_CFLAGS += -I$(LDDINCDIR) -I$(LDDINCDIR1)
+EXTRA_CFLAGS += -I$(M)/../include -I$(M)/inc
+
+# if ARCH variable is set, unset it to avoid conflicts with kbuild
+unexport ARCH
+
+# platform details
+MACH ?= $(shell uname -m)
+export MACH
+PLATFORM=x32
+ifeq ($(MACH),x86_64)
+PLATFORM=x32_64
+endif
+
+KERNEL_VERSION ?= $(shell uname -r)
+SMP := $(shell uname -v | grep SMP)
+ARITY=up
+ifneq ($(SMP),)
+ARITY=smp
+endif
+
+# eventual filename of SocPerf driver
+DRIVER_MODE=$(DRIVER_NAME)
+DRIVER_TYPE=$(PLATFORM)-$(KERNEL_VERSION)$(ARITY)
+DRIVER_FILENAME=$(DRIVER_MODE)-$(DRIVER_TYPE).ko
+
+# build options ...
+ifneq ($(KERNELRELEASE),)
+	obj-m := $(DRIVER_NAME).o
+
+arch-objs :=    pci.o                 \
+		soc_uncore.o                  \
+		haswellunc_sa.o               \
+		npk_uncore.o
+
+EXTRA_CFLAGS += -DDRV_ANDROID
+
+$(DRIVER_NAME)-objs :=    \
+		socperfdrv.o      \
+		control.o         \
+		utility.o         \
+		$(arch-objs)
+
+# targets ...
+
+# Otherwise, we were called directly from the command
+# line, so the kernel build system will be used.
+else
+	PWD  := $(shell pwd)
+	PATH := $(ANDROID_TOOLCHAIN):$(PATH)
+	export PATH
+
+all: default
+
+default:
+	$(MAKE) -C $(KERNEL_SRC_DIR) M=$(PWD) LDDINCDIR=$(PWD)/../include LDDINCDIR1=$(PWD)/inc modules PWD=$(PWD)
+	cp $(DRIVER_NAME).ko $(DRIVER_FILENAME)
+
+endif
+
+install:
+	@cp $(DRIVER_NAME).ko $(INSTALL)/$(DRIVER_FILENAME)
+	@echo "Installed $(DRIVER_NAME) driver to $(INSTALL)/$(DRIVER_FILENAME) ."
+	@if [ -f insmod-socperf  -a $(shell pwd) != $(INSTALL) ]; then \
+		(cp insmod-socperf $(INSTALL)/insmod-socperf); \
+	fi;
+	@if [ -f rmmod-socperf -a $(shell pwd) != $(INSTALL) ]; then \
+		(cp rmmod-socperf $(INSTALL)/rmmod-socperf); \
+	fi;
+	@if [ -f boot-script -a $(shell pwd) != $(INSTALL) ]; then \
+		(cp boot-script $(INSTALL)/boot-script); \
+	fi;
+
+clean:
+	rm -f *.o .*.o.cmd .*.o.d .*.ko.cmd .*.ko.unsigned.cmd *.gcno
+	rm -f $(DRIVER_NAME).ko $(DRIVER_NAME).ko.unsigned
+	rm -f $(DRIVER_MODE)*$(DRIVER_TYPE).ko
+	rm -f Module.symvers Modules.symvers *.mod.c modules.order Module.markers
+	rm -rf .tmp_versions
+
+distclean: clean
+	rm -f $(DRIVER_NAME)*.ko

--- a/perftools-external/soc_perf_driver/src/build-driver
+++ b/perftools-external/soc_perf_driver/src/build-driver
@@ -1,0 +1,706 @@
+#!/bin/sh
+
+#
+# File: build-driver
+#
+# Description: script to build the SocPerf driver
+#
+# Version: 1.7
+#
+#  This file is provided under a dual BSD/GPLv2 license.  When using or 
+#  redistributing this file, you may do so under either license.
+#
+#  GPL LICENSE SUMMARY
+#
+#  Copyright(C) 2008-2018 Intel Corporation. All rights reserved.
+#
+#  This program is free software; you can redistribute it and/or modify 
+#  it under the terms of version 2 of the GNU General Public License as
+#  published by the Free Software Foundation.
+#
+#  This program is distributed in the hope that it will be useful, but 
+#  WITHOUT ANY WARRANTY; without even the implied warranty of 
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+#  General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License 
+#  along with this program; if not, write to the Free Software 
+#  Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+#  The full GNU General Public License is included in this distribution 
+#  in the file called LICENSE.GPL.
+#
+#  BSD LICENSE 
+#
+#  Copyright(C) 2008-2018 Intel Corporation. All rights reserved.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without 
+#  modification, are permitted provided that the following conditions 
+#  are met:
+#
+#    * Redistributions of source code must retain the above copyright 
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright 
+#      notice, this list of conditions and the following disclaimer in 
+#      the documentation and/or other materials provided with the 
+#      distribution.
+#    * Neither the name of Intel Corporation nor the names of its 
+#      contributors may be used to endorse or promote products derived 
+#      from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+# set the path to include "standard" locations so commands below can be found
+ANDROID_BUILD=1
+export ANDROID_BUILD
+
+PATH="/sbin:/usr/sbin:/usr/local/sbin:/bin:/usr/bin/:/usr/local/sbin:/usr/local/bin:/usr/local/gnu/bin:.:"${PATH}""
+export PATH
+
+# ------------------------------ COMMANDS ------------------------------------
+
+CUT="cut"
+ECHO="echo"
+GREP="grep"
+HEAD="head"
+SED="sed"
+UNAME="uname"
+WHICH="which"
+
+COMMANDS_TO_CHECK="${CUT} ${GREP} ${HEAD} ${UNAME}"
+
+# if any of the COMMANDS_TO_CHECK are not executable, then exit script
+
+OK="true"
+for c in ${COMMANDS_TO_CHECK} ; do
+  CMD=`${WHICH} $c 2>&1` ;
+  if [ -z "${CMD}" ] ; then
+    OK="false"
+    echo "ERROR: unable to find command \"$c\" !"
+  fi
+done
+if [ ${OK} != "true" ] ; then
+  echo "Please add the above commands to your PATH and re-run the script ... exiting."
+  exit 255
+fi
+
+# ------------------------------ CONSTANTS -----------------------------------
+
+# base driver name and version
+DRIVER_BASE=socperf
+DRIVER_MAJOR=2
+DRIVER_MINOR=0
+# basic name of driver
+DRIVER_NAME=${DRIVER_BASE}${DRIVER_MAJOR}_${DRIVER_MINOR}
+
+# ------------------------------ VARIABLES -----------------------------------
+
+SCRIPT=$0
+SCRIPT_ARGS="$*"
+SCRIPT_DIR=`dirname "$SCRIPT"`
+PLATFORM=`${UNAME} -m`
+KERNEL_VERSION=`${UNAME} -r`
+MACHINE_TYPE=`${UNAME} -m`
+DRIVER_DIRECTORY=$PWD
+DRIVER_SOURCE_DIRECTORY=$PWD
+PER_USER_MODE="NO"
+
+# ------------------------------ FUNCTIONS -----------------------------------
+
+# function to show usage and exit
+
+print_usage_and_exit()
+{
+  echo ""
+  echo "Usage: $0 [ options ]"
+  echo ""
+  echo " where \"options\" are the following:"
+  echo ""
+  echo "    --help | -h"
+  echo "      prints out usage"
+  echo ""
+  echo "    --non-interactive | -ni"
+  echo "      attempts to automatically build the driver using"
+  echo "      default values without prompting for user input"
+  echo ""
+  echo "    --print-driver-name"
+  echo "      returns the name of the driver that would be built"
+  echo "      based on the current running kernel"
+  echo ""
+  echo "    --install-dir=path"
+  echo "      \"path\" is an existing, writable directory where the"
+  echo "      driver will be copied after it is successfully built;"
+  echo "      this defaults to \"${DRIVER_DIRECTORY}\""
+  echo ""
+  echo "    --print-kernel-checksum"
+  echo "      returns kernel checksum information for running kernel;"
+  echo "      this can be used to verify driver/kernel compatibility"
+  echo ""
+  echo "    --kernel-file=file"
+  echo "      \"file\" is pathname of kernel file for currently"
+  echo "      running kernel; used for comparing kernel checksums;"
+  echo "      this can be either compressed (vmlinuz) or"
+  echo "      uncompressed (vmlinux) kernel file, but must be the"
+  echo "      kernel that was booted; this defaults to \"/boot/vmlinuz-${KERNEL_VERSION}\""
+  echo ""
+  echo "    --kernel-version=version"
+  echo "      \"version\" is version string of kernel that should"
+  echo "      be used for checksum or for building the driver;"
+  echo "      this defaults to \"${KERNEL_VERSION}\""
+  echo ""
+  echo "    --kernel-src-dir=path"
+  echo "      \"path\" directory of the configured kernel source tree;"
+  echo "      several paths are searched to find a suitable default,"
+  echo "      including \"/lib/modules/${KERNEL_VERSION}/{source,build}\","
+  echo "      \"/usr/src/linux-${KERNEL_VERSION}\", and \"/usr/src/linux\""
+  echo ""
+  echo "    --c-compiler=c_compiler"
+  echo "      \"c_compiler\" is the C compiler used to compile the kernel;"
+  echo "      this defaults to \"gcc\""
+  echo ""
+  echo "    --make-command=make_command"
+  echo "      \"make_command\" is the make command used to build the kernel;"
+  echo "      this defaults to \"make\""
+  echo ""
+  echo "    --make-args=args"
+  echo "      arguments to pass to make command (e.g., \"-n\" causes all make"
+  echo "      commands to be shown but does not actually carry them out,"
+  echo "      \"V=1\" shows the detailed build commands, etc.)"
+  echo ""
+  echo "    --exit-if-driver-exists"
+  echo "      exits if a pre-built driver for the current running"
+  echo "      kernel exists in the driver install directory"
+  echo ""
+  echo "    --non-verbose"
+  echo "      decrease the amount of (helpful) messages"
+  echo ""
+  echo "    --config-file=file"
+  echo "      \"file\" is pathname of configuration file to read"
+  echo "      default VARIABLE=VALUE entries from; NOTE: order of"
+  echo "      this option (relative to the other options) matters"
+  echo ""
+  echo "    --per-user | -pu"
+  echo "      build the driver in secure sampling mode"
+  echo ""
+  echo ""
+  exit 0
+}
+
+# print kernel checksum info for future comparision
+# check for kernel file in kernel source tree
+#  KERNEL_FILE=${KERNEL_SRC_DIR}/vmlinux
+#  KERNEL_FILE=`cat /proc/cmdline | tr ' ' '\n' | grep BOOT_FILE | cut -d '=' -f 2`
+
+print_kernel_checksum()
+{
+  KERNEL_FILE=$1
+  MD5SUM=`${WHICH} ${MD5SUM:-md5sum} 2>&1`
+
+  if [ -x "${MD5SUM}" ] ; then
+    if [ -r "${KERNEL_FILE}" ] ; then
+      CHECKSUM=`${MD5SUM} ${KERNEL_FILE}`
+      echo "${CHECKSUM}  ${kernel_version}  ${MACHINE_TYPE}"
+    fi
+  fi
+}
+
+read_config_file()
+{
+  CONFIG_FILE=$1
+  if [ -r "${CONFIG_FILE}" ] ; then
+    driver_install_dir=`${GREP} "^VDK_INSTALL_DIR=" ${CONFIG_FILE} | ${SED} -e s^VDK_INSTALL_DIR=^^`
+    c_compiler=`${GREP} "^VDK_C_COMPILER=" ${CONFIG_FILE} | ${SED} -e s^VDK_C_COMPILER=^^`
+    make_command=`${GREP} "^VDK_MAKE_COMMAND=" ${CONFIG_FILE} | ${SED} -e s^VDK_MAKE_COMMAND=^^`
+    kernel_src_dir=`${GREP} "^VDK_KERNEL_SRC_DIR=" ${CONFIG_FILE} | ${SED} -e s^VDK_KERNEL_SRC_DIR=^^`
+  else
+    if [ $non_verbose -eq 1 ] ; then
+      echo ""
+      echo "Warning: unable to access config file \"${CONFIG_FILE}\" ... option ignored ..."
+    fi
+  fi
+}
+
+exit_if_file_inaccessible()
+{
+  proposed_file=$1
+  attr=${2:-f}
+  # check for executable
+  if [ "$attr" = "x" ] ; then
+    file=`${WHICH} $proposed_file 2>&1`
+    if [ ! -$attr "$file" ] ; then
+      echo "ERROR: file \"$proposed_file\" either does not exist or is not an executable!"
+      exit 111
+    fi
+  # otherwise assume regular file
+  else
+    if [ ! -$attr "$proposed_file" ] ; then
+      echo "ERROR: \"$proposed_file\" is either not a file or is not accessible!"
+      exit 111
+    fi
+  fi
+}
+
+exit_if_directory_inaccessible()
+{
+  dir=$1
+  err=$2
+  if [ ! -d "$dir" ] ; then
+    echo "ERROR: \"$dir\" either does not exist or is not a directory!"
+    exit $err
+  fi
+  if [ ! -r "$dir" ] ; then
+    echo "ERROR: directory \"$dir\" is not accessible!"
+    exit $err
+  fi
+}
+
+non_interactive=0
+print_driver_name=0
+print_kernel_checksum=0
+use_install_dir=0
+build_kernel=2  #  0=no, 1=yes, 2=maybe
+exit_if_driver_exists=0
+non_verbose=0
+
+while [ $# -gt 0 ] ; do
+  case "$1" in
+    --help | -h)
+      print_usage_and_exit
+      ;;
+    --non-interactive | -ni)
+       non_interactive=1
+       ;;
+    --print-driver-name)
+       print_driver_name=1
+       build_kernel=0
+       ;;
+    --install-dir=*)
+       driver_install_dir=`echo $1 | sed s?^--install-dir=??g`
+       use_install_dir=1
+       ;;
+    --kernel-file=*)
+       kernel_file=`echo $1 | sed s?^--kernel-file=??g`
+       ;;
+    --kernel-version=*)
+       kernel_version=`echo $1 | sed s?^--kernel-version=??g`
+       ;;
+    --kernel-src-dir=*)
+       kernel_src_dir=`echo $1 | sed s?^--kernel-src-dir=??g`
+       ;;
+    --c-compiler=*)
+       c_compiler=`echo $1 | sed s?^--c-compiler=??g`
+       ;;
+    --make-command=*)
+       make_command=`echo $1 | sed s?^--make-command=??g`
+       ;;
+    --make-args=*)
+       make_args=`echo $1 | sed s?^--make-args=??g`
+       ;;
+    --print-kernel-checksum)
+       print_kernel_checksum=1
+       build_kernel=0
+       ;;
+    --exit-if-driver-exists)
+       exit_if_driver_exists=1
+       ;;
+    --non-verbose)
+       non_verbose=1
+       ;;
+    --config-file=*)
+       config_file=`echo $1 | sed s?^--config-file=??g`
+       read_config_file $config_file
+       ;;
+    --per-user | -pu)
+       PER_USER_MODE="YES"
+       ;;
+    *)
+       echo ""
+       echo "Invalid option: \"$1\""
+       print_usage_and_exit
+       ;;
+  esac
+  shift
+done
+
+if [ -z "${kernel_version}" ] ; then
+  kernel_version=${KERNEL_VERSION}
+fi
+
+if [ -z "${kernel_src_dir}" ] ; then
+  kernel_src_dir=/usr/src/linux-${kernel_version}
+else
+  exit_if_directory_inaccessible $kernel_src_dir 110
+fi
+
+if [ -z "${kernel_file}" ] ; then
+  kernel_file=/boot/vmlinuz-${kernel_version}
+else
+  exit_if_file_inaccessible $kernel_file
+fi
+
+if [ -z "${c_compiler}" ] ; then
+  c_compiler=gcc
+else
+  exit_if_file_inaccessible $c_compiler x
+fi
+
+if [ -z "${make_command}" ] ; then
+  make_command=make
+else
+  exit_if_file_inaccessible $make_command x
+fi
+
+# function to describe default option
+
+show_preamble()
+{
+  if [ $non_verbose -eq 0 ] ; then
+    echo ""
+    echo "Options in brackets \"[ ... ]\" indicate default values"
+    echo "that will be used when only the ENTER key is pressed."
+  fi
+  echo ""
+}
+
+# function to return absolute path location (from script directory)
+
+get_absolute_path()
+{
+  target_dir=$1
+  if [ -d ${target_dir} ] ; then
+    cd ${SCRIPT_DIR} -
+    cd ${target_dir} -
+    actual_dir=$PWD
+    cd ${SCRIPT_DIR} -
+    echo "${actual_dir}"
+  else
+    echo "${target_dir}"
+  fi
+}
+
+# function to repeat this script or exit with error code
+
+repeat_or_exit()
+{
+  EXIT_CODE=$1
+  echo ""
+  # for now, just exit with error
+  exit ${EXIT_CODE}
+  if [ $non_interactive -eq 1 ] ; then
+    exit ${EXIT_CODE}
+  fi
+  echo -n "Retry building the driver? (yes/no) [Yes] "
+  read YESNO
+  if [ "${YESNO}" = "N" -o "${YESNO}" = "n" -o "${YESNO}" = "no" -o "${YESNO}" = "No" ] ; then
+    echo ""
+    exit ${EXIT_CODE}
+  else
+    exec ${SCRIPT} ${SCRIPT_ARGS}
+  fi
+  echo ""
+}
+
+# ----------------------------- PRE-CHECK ------------------------------------
+
+# check if OS and platform is supported
+
+# if ARCH variable is set, unset it to avoid conflicts below
+
+unset ARCH
+
+if [ "${PLATFORM}" = "ia64" ] ; then
+  ARCH="x64"
+elif [ "${PLATFORM}" = "x86_64" ] ; then
+  ARCH="x32_64"
+elif [ "${PLATFORM}" = "i386" -o "${PLATFORM}" = "i486" -o "${PLATFORM}" = "i586" -o "${PLATFORM}" = "i686" ] ; then
+  ARCH="x32"
+else
+  echo ""
+  echo "ERROR: Unsupported platform \"${PLATFORM}\" ... exiting."
+  echo ""
+  exit 254
+fi
+
+# determine if using kernel 2.6 sources or later
+
+KS_MAKEFILE=${kernel_src_dir}/Makefile
+if [ -r ${KS_MAKEFILE} ] ; then
+  KS_VERSION=`${GREP} "^VERSION" ${KS_MAKEFILE} | ${HEAD} -1 | ${SED} -e 's/ //g' | ${CUT} -d '=' -f 2`
+  KS_PATCHLEVEL=`${GREP} "^PATCHLEVEL" ${KS_MAKEFILE} | ${HEAD} -1 | ${SED} -e 's/ //g' | ${CUT} -d '=' -f 2`
+  KS_SUBLEVEL=`${GREP} "^SUBLEVEL" ${KS_MAKEFILE} | ${HEAD} -1 | ${SED} -e 's/ //g' | ${CUT} -d '=' -f 2`
+  KERNEL_26X=`echo "${KS_VERSION}.${KS_PATCHLEVEL}.${KS_SUBLEVEL}" | ${GREP} ^2.6.`
+  KERNEL_3XY=`echo "${KS_VERSION}.${KS_PATCHLEVEL}.${KS_SUBLEVEL}" | ${GREP} ^3.`
+  KERNEL_4XY=`echo "${KS_VERSION}.${KS_PATCHLEVEL}.${KS_SUBLEVEL}" | ${GREP} ^4.`
+else
+  KERNEL_26X=`echo ${kernel_version} | ${GREP} ^2.6.`
+  KERNEL_3XY=`echo ${kernel_version} | ${GREP} ^3.`
+  KERNEL_4XY=`echo ${kernel_version} | ${GREP} ^4.`
+fi
+KERNEL_SUPPORTED="${KERNEL_26X}${KERNEL_3XY}${KERNEL_4XY}"
+
+# if not using kernel 2.6.x or later, then exit with error
+
+if [ -z "${KERNEL_SUPPORTED}" ] ; then
+  echo ""
+  echo "ERROR: Linux kernels prior to 2.6.x are unsupported ... exiting."
+  echo ""
+  exit 254
+fi
+
+# print checksum and exit, if requested
+
+if [ $print_kernel_checksum -eq 1 ] ; then
+  print_kernel_checksum $kernel_file
+  exit 0
+fi
+
+# check whether kernel is for UP or SMP
+
+SMP=`${UNAME} -v | ${GREP} SMP`
+if [ -z "${SMP}" ] ; then
+  ARITY="up"
+else
+  ARITY="smp"
+fi
+
+# check driver file extension
+
+EXT="ko"
+
+# name of the driver that will be built (see Makefile)
+
+DRIVER_FILENAME=${DRIVER_NAME}-${ARCH}-${kernel_version}${ARITY}.${EXT}
+
+if [ $print_driver_name -eq 1 ] ; then
+  echo "${DRIVER_FILENAME}"
+  exit 0
+fi
+
+# ----------------------- BUILD / INSTALL DRIVER -----------------------------
+
+if [ -z "$driver_install_dir" ] ; then
+  driver_install_dir=${DRIVER_DIRECTORY}
+else
+  exit_if_directory_inaccessible $driver_install_dir 101
+fi
+
+if [ -d $driver_install_dir ] ; then
+  DRIVER_DIRECTORY=$driver_install_dir
+fi
+
+DRIVER_DIRECTORY=`get_absolute_path ${DRIVER_DIRECTORY}`
+
+# if specifed, check whether pre-built driver exists and exit if it does
+
+if [ $exit_if_driver_exists -eq 1 ] ; then
+  if [ -r $driver_install_dir/${DRIVER_FILENAME} ] ; then
+    echo ""
+    echo "Found pre-built driver: $driver_install_dir/${DRIVER_FILENAME}"
+    echo ""
+    exit 0
+  else
+    show_preamble
+    echo "Pre-built driver \"${DRIVER_FILENAME}\" was NOT found"
+    echo "in directory \"$driver_install_dir\" ."
+    echo ""
+    echo -n "Proceed with building a driver for this kernel? (Yes/No) [Yes] "
+    if [ $non_interactive -eq 1 ] ; then
+      YESNO=y
+    else
+      read YESNO
+    fi
+    echo ""
+    if [ "${YESNO}" = "N" -o "${YESNO}" = "n" -o "${YESNO}" = "no" -o "${YESNO}" = "No" ] ; then
+      exit 100
+    fi
+  fi
+else
+  if [ $non_interactive -eq 0 ] ; then
+    show_preamble
+  fi
+fi
+
+# prompt for C compiler
+
+OLD_CC=${CC}
+NEW_CC=""
+CURRENT_CC=`${WHICH} $c_compiler 2>&1`
+if [ -z "${CURRENT_CC}" ] ; then
+  CURRENT_CC=$c_compiler
+fi
+if [ $non_verbose -eq 0 -o $non_interactive -eq 0 ] ; then
+  echo -n "C compiler to use: [ ${CURRENT_CC} ] "
+fi
+if [ $non_interactive -eq 0 ] ; then
+  read NEW_CC
+  echo ""
+else
+  if [ $non_verbose -eq 0 ] ; then
+    echo ""
+  fi
+fi
+if [ -z "${NEW_CC}" ] ; then
+  NEW_CC=${CURRENT_CC}
+fi
+CHECK_CC=`${WHICH} "${NEW_CC}" 2>&1`
+if [ -z "${CHECK_CC}" -o -d "${CHECK_CC}" ] ; then
+  echo "ERROR: invalid or inaccessible C compiler \"${NEW_CC}\" !"
+  repeat_or_exit 255
+fi
+
+export CC="${CHECK_CC}"
+
+# prompt for make command
+
+NEW_MAKE=""
+CURRENT_MAKE=`${WHICH} $make_command 2>&1`
+if [ -z "${CURRENT_MAKE}" ] ; then
+  CURRENT_MAKE=$make_command
+fi
+if [ $non_verbose -eq 0 -o $non_interactive -eq 0 ] ; then
+  echo -n "Make command to use: [ ${CURRENT_MAKE} ] "
+fi
+if [ $non_interactive -eq 0 ] ; then
+  read NEW_MAKE
+  echo ""
+else
+  if [ $non_verbose -eq 0 ] ; then
+    echo ""
+  fi
+fi
+if [ -z "${NEW_MAKE}" ] ; then
+  NEW_MAKE=${CURRENT_MAKE}
+fi
+CHECK_MAKE=`${WHICH} "${NEW_MAKE}" 2>&1`
+if [ -z "${CHECK_MAKE}" -o -d "${CHECK_MAKE}" ] ; then
+  echo "ERROR: invalid or inaccessible make command \"${NEW_MAKE}\" !"
+  repeat_or_exit 255
+fi
+
+export MAKE="${CHECK_MAKE}"
+
+# ---------------------------------------------------------------------------
+
+# prompt for kernel source directory
+
+DEFAULT_KERNEL_SRC_DIR=${kernel_src_dir}
+
+# search heuristic for determining default kernel source directory
+if [ ! -d ${DEFAULT_KERNEL_SRC_DIR} ] ; then
+  DEFAULT_KERNEL_SRC_DIR=/lib/modules/${kernel_version}/build
+  if [ ! -d ${DEFAULT_KERNEL_SRC_DIR} ] ; then
+    DEFAULT_KERNEL_SRC_DIR=/lib/modules/${kernel_version}/source
+    if [ ! -d ${DEFAULT_KERNEL_SRC_DIR} ] ; then
+      if [ -n "${KERNEL_26X}" ] ; then
+        DEFAULT_KERNEL_SRC_DIR=/usr/src/linux-2.6
+      else
+        DEFAULT_KERNEL_SRC_DIR=/usr/src/linux-3.0
+      fi
+      if [ ! -d ${DEFAULT_KERNEL_SRC_DIR} ] ; then
+        DEFAULT_KERNEL_SRC_DIR=/usr/src/linux
+        if [ ! -d ${DEFAULT_KERNEL_SRC_DIR} ] ; then
+          # punt ...
+          DEFAULT_KERNEL_SRC_DIR=${kernel_src_dir}
+        fi
+      fi
+    fi
+  fi
+fi
+
+CURRENT_KERNEL_SRC_DIR=${KERNEL_SRC_DIR:-${DEFAULT_KERNEL_SRC_DIR}}
+
+if [ $non_verbose -eq 0 -o $non_interactive -eq 0 ] ; then
+  echo -n "Kernel source directory: [ ${CURRENT_KERNEL_SRC_DIR} ] "
+fi
+if [ $non_interactive -eq 0 ] ; then
+  read KERNEL_SRC_DIR
+else
+  if [ $non_verbose -eq 0 ] ; then
+    echo ""
+  fi
+fi
+if [ -z "${KERNEL_SRC_DIR}" ] ; then
+  KERNEL_SRC_DIR=${CURRENT_KERNEL_SRC_DIR}
+fi
+KERNEL_SRC_DIR=`get_absolute_path ${KERNEL_SRC_DIR}`
+if [ ! -d ${KERNEL_SRC_DIR} ] || [ ! -x ${KERNEL_SRC_DIR} ] ; then
+  echo "ERROR: invalid or inaccessible kernel source directory \"${KERNEL_SRC_DIR}\" !"
+  repeat_or_exit 110
+fi
+
+# make the driver
+
+make_args="KERNEL_VERSION=$kernel_version KERNEL_SRC_DIR=$KERNEL_SRC_DIR PER_USER_MODE=$PER_USER_MODE $make_args"
+
+if [ -x "${MAKE}" ] ; then
+  ${MAKE} CC=$CC MAKE=$MAKE $make_args clean default
+  ERR=$?
+  if [ $ERR -ne 0 ] ; then
+    repeat_or_exit 100
+  fi
+else
+  echo "ERROR: unable to access make command \"${MAKE}\" !"
+  repeat_or_exit 255
+fi
+
+echo ""
+
+# where to install the driver once it is successfully built
+
+if [ ! -w $driver_install_dir ] ; then
+  echo "Warning: directory \"$driver_install_dir\" is not writable."
+  echo ""
+  driver_install_dir=.
+  use_install_dir=0
+fi
+
+if [  $use_install_dir -eq 0 ] ; then
+  echo -n "Directory to install ${DRIVER_NAME} driver: [ $driver_install_dir ] "
+  if [ $non_interactive -eq 1 ] ; then
+    NEW_DRIVER_DIRECTORY=$driver_install_dir
+  else
+    read NEW_DRIVER_DIRECTORY
+  fi
+  echo ""
+  if [ -n "${NEW_DRIVER_DIRECTORY}" ] ; then
+    driver_install_dir=${NEW_DRIVER_DIRECTORY}
+  fi
+  driver_install_dir=`get_absolute_path $driver_install_dir`
+  if [ -d $driver_install_dir ] ; then
+    if [ -w $driver_install_dir ] ; then
+      DRIVER_DIRECTORY=$driver_install_dir
+    else
+      echo "Error: driver install directory \"$driver_install_dir\" is not writable!"
+      repeat_or_exit 101
+    fi
+  else
+    echo "Error: \"$driver_install_dir\" does not exist or is not a directory!"
+    repeat_or_exit 101
+  fi
+fi
+
+# install the previously built driver to specified location
+
+${MAKE} $make_args INSTALL=${DRIVER_DIRECTORY} install
+
+ERR=$?
+
+if [ ${ERR} -ne 0 ] ; then
+  repeat_or_exit 101
+fi
+
+# all done
+
+echo ""
+exit 0

--- a/perftools-external/soc_perf_driver/src/control.c
+++ b/perftools-external/soc_perf_driver/src/control.c
@@ -1,0 +1,749 @@
+/* ***********************************************************************************************
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or 
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(C) 2005-2018 Intel Corporation. All rights reserved.
+
+  This program is free software; you can redistribute it and/or modify 
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but 
+  WITHOUT ANY WARRANTY; without even the implied warranty of 
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License 
+  along with this program; if not, write to the Free Software 
+  Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+  The full GNU General Public License is included in this distribution 
+  in the file called LICENSE.GPL.
+
+  BSD LICENSE 
+
+  Copyright(C) 2005-2018 Intel Corporation. All rights reserved.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+    * Redistributions of source code must retain the above copyright 
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright 
+      notice, this list of conditions and the following disclaimer in 
+      the documentation and/or other materials provided with the 
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its 
+      contributors may be used to endorse or promote products derived 
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ***********************************************************************************************
+*/
+
+
+#include "lwpmudrv_defines.h"
+#include <linux/version.h>
+#include <linux/mm.h>
+#include <linux/mempool.h>
+#include <linux/slab.h>
+#include <linux/vmalloc.h>
+
+#include "lwpmudrv_types.h"
+#include "rise_errors.h"
+#include "lwpmudrv_ecb.h"
+#include "socperfdrv.h"
+#include "control.h"
+#include <linux/sched.h>
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 27)
+#define SMP_CALL_FUNCTION(func,ctx,retry,wait)    smp_call_function((func),(ctx),(wait))
+#else
+#define SMP_CALL_FUNCTION(func,ctx,retry,wait)    smp_call_function((func),(ctx),(retry),(wait))
+#endif
+
+/*
+ *  Global State Nodes - keep here for now.  Abstract out when necessary.
+ */
+GLOBAL_STATE_NODE         socperf_driver_state;
+static MEM_TRACKER        mem_tr_head   = NULL;   // start of the mem tracker list
+static MEM_TRACKER        mem_tr_tail   = NULL;   // end of mem tracker list
+static spinlock_t         mem_tr_lock;            // spinlock for mem tracker list
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn       VOID SOCPERF_Invoke_Cpu (func, ctx, arg)
+ *
+ * @brief    Set up a DPC call and insert it into the queue
+ *
+ * @param    IN cpu_idx  - the core id to dispatch this function to
+ *           IN func     - function to be invoked by the specified core(s)
+ *           IN ctx      - pointer to the parameter block for each function
+ *                         invocation
+ *
+ * @return   None
+ *
+ * <I>Special Notes:</I>
+ *
+ */
+extern VOID
+SOCPERF_Invoke_Cpu (
+    int     cpu_idx,
+    VOID    (*func)(PVOID),
+    PVOID   ctx
+)
+{
+    SOCPERF_Invoke_Parallel(func, ctx);
+
+    return;
+}
+
+/* ------------------------------------------------------------------------- */
+/*
+ * @fn VOID SOCPERF_Invoke_Parallel_Service(func, ctx, blocking, exclude)
+ *
+ * @param    func     - function to be invoked by each core in the system
+ * @param    ctx      - pointer to the parameter block for each function invocation
+ * @param    blocking - Wait for invoked function to complete
+ * @param    exclude  - exclude the current core from executing the code
+ *
+ * @returns  None
+ *
+ * @brief    Service routine to handle all kinds of parallel invoke on all CPU calls
+ *
+ * <I>Special Notes:</I>
+ *           Invoke the function provided in parallel in either a blocking or
+ *           non-blocking mode.  The current core may be excluded if desired.
+ *           NOTE - Do not call this function directly from source code.
+ *           Use the aliases SOCPERF_Invoke_Parallel(), SOCPERF_Invoke_Parallel_NB(),
+ *           or SOCPERF_Invoke_Parallel_XS().
+ *
+ */
+extern VOID
+SOCPERF_Invoke_Parallel_Service (
+    VOID   (*func)(PVOID),
+    PVOID  ctx,
+    int    blocking,
+    int    exclude
+)
+{
+    GLOBAL_STATE_cpu_count(socperf_driver_state) = 0;
+    GLOBAL_STATE_dpc_count(socperf_driver_state) = 0;
+
+    preempt_disable();
+    SMP_CALL_FUNCTION (func, ctx, 0, blocking);
+
+    if (!exclude) {
+        func(ctx);
+    }
+    preempt_enable();
+
+    return;
+}
+
+/* ------------------------------------------------------------------------- */
+/*
+ * @fn VOID control_Memory_Tracker_Delete_Node(mem_tr)
+ *
+ * @param    IN mem_tr    - memory tracker node to delete
+ *
+ * @returns  None
+ *
+ * @brief    Delete specified node in the memory tracker
+ *
+ * <I>Special Notes:</I>
+ *           Assumes mem_tr_lock is already held while calling this function!
+ */
+static VOID
+control_Memory_Tracker_Delete_Node (
+    MEM_TRACKER mem_tr
+)
+{
+    MEM_TRACKER prev_tr = NULL;
+    MEM_TRACKER next_tr = NULL;
+    U32         size    = MEM_EL_MAX_ARRAY_SIZE * sizeof(MEM_EL_NODE);
+
+    if (! mem_tr) {
+        return;
+    }
+
+    // free the allocated mem_el array (if any)
+    if (MEM_TRACKER_mem(mem_tr)) {
+        if (size < MAX_KMALLOC_SIZE) {
+            kfree(MEM_TRACKER_mem(mem_tr));
+        }
+        else {
+            free_pages((unsigned long)MEM_TRACKER_mem(mem_tr), get_order(size));
+        }
+    }
+
+    // update the linked list
+    prev_tr = MEM_TRACKER_prev(mem_tr);
+    next_tr = MEM_TRACKER_next(mem_tr);
+    if (prev_tr) {
+        MEM_TRACKER_next(prev_tr) = next_tr;
+    }
+    if (next_tr) {
+        MEM_TRACKER_prev(next_tr) = prev_tr;
+    }
+
+    // free the mem_tracker node
+    kfree(mem_tr);
+
+    return;
+}
+
+/* ------------------------------------------------------------------------- */
+/*
+ * @fn VOID control_Memory_Tracker_Create_Node(void)
+ *
+ * @param    None    - size of the memory to allocate
+ *
+ * @returns  OS_SUCCESS if successful, otherwise error
+ *
+ * @brief    Initialize the memory tracker
+ *
+ * <I>Special Notes:</I>
+ *           Assumes mem_tr_lock is already held while calling this function!
+ *
+ *           Since this function can be called within either GFP_KERNEL or
+ *           GFP_ATOMIC contexts, the most restrictive allocation is used
+ *           (viz., GFP_ATOMIC).
+ */
+static U32
+control_Memory_Tracker_Create_Node (
+    void
+)
+{
+    U32         size     = MEM_EL_MAX_ARRAY_SIZE * sizeof(MEM_EL_NODE);
+    PVOID       location = NULL;
+    MEM_TRACKER mem_tr   = NULL;
+
+    // create a mem tracker node
+    mem_tr = (MEM_TRACKER)kmalloc(sizeof(MEM_TRACKER_NODE), GFP_ATOMIC);
+    if (!mem_tr) {
+        SOCPERF_PRINT_ERROR("control_Initialize_Memory_Tracker: failed to allocate mem tracker node\n");
+        return OS_FAULT;
+    }
+
+    // create an initial array of mem_el's inside the mem tracker node
+    if (size < MAX_KMALLOC_SIZE) {
+        location = (PVOID)kmalloc(size, GFP_ATOMIC);
+        SOCPERF_PRINT_DEBUG("control_Memory_Tracker_Create_Node: allocated small memory (0x%p, %d)\n", location, (S32) size);
+    }
+    else {
+        location = (PVOID)__get_free_pages(GFP_ATOMIC, get_order(size));
+        SOCPERF_PRINT_DEBUG("control_Memory_Tracker_Create_Node: allocated large memory (0x%p, %d)\n", location, (S32) size);
+    }
+
+    // initialize new mem tracker node
+    MEM_TRACKER_mem(mem_tr)  = location;
+    MEM_TRACKER_prev(mem_tr) = NULL;
+    MEM_TRACKER_next(mem_tr) = NULL;
+
+    // if mem_el array allocation failed, then remove node
+    if (!MEM_TRACKER_mem(mem_tr)) {
+        control_Memory_Tracker_Delete_Node(mem_tr);
+        SOCPERF_PRINT_ERROR("control_Memory_Tracker_Create_Node: failed to allocate mem_el array in tracker node ... deleting node\n");
+        return OS_FAULT;
+    }
+
+    // initialize mem_tracker's mem_el array
+    MEM_TRACKER_max_size(mem_tr) = MEM_EL_MAX_ARRAY_SIZE;
+    memset(MEM_TRACKER_mem(mem_tr), 0, size);
+
+    // update the linked list
+    if (!mem_tr_head) {
+        mem_tr_head = mem_tr;
+    }
+    else {
+        MEM_TRACKER_prev(mem_tr) = mem_tr_tail;
+        MEM_TRACKER_next(mem_tr_tail) = mem_tr;
+    }
+    mem_tr_tail = mem_tr;
+    SOCPERF_PRINT_DEBUG("control_Memory_Tracker_Create_node: allocating new node=0x%p, max_elements=%d, size=%d\n",
+                    MEM_TRACKER_mem(mem_tr_tail), MEM_EL_MAX_ARRAY_SIZE, size);
+
+    return OS_SUCCESS;
+}
+
+/* ------------------------------------------------------------------------- */
+/*
+ * @fn VOID control_Memory_Tracker_Add(location, size, vmalloc_flag)
+ *
+ * @param    IN location     - memory location
+ * @param    IN size         - size of the memory to allocate
+ * @param    IN vmalloc_flag - flag that indicates if the allocation was done with vmalloc
+ *
+ * @returns  None
+ *
+ * @brief    Keep track of allocated memory with memory tracker
+ *
+ * <I>Special Notes:</I>
+ *           Starting from first mem_tracker node, the algorithm
+ *           finds the first "hole" in the mem_tracker list and
+ *           tracks the memory allocation there.
+ */
+static U32
+control_Memory_Tracker_Add (
+    PVOID     location,
+    ssize_t   size,
+    DRV_BOOL  vmalloc_flag
+)
+{
+    S32         i, n;
+    U32         status;
+    DRV_BOOL    found;
+    MEM_TRACKER mem_tr;
+
+    spin_lock(&mem_tr_lock);
+
+    // check if there is space in ANY of mem_tracker's nodes for the memory item
+    mem_tr = mem_tr_head;
+    found = FALSE;
+    status = OS_SUCCESS;
+    i = n = 0;
+    while (mem_tr && (!found)) {
+        for (i = 0; i < MEM_TRACKER_max_size(mem_tr); i++) {
+            if (!MEM_TRACKER_mem_address(mem_tr,i)) {
+                SOCPERF_PRINT_DEBUG("SOCPERF_Memory_Tracker_Add: found index %d of %d available\n",
+                                        i,
+                                        MEM_TRACKER_max_size(mem_tr)-1);
+                n = i;
+                found = TRUE;
+            }
+        }
+        if (!found) {
+            mem_tr = MEM_TRACKER_next(mem_tr);
+        }
+    }
+
+    if (!found) {
+        // extend into (i.e., create new) mem_tracker node ...
+        status = control_Memory_Tracker_Create_Node();
+        if (status != OS_SUCCESS) {
+            SOCPERF_PRINT_ERROR("Unable to create mem tracker node\n");
+            goto finish_add;
+        }
+        // use mem tracker tail node and first available entry in mem_el array
+        mem_tr = mem_tr_tail;
+        n = 0;
+    }
+
+    // we now have a location in mem tracker to keep track of the memory item
+    MEM_TRACKER_mem_address(mem_tr,n) = location;
+    MEM_TRACKER_mem_size(mem_tr,n)    = size;
+    MEM_TRACKER_mem_vmalloc(mem_tr,n) = vmalloc_flag;
+    SOCPERF_PRINT_DEBUG("control_Memory_Tracker_Add: tracking (0x%p, %d) in node %d of %d\n",
+                     location, (S32)size, n, MEM_TRACKER_max_size(mem_tr)-1);
+
+finish_add:
+    spin_unlock(&mem_tr_lock);
+
+    return status;
+}
+
+/* ------------------------------------------------------------------------- */
+/*
+ * @fn VOID SOCPERF_Memory_Tracker_Init(void)
+ *
+ * @param    None
+ *
+ * @returns  None
+ *
+ * @brief    Initializes Memory Tracker
+ *
+ * <I>Special Notes:</I>
+ *           This should only be called when the driver is being loaded.
+ */
+extern VOID
+SOCPERF_Memory_Tracker_Init (
+    VOID
+)
+{
+    SOCPERF_PRINT_DEBUG("SOCPERF_Memory_Tracker_Init: initializing mem tracker\n");
+
+    mem_tr_head = NULL;
+    mem_tr_tail = NULL;
+
+    spin_lock_init(&mem_tr_lock);
+
+    return;
+}
+
+/* ------------------------------------------------------------------------- */
+/*
+ * @fn VOID SOCPERF_Memory_Tracker_Free(void)
+ *
+ * @param    None
+ *
+ * @returns  None
+ *
+ * @brief    Frees memory used by Memory Tracker
+ *
+ * <I>Special Notes:</I>
+ *           This should only be called when the driver is being unloaded.
+ */
+extern VOID
+SOCPERF_Memory_Tracker_Free (
+    VOID
+)
+{
+    S32         i;
+    MEM_TRACKER temp;
+
+    SOCPERF_PRINT_DEBUG("SOCPERF_Memory_Tracker_Free: destroying mem tracker\n");
+
+    spin_lock(&mem_tr_lock);
+
+    // check for any memory that was not freed, and free it
+    while (mem_tr_head) {
+        for (i = 0; i < MEM_TRACKER_max_size(mem_tr_head); i++) {
+            if (MEM_TRACKER_mem_address(mem_tr_head,i)) {
+                SOCPERF_PRINT_WARNING("SOCPERF_Memory_Tracker_Free: index %d of %d, not freed (0x%p, %d) ... freeing now\n",
+                                             i,
+                                             MEM_TRACKER_max_size(mem_tr_head)-1,
+                                             MEM_TRACKER_mem_address(mem_tr_head,i),
+                                             MEM_TRACKER_mem_size(mem_tr_head,i));
+                free_pages((unsigned long)MEM_TRACKER_mem_address(mem_tr_head,i), get_order(MEM_TRACKER_mem_size(mem_tr_head,i)));
+                MEM_TRACKER_mem_address(mem_tr_head,i) = NULL;
+                MEM_TRACKER_mem_size(mem_tr_head,i)    = 0;
+                MEM_TRACKER_mem_vmalloc(mem_tr_head,i) = FALSE;
+            }
+        }
+        temp = MEM_TRACKER_next(mem_tr_head);
+        control_Memory_Tracker_Delete_Node(mem_tr_head);
+        mem_tr_head = temp;
+    }
+
+    spin_unlock(&mem_tr_lock);
+
+    SOCPERF_PRINT_DEBUG("SOCPERF_Memory_Tracker_Free: mem tracker destruction complete\n");
+
+    return;
+}
+
+/* ------------------------------------------------------------------------- */
+/*
+ * @fn VOID SOCPERF_Memory_Tracker_Compaction(void)
+ *
+ * @param    None
+ *
+ * @returns  None
+ *
+ * @brief    Compacts the memory allocator if holes are detected
+ *
+ * <I>Special Notes:</I>
+ *           The algorithm compacts mem_tracker nodes such that
+ *           node entries are full starting from mem_tr_head
+ *           up until the first empty node is detected, after
+ *           which nodes up to mem_tr_tail will be empty.
+ *           At end of collection (or at other safe sync point),
+ *           we reclaim/compact space used by mem tracker.
+ */
+extern VOID
+SOCPERF_Memory_Tracker_Compaction (
+    void
+)
+{
+    S32         i, j, n, m, c, d;
+    DRV_BOOL    found, overlap;
+    MEM_TRACKER mem_tr1, mem_tr2;
+
+    spin_lock(&mem_tr_lock);
+
+    mem_tr1 = mem_tr_head;
+    mem_tr2 = mem_tr_tail;
+
+    // if memory tracker was never used, then no need to compact
+    if (!mem_tr1 || !mem_tr2) {
+        goto finish_compact;
+    }
+
+    i = j = n = c = d = 0;
+    m = MEM_TRACKER_max_size(mem_tr2) - 1;
+    overlap = FALSE;
+    while (!overlap) {
+        // find an empty node
+        found = FALSE;
+        while (!found && !overlap && mem_tr1) {
+            SOCPERF_PRINT_DEBUG("SOCPERF_Memory_Tracker_Compaction: looking at mem_tr1 0x%p, index=%d\n", mem_tr1, n);
+            for (i = n; i < MEM_TRACKER_max_size(mem_tr1); i++) {
+                if (!MEM_TRACKER_mem_address(mem_tr1,i)) {
+                    SOCPERF_PRINT_DEBUG("SOCPERF_Memory_Tracker_Compaction: found index %d of %d empty\n",
+                                            i,
+                                            MEM_TRACKER_max_size(mem_tr1)-1);
+                    found = TRUE;
+                }
+            }
+            // check for overlap
+            overlap = (mem_tr1==mem_tr2) && (i>=m);
+
+            // if no overlap and an empty node was not found, then advance to next node
+            if (!found && !overlap) {
+                mem_tr1 = MEM_TRACKER_next(mem_tr1);
+                n = 0;
+            }
+        }
+        // all nodes going in forward direction are full, so exit
+        if (!found || overlap) {
+            goto finish_compact;
+        }
+
+        // find a non-empty node
+        found = FALSE;
+        while (!found && !overlap && mem_tr2) {
+            SOCPERF_PRINT_DEBUG("SOCPERF_Memory_Tracker_Compaction: looking at mem_tr2 0x%p, index=%d\n", mem_tr2, m);
+            for (j = m; j >= 0; j--) {
+                if (MEM_TRACKER_mem_address(mem_tr2,j)) {
+                    SOCPERF_PRINT_DEBUG("SOCPERF_Memory_Tracker_Compaction: found index %d of %d non-empty\n",
+                                            j,
+                                            MEM_TRACKER_max_size(mem_tr2)-1);
+                    found = TRUE;
+                }
+            }
+            // check for overlap
+            overlap = (mem_tr1==mem_tr2) && (j<=i);
+
+            // if no overlap and no non-empty node was found, then retreat to prev node
+            if (!found && !overlap) {
+                MEM_TRACKER empty_tr = mem_tr2;  // keep track of empty node
+                mem_tr2 = MEM_TRACKER_prev(mem_tr2);
+                m = MEM_TRACKER_max_size(mem_tr2) - 1;
+                mem_tr_tail = mem_tr2; // keep track of new tail
+                // reclaim empty mem_tracker node
+                control_Memory_Tracker_Delete_Node(empty_tr);
+                // keep track of number of node deletions performed
+                d++;
+            }
+        }
+        // all nodes going in reverse direction are empty, so exit
+        if (!found || overlap) {
+            goto finish_compact;
+        }
+
+        // swap empty node with non-empty node so that "holes" get bubbled towards the end of list
+        MEM_TRACKER_mem_address(mem_tr1,i) = MEM_TRACKER_mem_address(mem_tr2,j);
+        MEM_TRACKER_mem_size(mem_tr1,i)    = MEM_TRACKER_mem_size(mem_tr2,j);
+        MEM_TRACKER_mem_vmalloc(mem_tr1,i) = MEM_TRACKER_mem_vmalloc(mem_tr2,j);
+
+        MEM_TRACKER_mem_address(mem_tr2,j) = NULL;
+        MEM_TRACKER_mem_size(mem_tr2,j)    = 0;
+        MEM_TRACKER_mem_vmalloc(mem_tr2,j) = FALSE;
+
+        // keep track of number of memory compactions performed
+        c++;
+
+        // start new search starting from next element in mem_tr1
+        n = i+1;
+
+        // start new search starting from prev element in mem_tr2
+        m = j-1;
+    }
+
+finish_compact:
+    spin_unlock(&mem_tr_lock);
+
+    SOCPERF_PRINT_DEBUG("SOCPERF_Memory_Tracker_Compaction: number of elements compacted = %d, nodes deleted = %d\n", c, d);
+
+    return;
+}
+
+/* ------------------------------------------------------------------------- */
+/*
+ * @fn PVOID SOCPERF_Allocate_Memory(size)
+ *
+ * @param    IN size     - size of the memory to allocate
+ *
+ * @returns  char*       - pointer to the allocated memory block
+ *
+ * @brief    Allocate and zero memory
+ *
+ * <I>Special Notes:</I>
+ *           Allocate memory in the GFP_KERNEL pool.
+ *
+ *           Use this if memory is to be allocated within a context where
+ *           the allocator can block the allocation (e.g., by putting
+ *           the caller to sleep) while it tries to free up memory to
+ *           satisfy the request.  Otherwise, if the allocation must
+ *           occur atomically (e.g., caller cannot sleep), then use
+ *           SOCPERF_Allocate_KMemory instead.
+ */
+extern PVOID
+SOCPERF_Allocate_Memory (
+    size_t size
+)
+{
+    U32   status;
+    PVOID location;
+
+    if (size <= 0) {
+        return NULL;
+    }
+
+    // determine whether to use mem_tracker or not
+    if (size < MAX_KMALLOC_SIZE) {
+        location = (PVOID)kmalloc(size, GFP_KERNEL);
+        SOCPERF_PRINT_DEBUG("SOCPERF_Allocate_Memory: allocated small memory (0x%p, %d)\n", location, (S32) size);
+    }
+    else {
+        location = (PVOID)vmalloc(size);
+        if (location) {
+            status = control_Memory_Tracker_Add(location, size, TRUE);
+            SOCPERF_PRINT_DEBUG("SOCPERF_Allocate_Memory: - allocated *large* memory (0x%p, %d)\n", location, (S32) size);
+            if (status != OS_SUCCESS) {
+                // failed to track in mem_tracker, so free up memory and return NULL
+                vfree(location);
+                SOCPERF_PRINT_ERROR("SOCPERF_Allocate_Memory: - able to allocate, but failed to track via MEM_TRACKER ... freeing\n");
+                return NULL;
+            }
+        }
+    }
+
+    if (!location) {
+        SOCPERF_PRINT_ERROR("SOCPERF_Allocate_Memory: failed for size %d bytes\n", (S32) size);
+        return NULL;
+    }
+
+    memset(location, 0, size);
+
+    return location;
+}
+
+/* ------------------------------------------------------------------------- */
+/*
+ * @fn PVOID SOCPERF_Allocate_KMemory(size)
+ *
+ * @param    IN size     - size of the memory to allocate
+ *
+ * @returns  char*       - pointer to the allocated memory block
+ *
+ * @brief    Allocate and zero memory
+ *
+ * <I>Special Notes:</I>
+ *           Allocate memory in the GFP_ATOMIC pool.
+ *
+ *           Use this if memory is to be allocated within a context where
+ *           the allocator cannot block the allocation (e.g., by putting
+ *           the caller to sleep) as it tries to free up memory to
+ *           satisfy the request.  Examples include interrupt handlers,
+ *           process context code holding locks, etc.
+ */
+extern PVOID
+SOCPERF_Allocate_KMemory (
+    size_t size
+)
+{
+    U32   status;
+    PVOID location;
+
+    if (size <= 0) {
+        return NULL;
+    }
+
+    if (size < MAX_KMALLOC_SIZE) {
+        location = (PVOID)kmalloc(size, GFP_ATOMIC);
+        SOCPERF_PRINT_DEBUG("SOCPERF_Allocate_KMemory: allocated small memory (0x%p, %d)\n", location, (S32) size);
+    }
+    else {
+        location = (PVOID)__get_free_pages(GFP_ATOMIC, get_order(size));
+        status = control_Memory_Tracker_Add(location, size, FALSE);
+        SOCPERF_PRINT_DEBUG("SOCPERF_Allocate_KMemory: allocated large memory (0x%p, %d)\n", location, (S32) size);
+        if (status != OS_SUCCESS) {
+            // failed to track in mem_tracker, so free up memory and return NULL
+            free_pages((unsigned long)location, get_order(size));
+            SOCPERF_PRINT_ERROR("SOCPERF_Allocate_KMemory: - able to allocate, but failed to track via MEM_TRACKER ... freeing\n");
+            return NULL;
+        }
+    }
+
+    if (!location) {
+        SOCPERF_PRINT_ERROR("SOCPERF_Allocate_KMemory: failed for size %d bytes\n", (S32) size);
+        return NULL;
+    }
+
+    memset(location, 0, size);
+
+    return location;
+}
+
+/* ------------------------------------------------------------------------- */
+/*
+ * @fn PVOID SOCPERF_Free_Memory(location)
+ *
+ * @param    IN location  - size of the memory to allocate
+ *
+ * @returns  pointer to the allocated memory block
+ *
+ * @brief    Frees the memory block
+ *
+ * <I>Special Notes:</I>
+ *           Does not try to free memory if fed with a NULL pointer
+ *           Expected usage:
+ *               ptr = SOCPERF_Free_Memory(ptr);
+ *           Does not do compaction ... can have "holes" in
+ *           mem_tracker list after this operation.
+ */
+extern PVOID
+SOCPERF_Free_Memory (
+    PVOID  location
+)
+{
+    S32         i;
+    DRV_BOOL    found;
+    MEM_TRACKER mem_tr;
+
+    if (!location) {
+        return NULL;
+    }
+
+    spin_lock(&mem_tr_lock);
+
+    // scan through mem_tracker nodes for matching entry (if any)
+    mem_tr = mem_tr_head;
+    found = FALSE;
+    while (mem_tr) {
+        for (i = 0; i < MEM_TRACKER_max_size(mem_tr); i++) {
+            if (location == MEM_TRACKER_mem_address(mem_tr,i)) {
+                SOCPERF_PRINT_DEBUG("SOCPERF_Free_Memory: freeing large memory location 0x%p\n", location);
+                found = TRUE;
+                if (MEM_TRACKER_mem_vmalloc(mem_tr, i)) {
+                    vfree(location);
+                }
+                else {
+                    free_pages((unsigned long)location, get_order(MEM_TRACKER_mem_size(mem_tr,i)));
+                }
+                MEM_TRACKER_mem_address(mem_tr,i) = NULL;
+                MEM_TRACKER_mem_size(mem_tr,i)    = 0;
+                MEM_TRACKER_mem_vmalloc(mem_tr,i) = FALSE;
+                goto finish_free;
+            }
+        }
+        mem_tr = MEM_TRACKER_next(mem_tr);
+    }
+
+finish_free:
+    spin_unlock(&mem_tr_lock);
+
+    // must have been of smaller than the size limit for mem tracker nodes
+    if (!found) {
+        SOCPERF_PRINT_DEBUG("SOCPERF_Free_Memory: freeing small memory location 0x%p\n", location);
+        kfree(location);
+    }
+
+    return NULL;
+}

--- a/perftools-external/soc_perf_driver/src/haswellunc_sa.c
+++ b/perftools-external/soc_perf_driver/src/haswellunc_sa.c
@@ -1,0 +1,391 @@
+/* ***********************************************************************************************
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(C) 2011-2018 Intel Corporation. All rights reserved.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+  The full GNU General Public License is included in this distribution
+  in the file called LICENSE.GPL.
+
+  BSD LICENSE
+
+  Copyright(C) 2011-2018 Intel Corporation. All rights reserved.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ***********************************************************************************************
+*/
+
+
+
+#include "lwpmudrv_defines.h"
+#include <linux/version.h>
+#include <linux/wait.h>
+#include <linux/fs.h>
+
+#include "lwpmudrv_types.h"
+#include "lwpmudrv_ecb.h"
+#include "lwpmudrv_struct.h"
+
+#include "socperfdrv.h"
+#include "control.h"
+#include "haswellunc_sa.h"
+#include "ecb_iterators.h"
+#include "inc/pci.h"
+
+static U64            counter_virtual_address = 0;
+static U32            counter_overflow[HSWUNC_SA_MAX_COUNTERS];
+extern LWPMU_DEVICE   device_uncore;
+static U32            device_id = 0;
+
+/*!
+ * @fn          static VOID hswunc_sa_Write_PMU(VOID*)
+ *
+ * @brief       Initial write of PMU registers
+ *              Walk through the entries and write the value of the register accordingly.
+ *              When current_group = 0, then this is the first time this routine is called,
+ *
+ * @param       param - device index
+ *
+ * @return      None
+ *
+ * <I>Special Notes:</I>
+ */
+static VOID
+hswunc_sa_Write_PMU (
+    VOID  *param
+)
+{
+    U32                        dev_idx  = *((U32*)param);
+    U32                        cur_grp  = LWPMU_DEVICE_cur_group(device_uncore);
+    ECB                        pecb     = LWPMU_DEVICE_PMU_register_data(device_uncore)[cur_grp];
+    DRV_PCI_DEVICE_ENTRY       dpden;
+    U32                        pci_address;
+    U32                        bar_lo;
+    U64                        bar_hi;
+    U64                        final_bar;
+    U64                        physical_address;
+    U32                        dev_index       = 0;
+    S32                        bar_list[HSWUNC_SA_MAX_PCI_DEVICES];
+    U32                        bar_index       = 0;
+    U64                        gdxc_bar        = 0;
+    U32                        map_size        = 0;
+    U64                        virtual_address = 0;
+    U64                        mmio_offset     = 0;
+    U32                        bar_name        = 0;
+    DRV_PCI_DEVICE_ENTRY       curr_pci_entry  = NULL;
+    U32                        next_bar_offset = 0;
+    U32                        i               = 0;
+
+    for (dev_index = 0; dev_index < HSWUNC_SA_MAX_PCI_DEVICES; dev_index++) {
+        bar_list[dev_index] = -1;
+    }
+
+    device_id = dev_idx;
+    // initialize the CHAP per-counter overflow numbers
+    for (i = 0; i < HSWUNC_SA_MAX_COUNTERS; i++) {
+        counter_overflow[i]          = 0;
+        socperf_pcb[0].last_uncore_count[i] = 0;
+    }
+
+    ECB_pcidev_entry_list(pecb) = (DRV_PCI_DEVICE_ENTRY)((S8*)pecb + ECB_pcidev_list_offset(pecb));
+    dpden = ECB_pcidev_entry_list(pecb);
+
+    if (counter_virtual_address) {
+        for (i = 0; i < ECB_num_entries(pecb); i++) {
+            writel(HSWUNC_SA_CHAP_STOP,
+                (U32*)(((char*)(UIOP)counter_virtual_address)+HSWUNC_SA_CHAP_CTRL_REG_OFFSET+i*0x10));
+        }
+    }
+
+    for (dev_index = 0; dev_index < ECB_num_pci_devices(pecb); dev_index++) {
+        curr_pci_entry = &dpden[dev_index];
+        mmio_offset    = DRV_PCI_DEVICE_ENTRY_base_offset_for_mmio(curr_pci_entry);
+        bar_name       = DRV_PCI_DEVICE_ENTRY_bar_name(curr_pci_entry);
+        if (DRV_PCI_DEVICE_ENTRY_config_type(curr_pci_entry) == UNC_PCICFG) {
+            pci_address = FORM_PCI_ADDR(DRV_PCI_DEVICE_ENTRY_bus_no(curr_pci_entry),
+                                        DRV_PCI_DEVICE_ENTRY_dev_no(curr_pci_entry),
+                                        DRV_PCI_DEVICE_ENTRY_func_no(curr_pci_entry),
+                                        mmio_offset);
+            SOCPERF_PCI_Write_Ulong(pci_address, DRV_PCI_DEVICE_ENTRY_value(curr_pci_entry));
+            continue;
+        }
+        // UNC_MMIO programming
+        if (bar_list[bar_name] != -1) {
+            bar_index                                            = bar_list[bar_name];
+            virtual_address                                      = DRV_PCI_DEVICE_ENTRY_virtual_address(&dpden[bar_index]);
+            DRV_PCI_DEVICE_ENTRY_virtual_address(curr_pci_entry) = DRV_PCI_DEVICE_ENTRY_virtual_address(&dpden[bar_index]);
+            writel(DRV_PCI_DEVICE_ENTRY_value(curr_pci_entry), (U32*)(((char*)(UIOP)virtual_address)+mmio_offset));
+            continue;
+        }
+        if (bar_name == UNC_GDXCBAR) {
+            DRV_PCI_DEVICE_ENTRY_bar_address(curr_pci_entry) = gdxc_bar;
+        }
+        else {
+            pci_address     = FORM_PCI_ADDR(DRV_PCI_DEVICE_ENTRY_bus_no(curr_pci_entry),
+                                        DRV_PCI_DEVICE_ENTRY_dev_no(curr_pci_entry),
+                                        DRV_PCI_DEVICE_ENTRY_func_no(curr_pci_entry),
+                                        DRV_PCI_DEVICE_ENTRY_bar_offset(curr_pci_entry));
+            bar_lo          = SOCPERF_PCI_Read_Ulong(pci_address);
+            next_bar_offset = DRV_PCI_DEVICE_ENTRY_bar_offset(curr_pci_entry)+HSWUNC_SA_NEXT_ADDR_OFFSET;
+            pci_address     = FORM_PCI_ADDR(DRV_PCI_DEVICE_ENTRY_bus_no(curr_pci_entry),
+                                        DRV_PCI_DEVICE_ENTRY_dev_no(curr_pci_entry),
+                                        DRV_PCI_DEVICE_ENTRY_func_no(curr_pci_entry),
+                                        next_bar_offset);
+            bar_hi      = SOCPERF_PCI_Read_Ulong(pci_address);
+            final_bar   = (bar_hi << HSWUNC_SA_BAR_ADDR_SHIFT) | bar_lo;
+            final_bar  &= HSWUNC_SA_BAR_ADDR_MASK;
+
+            DRV_PCI_DEVICE_ENTRY_bar_address(curr_pci_entry) = final_bar;
+        }
+        physical_address = DRV_PCI_DEVICE_ENTRY_bar_address(curr_pci_entry);
+
+        if (physical_address) {
+            if (bar_name == UNC_MCHBAR) {
+                map_size = HSWUNC_SA_MCHBAR_MMIO_PAGE_SIZE;
+            }
+            else if (bar_name == UNC_PCIEXBAR) {
+                map_size = HSWUNC_SA_PCIEXBAR_MMIO_PAGE_SIZE;
+            }
+            else {
+                map_size = HSWUNC_SA_OTHER_BAR_MMIO_PAGE_SIZE;
+            }
+            DRV_PCI_DEVICE_ENTRY_virtual_address(curr_pci_entry) = (U64) (UIOP)ioremap_nocache(physical_address, map_size);
+            virtual_address = DRV_PCI_DEVICE_ENTRY_virtual_address(curr_pci_entry);
+
+            if (!gdxc_bar && bar_name == UNC_MCHBAR) {
+                bar_lo   = readl((U32*)((char*)(UIOP)virtual_address+HSWUNC_SA_GDXCBAR_OFFSET_LO));
+                bar_hi   = readl((U32*)((char*)(UIOP)virtual_address+HSWUNC_SA_GDXCBAR_OFFSET_HI));
+                gdxc_bar = (bar_hi << HSWUNC_SA_BAR_ADDR_SHIFT) | bar_lo;
+                gdxc_bar = gdxc_bar & HSWUNC_SA_GDXCBAR_MASK;
+            }
+            writel((U32)DRV_PCI_DEVICE_ENTRY_value(curr_pci_entry), (U32*)(((char*)(UIOP)virtual_address)+mmio_offset));
+            bar_list[bar_name] = dev_index;
+            if (counter_virtual_address == 0 && bar_name == UNC_CHAPADR) {
+                counter_virtual_address = virtual_address;
+            }
+        }
+    }
+
+    return;
+}
+
+/*!
+ * @fn         static VOID hswunc_sa_Disable_PMU(PVOID)
+ *
+ * @brief      Unmap the virtual address when sampling/driver stops
+ *
+ * @param      param - device index
+ *
+ * @return     None
+ *
+ * <I>Special Notes:</I>
+ */
+static VOID
+hswunc_sa_Disable_PMU (
+    PVOID  param
+)
+{
+
+    DRV_PCI_DEVICE_ENTRY  dpden;
+    U32                   dev_index = 0;
+    U32                   cur_grp   = LWPMU_DEVICE_cur_group(device_uncore);
+    ECB                   pecb      = LWPMU_DEVICE_PMU_register_data(device_uncore)[cur_grp];
+    U32                   i         = 0;
+
+    if (GLOBAL_STATE_current_phase(socperf_driver_state) == DRV_STATE_PREPARE_STOP) {
+
+        if (counter_virtual_address) {
+            for (i = 0; i < ECB_num_entries(pecb); i++) {
+                writel(HSWUNC_SA_CHAP_STOP,
+                    (U32*)(((char*)(UIOP)counter_virtual_address)+HSWUNC_SA_CHAP_CTRL_REG_OFFSET+i*0x10));
+            }
+        }
+
+        dpden = ECB_pcidev_entry_list(pecb);
+        for (dev_index = 0; dev_index < ECB_num_pci_devices(pecb); dev_index++) {
+            if (DRV_PCI_DEVICE_ENTRY_config_type(&dpden[dev_index]) == UNC_MMIO &&
+                DRV_PCI_DEVICE_ENTRY_bar_address(&dpden[dev_index]) != 0) {
+                iounmap((void*)(UIOP)(DRV_PCI_DEVICE_ENTRY_virtual_address(&dpden[dev_index])));
+            }
+        }
+        counter_virtual_address = 0;
+    }
+
+    return;
+}
+
+/*!
+ * @fn         static VOID hswunc_sa_Initialize(PVOID)
+ *
+ * @brief      Initialize any registers or addresses
+ *
+ * @param      param
+ *
+ * @return     None
+ *
+ * <I>Special Notes:</I>
+ */
+static VOID
+hswunc_sa_Initialize (
+    VOID  *param
+)
+{
+    counter_virtual_address = 0;
+    return;
+}
+
+
+/*!
+ * @fn         static VOID hswunc_sa_Clean_Up(PVOID)
+ *
+ * @brief      Reset any registers or addresses
+ *
+ * @param      param
+ *
+ * @return     None
+ *
+ * <I>Special Notes:</I>
+ */
+static VOID
+hswunc_sa_Clean_Up (
+    VOID   *param
+)
+{
+    counter_virtual_address = 0;
+    return;
+}
+
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn hswunc_sa_Read_Data(param, id)
+ *
+ * @param    data_buffer    data buffer to read data into
+ *
+ * @return   None     No return needed
+ *
+ * @brief    Read the Uncore count data and store into the buffer param;
+ *
+ */
+static VOID
+hswunc_sa_Read_Data (
+    PVOID data_buffer
+)
+{
+    U32                   event_id    = 0;
+    U64                  *data;
+    int                   data_index;
+    U32                   data_val    = 0;
+    U64                   total_count = 0;
+    U32                   cur_grp     = LWPMU_DEVICE_cur_group(device_uncore);
+
+    if (GLOBAL_STATE_current_phase(socperf_driver_state) == DRV_STATE_UNINITIALIZED ||
+        GLOBAL_STATE_current_phase(socperf_driver_state) == DRV_STATE_IDLE          ||
+        GLOBAL_STATE_current_phase(socperf_driver_state) == DRV_STATE_RESERVED      ||
+        GLOBAL_STATE_current_phase(socperf_driver_state) == DRV_STATE_PREPARE_STOP  ||
+        GLOBAL_STATE_current_phase(socperf_driver_state) == DRV_STATE_STOPPED) {
+        SOCPERF_PRINT_ERROR("ERROR: RETURING EARLY from Read_Data\n");
+        return;
+    }
+    if (data_buffer == NULL) {
+        return;
+    }
+    data       = (U64 *)data_buffer;
+    data_index = 0;
+    // group id
+    data[data_index] = cur_grp + 1;
+    data_index++;
+
+    FOR_EACH_PCI_DATA_REG_RAW(pecb, i, dev_idx) {
+        //event_id = ECB_entries_event_id_index_local(pecb, i);
+        if (counter_virtual_address) {
+            writel(HSWUNC_SA_CHAP_SAMPLE_DATA,
+               (U32*)(((char*)(UIOP)counter_virtual_address) + HSWUNC_SA_CHAP_CTRL_REG_OFFSET + i*0x10));
+            data_val = readl((U32*)((char*)(UIOP)(counter_virtual_address) + ECB_entries_pci_id_offset(pecb, i)));
+        }
+
+        if (data_val < socperf_pcb[0].last_uncore_count[i]) {
+            counter_overflow[i]++;
+        }
+        socperf_pcb[0].last_uncore_count[i] = data_val;
+
+        total_count = data_val + counter_overflow[i]*HSWUNC_SA_MAX_COUNT;
+        data[data_index+event_id] = total_count;
+        SOCPERF_PRINT_DEBUG("DATA=%u\n", data_val);
+        event_id++;
+    } END_FOR_EACH_PCI_DATA_REG_RAW;
+
+    return;
+}
+
+/*
+ * Initialize the dispatch table
+ */
+DISPATCH_NODE  socperf_hswunc_sa_dispatch =
+{
+    hswunc_sa_Initialize,        // initialize
+    NULL,                        // destroy
+    hswunc_sa_Write_PMU ,        // write
+    hswunc_sa_Disable_PMU,       // freeze
+    NULL,                        // restart
+    NULL,                        // read
+    NULL,                        // check for overflow
+    NULL,
+    NULL,
+    hswunc_sa_Clean_Up,
+    NULL,
+    NULL,
+    NULL,
+    NULL,                        //read_counts
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    hswunc_sa_Read_Data,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+

--- a/perftools-external/soc_perf_driver/src/inc/control.h
+++ b/perftools-external/soc_perf_driver/src/inc/control.h
@@ -1,0 +1,496 @@
+/* ***********************************************************************************************
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or 
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(C) 2005-2018 Intel Corporation. All rights reserved.
+
+  This program is free software; you can redistribute it and/or modify 
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but 
+  WITHOUT ANY WARRANTY; without even the implied warranty of 
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License 
+  along with this program; if not, write to the Free Software 
+  Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+  The full GNU General Public License is included in this distribution 
+  in the file called LICENSE.GPL.
+
+  BSD LICENSE 
+
+  Copyright(C) 2005-2018 Intel Corporation. All rights reserved.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+    * Redistributions of source code must retain the above copyright 
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright 
+      notice, this list of conditions and the following disclaimer in 
+      the documentation and/or other materials provided with the 
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its 
+      contributors may be used to endorse or promote products derived 
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ***********************************************************************************************
+*/
+
+#ifndef _CONTROL_H_
+#define _CONTROL_H_
+
+#include <linux/smp.h>
+#include <linux/timer.h>
+#if defined(DRV_IA32)
+#include <asm/apic.h>
+#endif
+#include <asm/io.h>
+#if defined(DRV_IA32)
+#include <asm/msr.h>
+#endif
+#include <asm/atomic.h>
+
+#include "lwpmudrv_defines.h"
+#include "socperfdrv.h"
+#include "lwpmudrv_types.h"
+
+// large memory allocation will be used if the requested size (in bytes) is
+// above this threshold
+#define  MAX_KMALLOC_SIZE ((1<<17)-1)
+
+// check whether Linux driver should use unlocked ioctls (not protected by BKL)
+#if defined(HAVE_UNLOCKED_IOCTL)
+#define DRV_USE_UNLOCKED_IOCTL
+#endif
+#if defined(DRV_USE_UNLOCKED_IOCTL)
+#define IOCTL_OP .unlocked_ioctl
+#define IOCTL_OP_TYPE long
+#define IOCTL_USE_INODE
+#else
+#define IOCTL_OP .ioctl
+#define IOCTL_OP_TYPE S32
+#define IOCTL_USE_INODE struct   inode  *inode,
+#endif
+
+// Information about the state of the driver
+typedef struct GLOBAL_STATE_NODE_S  GLOBAL_STATE_NODE;
+typedef        GLOBAL_STATE_NODE   *GLOBAL_STATE;
+struct GLOBAL_STATE_NODE_S {
+    volatile S32    cpu_count;
+    volatile S32    dpc_count;
+
+    S32             num_cpus;       // Number of CPUs in the system
+    S32             active_cpus;    // Number of active CPUs - some cores can be
+                                    // deactivated by the user / admin
+    S32             num_em_groups;
+    S32             num_descriptors;
+    volatile S32    current_phase;
+};
+
+// Access Macros
+#define  GLOBAL_STATE_num_cpus(x)          ((x).num_cpus)
+#define  GLOBAL_STATE_active_cpus(x)       ((x).active_cpus)
+#define  GLOBAL_STATE_cpu_count(x)         ((x).cpu_count)
+#define  GLOBAL_STATE_dpc_count(x)         ((x).dpc_count)
+#define  GLOBAL_STATE_num_em_groups(x)     ((x).num_em_groups)
+#define  GLOBAL_STATE_num_descriptors(x)   ((x).num_descriptors)
+#define  GLOBAL_STATE_current_phase(x)     ((x).current_phase)
+#define  GLOBAL_STATE_sampler_id(x)        ((x).sampler_id)
+
+/*
+ *
+ *
+ * CPU State data structure and access macros
+ *
+ */
+typedef struct CPU_STATE_NODE_S  CPU_STATE_NODE;
+typedef        CPU_STATE_NODE   *CPU_STATE;
+struct CPU_STATE_NODE_S {
+    S32         apic_id;             // Processor ID on the system bus
+    PVOID       apic_linear_addr;    // linear address of local apic
+    PVOID       apic_physical_addr;  // physical address of local apic
+
+    PVOID       idt_base;            // local IDT base address
+    atomic_t    in_interrupt;
+
+#if defined(DRV_IA32)
+    U64         saved_ih;            // saved perfvector to restore
+#endif
+#if defined(DRV_EM64T)
+    PVOID       saved_ih;            // saved perfvector to restore
+#endif
+
+    S64        *em_tables;           // holds the data that is saved/restored
+                                     // during event multiplexing
+
+    struct timer_list *em_timer;
+    U32         current_group;
+    S32         trigger_count;
+    S32         trigger_event_num;
+
+    DISPATCH    dispatch;
+    PVOID       lbr_area;
+    PVOID       old_dts_buffer;
+    PVOID       dts_buffer;
+    U32         initial_mask;
+    U32         accept_interrupt;
+
+#if defined(BUILD_CHIPSET)
+    // Chipset counter stuff
+    U32         chipset_count_init;  // flag to initialize the last MCH and ICH arrays below.
+    U64         last_mch_count[8];
+    U64         last_ich_count[8];
+    U64         last_gmch_count[MAX_CHIPSET_COUNTERS];
+    U64         last_mmio_count[32]; // it's only 9 now but the next generation may have 29.
+#endif
+
+    U64        *pmu_state;           // holds PMU state (e.g., MSRs) that will be
+                                     // saved before and restored after collection
+    S32         socket_master;
+    S32         core_master;
+    S32         thr_master;
+    U64         num_samples;
+    U64         reset_mask;
+    U64         group_swap;
+    U64         last_uncore_count[16];
+};
+
+#define CPU_STATE_apic_id(cpu)              (cpu)->apic_id
+#define CPU_STATE_apic_linear_addr(cpu)     (cpu)->apic_linear_addr
+#define CPU_STATE_apic_physical_addr(cpu)   (cpu)->apic_physical_addr
+#define CPU_STATE_idt_base(cpu)             (cpu)->idt_base
+#define CPU_STATE_in_interrupt(cpu)         (cpu)->in_interrupt
+#define CPU_STATE_saved_ih(cpu)             (cpu)->saved_ih
+#define CPU_STATE_saved_ih_hi(cpu)          (cpu)->saved_ih_hi
+#define CPU_STATE_dpc(cpu)                  (cpu)->dpc
+#define CPU_STATE_em_tables(cpu)            (cpu)->em_tables
+#define CPU_STATE_pmu_state(cpu)            (cpu)->pmu_state
+#define CPU_STATE_em_dpc(cpu)               (cpu)->em_dpc
+#define CPU_STATE_em_timer(cpu)             (cpu)->em_timer
+#define CPU_STATE_current_group(cpu)        (cpu)->current_group
+#define CPU_STATE_trigger_count(cpu)        (cpu)->trigger_count
+#define CPU_STATE_trigger_event_num(cpu)    (cpu)->trigger_event_num
+#define CPU_STATE_dispatch(cpu)             (cpu)->dispatch
+#define CPU_STATE_lbr(cpu)                  (cpu)->lbr
+#define CPU_STATE_old_dts_buffer(cpu)       (cpu)->old_dts_buffer
+#define CPU_STATE_dts_buffer(cpu)           (cpu)->dts_buffer
+#define CPU_STATE_initial_mask(cpu)         (cpu)->initial_mask
+#define CPU_STATE_accept_interrupt(cpu)     (cpu)->accept_interrupt
+#define CPU_STATE_msr_value(cpu)            (cpu)->msr_value
+#define CPU_STATE_msr_addr(cpu)             (cpu)->msr_addr
+#define CPU_STATE_socket_master(cpu)        (cpu)->socket_master
+#define CPU_STATE_core_master(cpu)          (cpu)->core_master
+#define CPU_STATE_thr_master(cpu)           (cpu)->thr_master
+#define CPU_STATE_num_samples(cpu)          (cpu)->num_samples
+#define CPU_STATE_reset_mask(cpu)           (cpu)->reset_mask
+#define CPU_STATE_group_swap(cpu)           (cpu)->group_swap
+
+/*
+ * For storing data for --read/--write-msr command line options
+ */
+typedef struct MSR_DATA_NODE_S MSR_DATA_NODE;
+typedef        MSR_DATA_NODE  *MSR_DATA;
+struct MSR_DATA_NODE_S {
+    U64         value;             // Used for emon, for read/write-msr value
+    U64         addr;
+};
+
+#define MSR_DATA_value(md)   (md)->value
+#define MSR_DATA_addr(md)    (md)->addr
+
+/*
+ * Memory Allocation tracker
+ *
+ * Currently used to track large memory allocations
+ */
+
+typedef struct MEM_EL_NODE_S  MEM_EL_NODE;
+typedef        MEM_EL_NODE   *MEM_EL;
+struct MEM_EL_NODE_S {
+    char     *address;         // pointer to piece of memory we're tracking
+    S32       size;            // size (bytes) of the piece of memory
+    DRV_BOOL  is_addr_vmalloc; // flag to check if the memory is allocated using vmalloc
+};
+
+// accessors for MEM_EL defined in terms of MEM_TRACKER below
+
+#define MEM_EL_MAX_ARRAY_SIZE  32   // minimum is 1, nominal is 64
+
+typedef struct MEM_TRACKER_NODE_S  MEM_TRACKER_NODE;
+typedef        MEM_TRACKER_NODE   *MEM_TRACKER;
+struct MEM_TRACKER_NODE_S {
+    S32         max_size;     // number of elements in the array (default: MEM_EL_MAX_ARRAY_SIZE)
+    MEM_EL      mem;          // array of large memory items we're tracking
+    MEM_TRACKER prev,next;    // enables bi-directional scanning of linked list
+};
+#define MEM_TRACKER_max_size(mt)         (mt)->max_size
+#define MEM_TRACKER_mem(mt)              (mt)->mem
+#define MEM_TRACKER_prev(mt)             (mt)->prev
+#define MEM_TRACKER_next(mt)             (mt)->next
+#define MEM_TRACKER_mem_address(mt, i)   (MEM_TRACKER_mem(mt)[(i)].address)
+#define MEM_TRACKER_mem_size(mt, i)      (MEM_TRACKER_mem(mt)[(i)].size)
+#define MEM_TRACKER_mem_vmalloc(mt, i)   (MEM_TRACKER_mem(mt)[(i)].is_addr_vmalloc)
+
+/****************************************************************************
+ ** Global State variables exported
+ ***************************************************************************/
+extern   CPU_STATE            socperf_pcb;
+extern   U64                 *tsc_info;
+extern   GLOBAL_STATE_NODE    socperf_driver_state;
+extern   MSR_DATA             msr_data;
+extern   U32                 *core_to_package_map;
+extern   U32                  num_packages;
+extern   U64                 *restore_bl_bypass;
+extern   U32                 **restore_ha_direct2core;
+extern   U32                 **restore_qpi_direct2core;
+/****************************************************************************
+ **  Handy Short cuts
+ ***************************************************************************/
+
+/*
+ * SOCPERF_THIS_CPU()
+ *     Parameters
+ *         None
+ *     Returns
+ *         CPU number of the processor being executed on
+ *
+ */
+#define SOCPERF_THIS_CPU()     smp_processor_id()
+
+/****************************************************************************
+ **  Interface definitions
+ ***************************************************************************/
+
+/*
+ *  Execution Control Functions
+ */
+
+extern VOID
+SOCPERF_Invoke_Cpu (
+    S32   cpuid,
+    VOID  (*func)(PVOID),
+    PVOID ctx
+);
+
+/*
+ * @fn VOID SOCPERF_Invoke_Parallel_Service(func, ctx, blocking, exclude)
+ *
+ * @param    func     - function to be invoked by each core in the system
+ * @param    ctx      - pointer to the parameter block for each function invocation
+ * @param    blocking - Wait for invoked function to complete
+ * @param    exclude  - exclude the current core from executing the code
+ *
+ * @returns  none
+ *
+ * @brief    Service routine to handle all kinds of parallel invoke on all CPU calls
+ *
+ * <I>Special Notes:</I>
+ *         Invoke the function provided in parallel in either a blocking/non-blocking mode.
+ *         The current core may be excluded if desired.
+ *         NOTE - Do not call this function directly from source code.  Use the aliases
+ *         SOCPERF_Invoke_Parallel(), SOCPERF_Invoke_Parallel_NB(), SOCPERF_Invoke_Parallel_XS().
+ *
+ */
+extern VOID
+SOCPERF_Invoke_Parallel_Service (
+        VOID   (*func)(PVOID),
+        PVOID  ctx,
+        S32    blocking,
+        S32    exclude
+);
+
+/*
+ * @fn VOID SOCPERF_Invoke_Parallel(func, ctx)
+ *
+ * @param    func     - function to be invoked by each core in the system
+ * @param    ctx      - pointer to the parameter block for each function invocation
+ *
+ * @returns  none
+ *
+ * @brief    Invoke the named function in parallel. Wait for all the functions to complete.
+ *
+ * <I>Special Notes:</I>
+ *        Invoke the function named in parallel, including the CPU that the control is
+ *        being invoked on
+ *        Macro built on the service routine
+ *
+ */
+#define SOCPERF_Invoke_Parallel(a,b)      SOCPERF_Invoke_Parallel_Service((a),(b),TRUE,FALSE)
+
+/*
+ * @fn VOID SOCPERF_Invoke_Parallel_NB(func, ctx)
+ *
+ * @param    func     - function to be invoked by each core in the system
+ * @param    ctx      - pointer to the parameter block for each function invocation
+ *
+ * @returns  none
+ *
+ * @brief    Invoke the named function in parallel. DO NOT Wait for all the functions to complete.
+ *
+ * <I>Special Notes:</I>
+ *        Invoke the function named in parallel, including the CPU that the control is
+ *        being invoked on
+ *        Macro built on the service routine
+ *
+ */
+#define SOCPERF_Invoke_Parallel_NB(a,b)   SOCPERF_Invoke_Parallel_Service((a),(b),FALSE,FALSE)
+
+/*
+ * @fn VOID SOCPERF_Invoke_Parallel_XS(func, ctx)
+ *
+ * @param    func     - function to be invoked by each core in the system
+ * @param    ctx      - pointer to the parameter block for each function invocation
+ *
+ * @returns  none
+ *
+ * @brief    Invoke the named function in parallel. Wait for all the functions to complete.
+ *
+ * <I>Special Notes:</I>
+ *        Invoke the function named in parallel, excluding the CPU that the control is
+ *        being invoked on
+ *        Macro built on the service routine
+ *
+ */
+#define SOCPERF_Invoke_Parallel_XS(a,b)   SOCPERF_Invoke_Parallel_Service((a),(b),TRUE,TRUE)
+
+
+/*
+ * @fn VOID SOCPERF_Memory_Tracker_Init(void)
+ *
+ * @param    None
+ *
+ * @returns  None
+ *
+ * @brief    Initializes Memory Tracker
+ *
+ * <I>Special Notes:</I>
+ *           This should only be called when the
+ *           the driver is being loaded.
+ */
+extern VOID
+SOCPERF_Memory_Tracker_Init (
+    VOID
+);
+
+/*
+ * @fn VOID SOCPERF_Memory_Tracker_Free(void)
+ *
+ * @param    None
+ *
+ * @returns  None
+ *
+ * @brief    Frees memory used by Memory Tracker
+ *
+ * <I>Special Notes:</I>
+ *           This should only be called when the
+ *           driver is being unloaded.
+ */
+extern VOID
+SOCPERF_Memory_Tracker_Free (
+    VOID
+);
+
+/*
+ * @fn VOID SOCPERF_Memory_Tracker_Compaction(void)
+ *
+ * @param    None
+ *
+ * @returns  None
+ *
+ * @brief    Compacts the memory allocator if holes are detected
+ *
+ * <I>Special Notes:</I>
+ *           At end of collection (or at other safe sync point), 
+ *           reclaim/compact space used by mem tracker
+ */
+extern VOID
+SOCPERF_Memory_Tracker_Compaction (
+    void
+);
+
+/*
+ * @fn PVOID SOCPERF_Allocate_Memory(size)
+ *
+ * @param    IN size     - size of the memory to allocate
+ *
+ * @returns  char*       - pointer to the allocated memory block
+ *
+ * @brief    Allocate and zero memory
+ *
+ * <I>Special Notes:</I>
+ *           Allocate memory in the GFP_KERNEL pool.
+ *
+ *           Use this if memory is to be allocated within a context where
+ *           the allocator can block the allocation (e.g., by putting
+ *           the caller to sleep) while it tries to free up memory to
+ *           satisfy the request.  Otherwise, if the allocation must
+ *           occur atomically (e.g., caller cannot sleep), then use
+ *           SOCPERF_Allocate_KMemory instead.
+ */
+extern PVOID
+SOCPERF_Allocate_Memory (
+    size_t    size
+);
+
+/*
+ * @fn PVOID SOCPERF_Allocate_KMemory(size)
+ *
+ * @param    IN size     - size of the memory to allocate
+ *
+ * @returns  char*       - pointer to the allocated memory block
+ *
+ * @brief    Allocate and zero memory
+ *
+ * <I>Special Notes:</I>
+ *           Allocate memory in the GFP_ATOMIC pool.
+ *
+ *           Use this if memory is to be allocated within a context where
+ *           the allocator cannot block the allocation (e.g., by putting
+ *           the caller to sleep) as it tries to free up memory to
+ *           satisfy the request.  Examples include interrupt handlers,
+ *           process context code holding locks, etc.
+ */
+extern PVOID
+SOCPERF_Allocate_KMemory (
+    size_t  size
+);
+
+/*
+ * @fn PVOID SOCPERF_Free_Memory(location)
+ *
+ * @param    IN location  - size of the memory to allocate
+ *
+ * @returns  pointer to the allocated memory block
+ *
+ * @brief    Frees the memory block
+ *
+ * <I>Special Notes:</I>
+ *           Does not try to free memory if fed with a NULL pointer
+ *           Expected usage:
+ *               ptr = SOCPERF_Free_Memory(ptr);
+ */
+extern PVOID
+SOCPERF_Free_Memory (
+    PVOID    location
+);
+
+#endif  

--- a/perftools-external/soc_perf_driver/src/inc/ecb_iterators.h
+++ b/perftools-external/soc_perf_driver/src/inc/ecb_iterators.h
@@ -1,0 +1,119 @@
+/* ***********************************************************************************************
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(C) 2005-2018 Intel Corporation. All rights reserved.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+  The full GNU General Public License is included in this distribution
+  in the file called LICENSE.GPL.
+
+  BSD LICENSE
+
+  Copyright(C) 2005-2018 Intel Corporation. All rights reserved.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ***********************************************************************************************
+*/
+
+#ifndef _ECB_ITERATORS_H_
+#define _ECB_ITERATORS_H_
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+//
+// Loop macros to walk through the event control block
+// Use for access only in the kernel mode
+// To Do - Control access from kernel mode by a macro
+//
+
+
+#define FOR_EACH_PCI_DATA_REG_RAW(pecb,i, device_idx ) {                                                \
+    U32                 (i)       = 0;                                                                  \
+    U32                 (cur_grp) = LWPMU_DEVICE_cur_group(device_uncore);                              \
+    ECB                 (pecb)    = LWPMU_DEVICE_PMU_register_data(device_uncore)[(cur_grp)];           \
+    if ((pecb)) {                                                                                       \
+        for ((i) = ECB_operations_register_start(pecb, PMU_OPERATION_READ);                             \
+             (i) < ECB_operations_register_start(pecb, PMU_OPERATION_READ) +                            \
+                ECB_operations_register_len(pecb, PMU_OPERATION_READ);                                  \
+             (i)++) {                                                                                   \
+            if (ECB_entries_pci_id_offset((pecb),(i)) == 0) {                                           \
+                continue;                                                                               \
+            }
+
+#define END_FOR_EACH_PCI_DATA_REG_RAW    } } }
+
+
+#define FOR_EACH_PCI_REG_RAW(pecb, i, device_idx ) {                                                   \
+    U32                 (i)       = 0;                                                                 \
+    U32                 (cur_grp) = LWPMU_DEVICE_cur_group(device_uncore);                       \
+    ECB                 (pecb)    = LWPMU_DEVICE_PMU_register_data(device_uncore)[(cur_grp)]; \
+    if ((pecb)) {                                                                                      \
+        for ((i) = 0;                                                                                  \
+             (i) < ECB_num_entries(pecb);                                                              \
+             (i)++) {                                                                                  \
+            if (ECB_entries_pci_id_offset((pecb),(i)) == 0) {                                          \
+                continue;                                                                              \
+            }
+
+#define END_FOR_EACH_PCI_REG_RAW   } } }
+
+#define FOR_EACH_REG_ENTRY_UNC(pecb,device_idx,idx) {                                          \
+    U32        (idx);                                                                          \
+    U32        (cur_grp) = LWPMU_DEVICE_cur_group(device_uncore);                     \
+    ECB        (pecb)    = LWPMU_DEVICE_PMU_register_data(device_uncore)[(cur_grp)];  \
+    if ((pecb)) {                                                                              \
+        for ((idx) = 0; (idx) < ECB_num_entries(pecb); (idx)++) {                              \
+            if (ECB_entries_bus_no((pecb),(idx)) == 0 && ECB_entries_reg_id((pecb),(idx)) == 0) {    \
+                continue;                                                                      \
+            }
+
+#define END_FOR_EACH_REG_ENTRY_UNC  }}}
+
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/perftools-external/soc_perf_driver/src/inc/haswellunc_sa.h
+++ b/perftools-external/soc_perf_driver/src/inc/haswellunc_sa.h
@@ -1,0 +1,87 @@
+/* ***********************************************************************************************
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or 
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(C) 2011-2018 Intel Corporation. All rights reserved.
+
+  This program is free software; you can redistribute it and/or modify 
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but 
+  WITHOUT ANY WARRANTY; without even the implied warranty of 
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License 
+  along with this program; if not, write to the Free Software 
+  Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+  The full GNU General Public License is included in this distribution 
+  in the file called LICENSE.GPL.
+
+  BSD LICENSE 
+
+  Copyright(C) 2011-2018 Intel Corporation. All rights reserved.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+    * Redistributions of source code must retain the above copyright 
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright 
+      notice, this list of conditions and the following disclaimer in 
+      the documentation and/or other materials provided with the 
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its 
+      contributors may be used to endorse or promote products derived 
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ***********************************************************************************************
+*/
+
+
+#ifndef _HSWUNC_SA_H_INC_
+#define _HSWUNC_SA_H_INC_
+
+/*
+ * Local to this architecture: Haswell uncore SA unit 
+ * 
+ */
+#define HSWUNC_SA_DESKTOP_DID                 0x000C04
+#define HSWUNC_SA_NEXT_ADDR_OFFSET            4
+#define HSWUNC_SA_BAR_ADDR_SHIFT              32
+#define HSWUNC_SA_BAR_ADDR_MASK               0x0007FFFFFF000LL
+#define HSWUNC_SA_MAX_PCI_DEVICES             16
+#define HSWUNC_SA_MAX_COUNT                   0x00000000FFFFFFFFLL
+#define HSWUNC_SA_MAX_COUNTERS                8
+
+#define HSWUNC_SA_MCHBAR_MMIO_PAGE_SIZE       8*4096
+#define HSWUNC_SA_PCIEXBAR_MMIO_PAGE_SIZE     57*4096
+#define HSWUNC_SA_OTHER_BAR_MMIO_PAGE_SIZE    4096
+#define HSWUNC_SA_GDXCBAR_OFFSET_LO           0x5420
+#define HSWUNC_SA_GDXCBAR_OFFSET_HI           0x5424
+#define HSWUNC_SA_GDXCBAR_MASK                0x7FFFFFF000LL
+#define HSWUNC_SA_CHAP_SAMPLE_DATA            0x00020000
+#define HSWUNC_SA_CHAP_STOP                   0x00040000
+#define HSWUNC_SA_CHAP_CTRL_REG_OFFSET        0x0
+
+
+extern DISPATCH_NODE  socperf_hswunc_sa_dispatch;
+
+#endif

--- a/perftools-external/soc_perf_driver/src/inc/npk_uncore.h
+++ b/perftools-external/soc_perf_driver/src/inc/npk_uncore.h
@@ -1,0 +1,85 @@
+/* ***********************************************************************************************
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or 
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(C) 2013-2018 Intel Corporation. All rights reserved.
+
+  This program is free software; you can redistribute it and/or modify 
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but 
+  WITHOUT ANY WARRANTY; without even the implied warranty of 
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License 
+  along with this program; if not, write to the Free Software 
+  Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+  The full GNU General Public License is included in this distribution 
+  in the file called LICENSE.GPL.
+
+  BSD LICENSE 
+
+  Copyright(C) 2013-2018 Intel Corporation. All rights reserved.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+    * Redistributions of source code must retain the above copyright 
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright 
+      notice, this list of conditions and the following disclaimer in 
+      the documentation and/or other materials provided with the 
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its 
+      contributors may be used to endorse or promote products derived 
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ***********************************************************************************************
+*/
+
+
+#ifndef _NPK_UNCORE_H_INC_
+#define _NPK_UNCORE_H_INC_
+
+/*
+ * Local to this architecture: uncore SA unit
+ *
+ */
+#define SOC_NPK_UNCORE_NEXT_ADDR_OFFSET              4
+#define SOC_NPK_UNCORE_BAR_ADDR_SHIFT                32
+#define SOC_NPK_UNCORE_BAR_ADDR_MASK                 0x00FFFFF00000LL
+#define SOC_NPK_UNCORE_MAX_PCI_DEVICES               16
+#define SOC_NPK_COUNTER_MAX_COUNTERS                 16
+#define SOC_NPK_COUNTER_MAX_COUNT                    0x00000000FFFFFFFFLL
+#define SOC_NPK_UNCORE_MCHBAR_ADDR_MASK              0x7FFFFF8000LL
+
+#define SOC_NPK_UNCORE_NPK_BAR_MMIO_PAGE_SIZE        0x100000
+#define SOC_NPK_UNCORE_MCHBAR_MMIO_PAGE_SIZE         8*4096
+#define SOC_NPK_UNCORE_SAMPLE_DATA                   0x00120000
+#define SOC_NPK_UNCORE_STOP                          0x00040000
+#define SOC_NPK_UNCORE_CHAP_START                    0x00110000
+#define SOC_NPK_UNCORE_CHAP_CTRL_REG_OFFSET          0x0
+
+
+extern DISPATCH_NODE  npk_dispatch;
+
+
+#endif

--- a/perftools-external/soc_perf_driver/src/inc/pci.h
+++ b/perftools-external/soc_perf_driver/src/inc/pci.h
@@ -1,0 +1,128 @@
+/* ***********************************************************************************************
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or 
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(C) 2013-2018 Intel Corporation. All rights reserved.
+
+  This program is free software; you can redistribute it and/or modify 
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but 
+  WITHOUT ANY WARRANTY; without even the implied warranty of 
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License 
+  along with this program; if not, write to the Free Software 
+  Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+  The full GNU General Public License is included in this distribution 
+  in the file called LICENSE.GPL.
+
+  BSD LICENSE 
+
+  Copyright(C) 2013-2018 Intel Corporation. All rights reserved.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+    * Redistributions of source code must retain the above copyright 
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright 
+      notice, this list of conditions and the following disclaimer in 
+      the documentation and/or other materials provided with the 
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its 
+      contributors may be used to endorse or promote products derived 
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ***********************************************************************************************
+*/
+
+#ifndef _PCI_H_
+#define _PCI_H_
+
+#include "lwpmudrv_defines.h"
+
+/*
+ * PCI Config Address macros
+ */
+#define PCI_ENABLE                          0x80000000
+
+#define PCI_ADDR_IO                         0xCF8
+#define PCI_DATA_IO                         0xCFC
+
+#define BIT0                                0x1
+#define BIT1                                0x2
+
+/*
+ * Macro for forming a PCI configuration address
+ */
+#define FORM_PCI_ADDR(bus,dev,fun,off)     (((PCI_ENABLE))          |   \
+                                            ((bus & 0xFF) << 16)    |   \
+                                            ((dev & 0x1F) << 11)    |   \
+                                            ((fun & 0x07) <<  8)    |   \
+                                            ((off & 0xFF) <<  0))
+
+#define VENDOR_ID_MASK                        0x0000FFFF
+#define DEVICE_ID_MASK                        0xFFFF0000
+#define DEVICE_ID_BITSHIFT                    16
+#define LOWER_4_BYTES_MASK                    0x00000000FFFFFFFF
+#define MAX_BUSNO                             256
+#define NEXT_ADDR_OFFSET                      4
+#define NEXT_ADDR_SHIFT                       32
+#define DRV_IS_PCI_VENDOR_ID_INTEL            0x8086
+
+#define CHECK_IF_GENUINE_INTEL_DEVICE(value, vendor_id, device_id)    \
+    {                                                                 \
+        vendor_id = value & VENDOR_ID_MASK;                           \
+        device_id = (value & DEVICE_ID_MASK) >> DEVICE_ID_BITSHIFT;   \
+                                                                      \
+        if (vendor_id != DRV_IS_PCI_VENDOR_ID_INTEL) {                \
+            continue;                                                 \
+        }                                                             \
+                                                                      \
+    }
+
+#if defined(DRV_IA32) || defined(DRV_EM64T)
+extern int
+SOCPERF_PCI_Read_From_Memory_Address (
+    U32 addr,
+    U32* val
+);
+
+extern int
+SOCPERF_PCI_Write_To_Memory_Address (
+    U32 addr,
+    U32 val
+);
+
+extern int
+SOCPERF_PCI_Read_Ulong (
+    U32 pci_address
+);
+
+extern void
+SOCPERF_PCI_Write_Ulong (
+    U32 pci_address,
+    U32 value
+);
+#endif
+
+#endif  

--- a/perftools-external/soc_perf_driver/src/inc/soc_uncore.h
+++ b/perftools-external/soc_perf_driver/src/inc/soc_uncore.h
@@ -1,0 +1,93 @@
+/* ***********************************************************************************************
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or 
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(C) 2013-2018 Intel Corporation. All rights reserved.
+
+  This program is free software; you can redistribute it and/or modify 
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but 
+  WITHOUT ANY WARRANTY; without even the implied warranty of 
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License 
+  along with this program; if not, write to the Free Software 
+  Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+  The full GNU General Public License is included in this distribution 
+  in the file called LICENSE.GPL.
+
+  BSD LICENSE 
+
+  Copyright(C) 2013-2018 Intel Corporation. All rights reserved.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+    * Redistributions of source code must retain the above copyright 
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright 
+      notice, this list of conditions and the following disclaimer in 
+      the documentation and/or other materials provided with the 
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its 
+      contributors may be used to endorse or promote products derived 
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ***********************************************************************************************
+*/
+
+
+#ifndef _SOC_UNCORE_H_INC_
+#define _SOC_UNCORE_H_INC_
+
+/*
+ * Local to this architecture: SoC uncore unit 
+ * 
+ */
+#define SOC_UNCORE_DESKTOP_DID                 0x000C04
+#define SOC_UNCORE_NEXT_ADDR_OFFSET            4
+#define SOC_UNCORE_BAR_ADDR_SHIFT              32
+#define SOC_UNCORE_BAR_ADDR_MASK               0x000FFFC00000LL
+#define SOC_UNCORE_MAX_PCI_DEVICES             16
+#define SOC_UNCORE_MCR_REG_OFFSET              0xD0
+#define SOC_UNCORE_MDR_REG_OFFSET              0xD4
+#define SOC_UNCORE_MCRX_REG_OFFSET             0xD8
+#define SOC_UNCORE_BYTE_ENABLES                0xF
+#define SOC_UNCORE_OP_CODE_SHIFT               24
+#define SOC_UNCORE_PORT_ID_SHIFT               16
+#define SOC_UNCORE_OFFSET_HI_MASK              0xFFFFFF00
+#define SOC_UNCORE_OFFSET_LO_MASK              0xFF
+#define SOC_COUNTER_PORT_ID                    23
+#define SOC_COUNTER_WRITE_OP_CODE              1
+#define SOC_COUNTER_READ_OP_CODE               0
+#define UNCORE_MAX_COUNTERS                    8
+#define UNCORE_MAX_COUNT                       0x00000000FFFFFFFFLL
+
+#define SOC_UNCORE_OTHER_BAR_MMIO_PAGE_SIZE    4096
+#define SOC_UNCORE_SAMPLE_DATA                 0x00020000
+#define SOC_UNCORE_STOP                        0x00040000
+#define SOC_UNCORE_CTRL_REG_OFFSET             0x0
+
+
+extern DISPATCH_NODE  soc_uncore_dispatch;
+
+#endif

--- a/perftools-external/soc_perf_driver/src/inc/socperfdrv.h
+++ b/perftools-external/soc_perf_driver/src/inc/socperfdrv.h
@@ -1,0 +1,188 @@
+/* ***********************************************************************************************
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or 
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(C) 2005-2018 Intel Corporation. All rights reserved.
+
+  This program is free software; you can redistribute it and/or modify 
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but 
+  WITHOUT ANY WARRANTY; without even the implied warranty of 
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License 
+  along with this program; if not, write to the Free Software 
+  Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+  The full GNU General Public License is included in this distribution 
+  in the file called LICENSE.GPL.
+
+  BSD LICENSE 
+
+  Copyright(C) 2005-2018 Intel Corporation. All rights reserved.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+    * Redistributions of source code must retain the above copyright 
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright 
+      notice, this list of conditions and the following disclaimer in 
+      the documentation and/or other materials provided with the 
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its 
+      contributors may be used to endorse or promote products derived 
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ***********************************************************************************************
+*/
+
+
+#ifndef _SOCPERFDRV_H_
+#define _SOCPERFDRV_H_
+
+#include <linux/version.h>
+#include <linux/kernel.h>
+#include <linux/compat.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,12,0)
+#include <asm/uaccess.h>
+#else
+#include <linux/uaccess.h>
+#endif
+#include "lwpmudrv_defines.h"
+#include "lwpmudrv_ecb.h"
+#include "lwpmudrv_struct.h"
+#include "lwpmudrv_types.h"
+#include "lwpmudrv_version.h"
+
+
+/*
+ * Print macros for driver messages
+ */
+
+#if defined(MYDEBUG)
+#define SOCPERF_PRINT_DEBUG(fmt,args...) { printk(KERN_INFO SOCPERF_MSG_PREFIX" [DEBUG] " fmt,##args); }
+#else
+#define SOCPERF_PRINT_DEBUG(fmt,args...) {;}
+#endif
+
+#define SOCPERF_PRINT(fmt,args...) { printk(KERN_INFO SOCPERF_MSG_PREFIX" " fmt,##args); }
+
+#define SOCPERF_PRINT_WARNING(fmt,args...) { printk(KERN_ALERT SOCPERF_MSG_PREFIX" [Warning] " fmt,##args); }
+
+#define SOCPERF_PRINT_ERROR(fmt,args...) { printk(KERN_CRIT SOCPERF_MSG_PREFIX" [ERROR] " fmt,##args); }
+
+// Macro to return the thread group id
+#define GET_CURRENT_TGID() (current->tgid)
+
+#if defined(DRV_IA32) || defined(DRV_EM64T)
+#define OVERFLOW_ARGS  U64*, U64*
+#elif defined(DRV_IA64)
+#define OVERFLOW_ARGS  U64*, U64*, U64*, U64*, U64*, U64*
+#endif
+
+/*
+ *  Dispatch table for virtualized functions.
+ *  Used to enable common functionality for different
+ *  processor microarchitectures
+ */
+typedef struct DISPATCH_NODE_S  DISPATCH_NODE;
+typedef        DISPATCH_NODE   *DISPATCH;
+
+struct DISPATCH_NODE_S {
+    VOID (*init)(PVOID);
+    VOID (*fini)(PVOID);
+    VOID (*write)(PVOID);
+    VOID (*freeze)(PVOID);
+    VOID (*restart)(PVOID);
+    VOID (*read_data)(PVOID);
+    VOID (*check_overflow)(DRV_MASKS);
+    VOID (*swap_group)(DRV_BOOL);
+    VOID (*read_lbrs)(PVOID);
+    VOID (*clean_up)(PVOID);
+    VOID (*hw_errata)(VOID);
+    VOID (*read_power)(PVOID);
+    U64  (*check_overflow_errata)(ECB, U32, U64);
+    VOID (*read_counts)(PVOID, U32);
+    U64  (*check_overflow_gp_errata)(ECB,U64*);
+    VOID (*read_ro)(PVOID, U32, U32);
+    U64  (*platform_info)(VOID);
+    VOID (*trigger_read)(VOID);    // Counter reads triggered/initiated by User mode timer
+    VOID (*read_current_data)(PVOID);
+    VOID (*create_mem)(U32, U64*);
+    VOID (*check_status)(U64*, U32*);
+    VOID (*read_mem)(U64, U64*, U32);
+    VOID (*stop_mem)(VOID);
+};
+
+extern DISPATCH dispatch;
+
+extern VOID         **PMU_register_data;
+extern VOID         **desc_data;
+extern U64           *prev_counter_data;
+extern U64           *cur_counter_data;
+
+/*!
+ * @struct LWPMU_DEVICE_NODE_S
+ * @brief  Struct to hold fields per device
+ *           PMU_register_data_unc - MSR info
+ *           dispatch_unc          - dispatch table
+ *           em_groups_counts_unc  - # groups
+ *           pcfg_unc              - config struct
+ */
+typedef struct LWPMU_DEVICE_NODE_S  LWPMU_DEVICE_NODE;
+typedef        LWPMU_DEVICE_NODE   *LWPMU_DEVICE;
+
+struct LWPMU_DEVICE_NODE_S {
+    VOID       **PMU_register_data_unc;
+    DISPATCH   dispatch_unc;
+    S32        em_groups_count_unc;
+    VOID       *pcfg_unc;
+    U64        **acc_per_thread;
+    U64        **prev_val_per_thread;
+    U64        counter_mask;
+    U64        num_events;
+    U32        num_units;
+    VOID       *ec;
+    S32        cur_group;
+};
+
+#define LWPMU_DEVICE_PMU_register_data(dev)   (dev)->PMU_register_data_unc
+#define LWPMU_DEVICE_dispatch(dev)            (dev)->dispatch_unc
+#define LWPMU_DEVICE_em_groups_count(dev)     (dev)->em_groups_count_unc
+#define LWPMU_DEVICE_pcfg(dev)                (dev)->pcfg_unc
+#define LWPMU_DEVICE_acc_per_thread(dev)      (dev)->acc_per_thread
+#define LWPMU_DEVICE_prev_val_per_thread(dev) (dev)->prev_val_per_thread
+#define LWPMU_DEVICE_counter_mask(dev)        (dev)->counter_mask
+#define LWPMU_DEVICE_num_events(dev)          (dev)->num_events
+#define LWPMU_DEVICE_num_units(dev)           (dev)->num_units
+#define LWPMU_DEVICE_ec(dev)                  (dev)->ec
+#define LWPMU_DEVICE_cur_group(dev)           (dev)->cur_group
+
+extern U32            num_devices;
+extern U32            cur_devices;
+extern LWPMU_DEVICE   device_uncore;
+extern U64           *pmu_state;
+
+// Handy macro
+#define TSC_SKEW(this_cpu)     (tsc_info[this_cpu] - tsc_info[0])
+
+#endif  

--- a/perftools-external/soc_perf_driver/src/inc/utility.h
+++ b/perftools-external/soc_perf_driver/src/inc/utility.h
@@ -1,0 +1,76 @@
+/* ***********************************************************************************************
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or 
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(C) 2005-2018 Intel Corporation. All rights reserved.
+
+  This program is free software; you can redistribute it and/or modify 
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but 
+  WITHOUT ANY WARRANTY; without even the implied warranty of 
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License 
+  along with this program; if not, write to the Free Software 
+  Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+  The full GNU General Public License is included in this distribution 
+  in the file called LICENSE.GPL.
+
+  BSD LICENSE 
+
+  Copyright(C) 2005-2018 Intel Corporation. All rights reserved.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+    * Redistributions of source code must retain the above copyright 
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright 
+      notice, this list of conditions and the following disclaimer in 
+      the documentation and/or other materials provided with the 
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its 
+      contributors may be used to endorse or promote products derived 
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ***********************************************************************************************
+*/
+
+
+#ifndef _UTILITY_H_
+#define _UTILITY_H_
+
+extern void  SOCPERF_UTILITY_Read_TSC (U64* pTsc);
+
+extern void
+SOCPERF_UTILITY_Read_Cpuid(
+    U64  cpuid_function,
+    U64 *rax_value,
+    U64 *rbx_value,
+    U64 *rcx_value,
+    U64 *rdx_value
+);
+
+extern  DISPATCH
+SOCPERF_UTILITY_Configure_CPU (U32);
+
+#endif 

--- a/perftools-external/soc_perf_driver/src/npk_uncore.c
+++ b/perftools-external/soc_perf_driver/src/npk_uncore.c
@@ -1,0 +1,514 @@
+/* ***********************************************************************************************
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(C) 2013-2018 Intel Corporation. All rights reserved.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+  The full GNU General Public License is included in this distribution
+  in the file called LICENSE.GPL.
+
+  BSD LICENSE
+
+  Copyright(C) 2013-2018 Intel Corporation. All rights reserved.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ***********************************************************************************************
+*/
+
+
+#include "lwpmudrv_defines.h"
+#include <linux/version.h>
+#include <linux/wait.h>
+#include <linux/fs.h>
+
+#include "lwpmudrv_types.h"
+#include "lwpmudrv_ecb.h"
+#include "lwpmudrv_struct.h"
+
+#include "inc/socperfdrv.h"
+#include "inc/ecb_iterators.h"
+#include "inc/pci.h"
+#include "inc/control.h"
+#include "inc/npk_uncore.h"
+
+
+extern LWPMU_DEVICE   device_uncore;
+static U32            counter_overflow[SOC_NPK_COUNTER_MAX_COUNTERS];
+static U64            counter_virtual_address = 0;
+static U64            mchbar_virtual_address  = 0;
+static U64            mchbar_offset           = 0;
+
+
+/*!
+ * @fn          static ULONG read_From_Register(U64  bar_virtual_address,
+                                                U64  mmio_offset,
+                                                U32 *data_val)
+ *
+ * @brief       Reads register programming info
+ *
+ * @param       bar_virtual_address - memory address
+ *              mmio_offset         - offset of the register
+ *              data_val            - register value read
+ *
+ * @return      data from the counter register
+ *
+ * <I>Special Notes:</I>
+ */
+static void
+read_From_Register (
+    U64  bar_virtual_address,
+    U64  mmio_offset,
+    U32 *data_val
+)
+{
+
+    if (data_val) {
+        *data_val = readl((U32*)((char*)(UIOP)(bar_virtual_address) + mmio_offset));
+    }
+    return;
+}
+
+
+/*!
+ * @fn          static ULONG write_To_Register(U64  bar_virtual_address,
+                                               U64  mmio_offset,
+                                               U32  value)
+ *
+ * @brief       Write register programming info
+ *
+ * @param       bar_virtual_address - memory address
+ *              mmio_offset         - offset of the register
+ *              value               - register value to be written
+ *
+ * @return      none
+ *
+ * <I>Special Notes:</I>
+ */
+static void
+write_To_Register (
+    U64   bar_virtual_address,
+    U64   mmio_offset,
+    ULONG value
+)
+{
+    U32 read_reg = 0;
+
+    writel(value, (U32*)(((char*)(UIOP)bar_virtual_address)+mmio_offset));
+    read_From_Register(bar_virtual_address, mmio_offset, &read_reg);
+
+    return;
+}
+
+
+/*!
+ * @fn          static VOID uncore_Reset_Counters(U32 dev_idx)
+ *
+ * @brief       Reset counters
+ *
+ * @param       dev_idx - device index
+ *
+ * @return      None
+ *
+ * <I>Special Notes:</I>
+ */
+static VOID
+uncore_Reset_Counters (
+    U32 dev_idx
+)
+{
+    U32 data_reg   = 0;
+
+    if (counter_virtual_address) {
+        FOR_EACH_PCI_REG_RAW(pecb, i, dev_idx) {
+            if (ECB_entries_reg_type(pecb,i) == PMU_REG_EVENT_SELECT) {
+                data_reg = i + ECB_operations_register_len(pecb, PMU_OPERATION_WRITE);
+                if (ECB_entries_reg_type(pecb,data_reg) == PMU_REG_DATA) {
+                    write_To_Register(counter_virtual_address,
+                                      ECB_entries_pci_id_offset(pecb, data_reg),
+                                      (ULONG)0);
+                }
+                write_To_Register(counter_virtual_address,
+                                  ECB_entries_pci_id_offset(pecb,i),
+                                  (ULONG)SOC_NPK_UNCORE_STOP);
+            }
+        } END_FOR_EACH_PCI_REG_RAW;
+    }
+
+    return;
+}
+
+/*!
+ * @fn          static VOID uncore_Write_PMU(VOID*)
+ *
+ * @brief       Initial write of PMU registers
+ *              Walk through the entries and write the value of the register accordingly.
+ *              When current_group = 0, then this is the first time this routine is called,
+ *
+ * @param       param - device index
+ *
+ * @return      None
+ *
+ * <I>Special Notes:</I>
+ */
+static VOID
+uncore_Write_PMU (
+    VOID  *param
+)
+{
+    U32                        dev_idx  = *((U32*)param);
+    ECB                        pecb;
+    DRV_PCI_DEVICE_ENTRY       dpden;
+    U32                        pci_address;
+    U32                        bar_lo;
+    U64                        bar_hi;
+    U64                        final_bar;
+    U64                        physical_address;
+    U32                        dev_index       = 0;
+    S32                        bar_list[SOC_NPK_UNCORE_MAX_PCI_DEVICES];
+    U32                        bar_index       = 0;
+    U64                        virtual_address = 0;
+    U32                        bar_name        = 0;
+    DRV_PCI_DEVICE_ENTRY       curr_pci_entry  = NULL;
+    U32                        next_bar_offset = 0;
+    U64                        mmio_offset     = 0;
+    U32                        i               = 0;
+    U32                        map_size        = 0;
+    U32                        cur_grp;
+
+    if (device_uncore == NULL) {
+        SOCPERF_PRINT_ERROR("ERROR: NULL device_uncore!\n");
+        return;
+    }
+    cur_grp = LWPMU_DEVICE_cur_group(device_uncore);
+
+    pecb     = (ECB)LWPMU_DEVICE_PMU_register_data(device_uncore)[cur_grp];
+    if (pecb == NULL) {
+        SOCPERF_PRINT_ERROR("ERROR: null pecb!\n");
+        return;
+    }
+
+    for (dev_index = 0; dev_index < SOC_NPK_UNCORE_MAX_PCI_DEVICES; dev_index++) {
+        bar_list[dev_index] = -1;
+    }
+
+    // initialize the per-counter overflow numbers
+    for (i = 0; i < SOC_NPK_COUNTER_MAX_COUNTERS; i++) {
+        counter_overflow[i]         = 0;
+        socperf_pcb[0].last_uncore_count[i] = 0;
+    }
+
+    ECB_pcidev_entry_list(pecb) = (DRV_PCI_DEVICE_ENTRY)((S8*)pecb + ECB_pcidev_list_offset(pecb));
+    dpden = ECB_pcidev_entry_list(pecb);
+
+    uncore_Reset_Counters(dev_idx);
+
+    SOCPERF_PRINT_DEBUG("Inside VISA Driver Write PMU: Number of entries=%d\n", ECB_num_pci_devices(pecb));
+    for (dev_index = 0; dev_index < ECB_num_pci_devices(pecb); dev_index++) {
+        curr_pci_entry = &dpden[dev_index];
+        bar_name       = DRV_PCI_DEVICE_ENTRY_bar_name(curr_pci_entry);
+        mmio_offset    = DRV_PCI_DEVICE_ENTRY_base_offset_for_mmio(curr_pci_entry);
+
+        // UNC_MMIO programming
+        if (bar_list[bar_name] != -1) {
+            bar_index = bar_list[bar_name];
+            virtual_address                                      = DRV_PCI_DEVICE_ENTRY_virtual_address(&dpden[bar_index]);
+            DRV_PCI_DEVICE_ENTRY_virtual_address(curr_pci_entry) = DRV_PCI_DEVICE_ENTRY_virtual_address(&dpden[bar_index]);
+            write_To_Register(virtual_address, mmio_offset, (U32)DRV_PCI_DEVICE_ENTRY_value(curr_pci_entry));
+            continue;
+        }
+
+        pci_address     = FORM_PCI_ADDR(DRV_PCI_DEVICE_ENTRY_bus_no(curr_pci_entry),
+                                    DRV_PCI_DEVICE_ENTRY_dev_no(curr_pci_entry),
+                                    DRV_PCI_DEVICE_ENTRY_func_no(curr_pci_entry),
+                                    DRV_PCI_DEVICE_ENTRY_bar_offset(curr_pci_entry));
+        bar_lo          = SOCPERF_PCI_Read_Ulong(pci_address);
+        SOCPERF_PRINT_DEBUG("The bus=%x device=%x function=%x offset=%x\n",
+                            DRV_PCI_DEVICE_ENTRY_bus_no(curr_pci_entry),
+                            DRV_PCI_DEVICE_ENTRY_dev_no(curr_pci_entry),
+                            DRV_PCI_DEVICE_ENTRY_func_no(curr_pci_entry),
+                            DRV_PCI_DEVICE_ENTRY_bar_offset(curr_pci_entry));
+        next_bar_offset = DRV_PCI_DEVICE_ENTRY_bar_offset(curr_pci_entry)+SOC_NPK_UNCORE_NEXT_ADDR_OFFSET;
+        pci_address     = FORM_PCI_ADDR(DRV_PCI_DEVICE_ENTRY_bus_no(curr_pci_entry),
+                                    DRV_PCI_DEVICE_ENTRY_dev_no(curr_pci_entry),
+                                    DRV_PCI_DEVICE_ENTRY_func_no(curr_pci_entry),
+                                    next_bar_offset);
+        bar_hi      = SOCPERF_PCI_Read_Ulong(pci_address);
+        SOCPERF_PRINT_DEBUG("The bus=%x device=%x function=%x offset=%x\n",
+                            DRV_PCI_DEVICE_ENTRY_bus_no(curr_pci_entry),
+                            DRV_PCI_DEVICE_ENTRY_dev_no(curr_pci_entry),
+                            DRV_PCI_DEVICE_ENTRY_func_no(curr_pci_entry),
+                            next_bar_offset);
+        final_bar   = (bar_hi << SOC_NPK_UNCORE_BAR_ADDR_SHIFT) | bar_lo;
+        if (bar_name == UNC_MCHBAR) {
+            final_bar  &= SOC_NPK_UNCORE_MCHBAR_ADDR_MASK;
+            map_size = SOC_NPK_UNCORE_MCHBAR_MMIO_PAGE_SIZE;
+        }
+        else {
+            final_bar  &= SOC_NPK_UNCORE_BAR_ADDR_MASK;
+            map_size = SOC_NPK_UNCORE_NPK_BAR_MMIO_PAGE_SIZE;
+        }
+        DRV_PCI_DEVICE_ENTRY_bar_address(curr_pci_entry) = final_bar;
+        physical_address = DRV_PCI_DEVICE_ENTRY_bar_address(curr_pci_entry);
+
+        if (physical_address) {
+            DRV_PCI_DEVICE_ENTRY_virtual_address(curr_pci_entry) = (U64) (UIOP)ioremap_nocache(physical_address, map_size);
+            virtual_address = DRV_PCI_DEVICE_ENTRY_virtual_address(curr_pci_entry);
+
+            write_To_Register(virtual_address, mmio_offset, (U32)DRV_PCI_DEVICE_ENTRY_value(curr_pci_entry));
+            bar_list[bar_name] = dev_index;
+            if (counter_virtual_address == 0) {
+                counter_virtual_address = virtual_address;
+            }
+            if (mchbar_virtual_address == 0 && bar_name == UNC_MCHBAR) {
+                mchbar_virtual_address = virtual_address;
+                mchbar_offset          = mmio_offset;
+            }
+        }
+    }
+
+    return;
+}
+
+
+
+/*!
+ * @fn         static VOID uncore_Disable_PMU(PVOID)
+ *
+ * @brief      Unmap the virtual address when sampling/driver stops
+ *
+ * @param      param - device index
+ *
+ * @return     None
+ *
+ * <I>Special Notes:</I>
+ */
+static VOID
+uncore_Disable_PMU (
+    PVOID  param
+)
+{
+    U32                   dev_idx   = *((U32*)param);
+
+    if (GLOBAL_STATE_current_phase(socperf_driver_state) == DRV_STATE_PREPARE_STOP) {
+        uncore_Reset_Counters(dev_idx);
+        if (mchbar_virtual_address) {
+            write_To_Register(mchbar_virtual_address, mchbar_offset, 0x0);
+            iounmap((void*)(UIOP)(mchbar_virtual_address));
+            SOCPERF_PRINT_DEBUG("Unmapping MCHBAR address=%x\n", mchbar_virtual_address);
+        }
+        if (counter_virtual_address) {
+            iounmap((void*)(UIOP)(counter_virtual_address));
+            SOCPERF_PRINT_DEBUG("Unmapping NPKBAR address=%x\n", counter_virtual_address);
+        }
+        counter_virtual_address = 0;
+        mchbar_virtual_address  = 0;
+        mchbar_offset           = 0;
+    }
+
+    return;
+}
+
+
+/*!
+ * @fn         static VOID uncore_Initialize(PVOID)
+ *
+ * @brief      Initialize any registers or addresses
+ *
+ * @param      param
+ *
+ * @return     None
+ *
+ * <I>Special Notes:</I>
+ */
+static VOID
+uncore_Initialize (
+    VOID  *param
+)
+{
+    counter_virtual_address = 0;
+    mchbar_virtual_address  = 0;
+    mchbar_offset           = 0;
+    return;
+}
+
+
+/*!
+ * @fn         static VOID uncore_Clean_Up(PVOID)
+ *
+ * @brief      Reset any registers or addresses
+ *
+ * @param      param
+ *
+ * @return     None
+ *
+ * <I>Special Notes:</I>
+ */
+static VOID
+uncore_Clean_Up (
+    VOID   *param
+)
+{
+    counter_virtual_address = 0;
+    mchbar_virtual_address  = 0;
+    mchbar_offset           = 0;
+    return;
+}
+
+
+
+
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn uncore_Read_Data()
+ *
+ * @param    None
+ *
+ * @return   None     No return needed
+ *
+ * @brief    Read the counters
+ *
+ */
+static VOID
+uncore_Read_Data (
+    PVOID data_buffer
+)
+{
+    U32              event_id    = 0;
+    U64             *data;
+    int              data_index;
+    U32              data_val    = 0;
+    U32              data_reg    = 0;
+    U64              total_count = 0;
+    U32              event_index = 0;
+    U32              cur_grp;
+
+    if (device_uncore == NULL) {
+        SOCPERF_PRINT_ERROR("ERROR: NULL device_uncore!\n");
+        return;
+    }
+    cur_grp = LWPMU_DEVICE_cur_group(device_uncore);
+
+    if (GLOBAL_STATE_current_phase(socperf_driver_state) == DRV_STATE_UNINITIALIZED ||
+        GLOBAL_STATE_current_phase(socperf_driver_state) == DRV_STATE_IDLE          ||
+        GLOBAL_STATE_current_phase(socperf_driver_state) == DRV_STATE_RESERVED      ||
+        GLOBAL_STATE_current_phase(socperf_driver_state) == DRV_STATE_PREPARE_STOP  ||
+        GLOBAL_STATE_current_phase(socperf_driver_state) == DRV_STATE_STOPPED) {
+        SOCPERF_PRINT_ERROR("ERROR: RETURING EARLY from Read_Data\n");
+        return;
+    }
+
+    if (data_buffer == NULL) {
+        return;
+    }
+
+    data       = (U64*)data_buffer;
+    data_index = 0;
+
+    // Write GroupID
+    data[data_index] = cur_grp + 1;
+    // Increment the data index as the event id starts from zero
+    data_index++;
+
+    FOR_EACH_PCI_REG_RAW(pecb, i, dev_idx) {
+
+        if (ECB_entries_reg_type(pecb,i) == PMU_REG_EVENT_SELECT) {
+            write_To_Register(counter_virtual_address,
+                              ECB_entries_pci_id_offset(pecb,i),
+                              (ULONG)SOC_NPK_UNCORE_SAMPLE_DATA);
+
+            data_reg = i + ECB_operations_register_len(pecb, PMU_OPERATION_WRITE);
+            if (ECB_entries_reg_type(pecb,data_reg) == PMU_REG_DATA) {
+                read_From_Register(counter_virtual_address,
+                                   ECB_entries_pci_id_offset(pecb,data_reg),
+                                   &data_val);
+                if (data_val < socperf_pcb[0].last_uncore_count[event_index]) {
+                    counter_overflow[event_index]++;
+                }
+                socperf_pcb[0].last_uncore_count[event_index] = data_val;
+                total_count = data_val + counter_overflow[event_index]*SOC_NPK_COUNTER_MAX_COUNT;
+                event_index++;
+                data[data_index+event_id] = total_count;
+                SOCPERF_PRINT_DEBUG("DATA[%d]=%llu\n", event_id, total_count);
+                event_id++;
+            }
+        }
+
+    } END_FOR_EACH_PCI_REG_RAW;
+
+    return;
+}
+
+
+
+
+/*
+ * Initialize the dispatch table
+ */
+DISPATCH_NODE  npk_dispatch =
+{
+    uncore_Initialize,        // initialize
+    NULL,                     // destroy
+    uncore_Write_PMU,         // write
+    uncore_Disable_PMU,       // freeze
+    NULL,                     // restart
+    NULL,                     // read
+    NULL,                     // check for overflow
+    NULL,
+    NULL,
+    uncore_Clean_Up,
+    NULL,
+    NULL,
+    NULL,
+    NULL,                    // read counts
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    uncore_Read_Data,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};

--- a/perftools-external/soc_perf_driver/src/pci.c
+++ b/perftools-external/soc_perf_driver/src/pci.c
@@ -1,0 +1,205 @@
+/* ***********************************************************************************************
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or 
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(C) 2005-2018 Intel Corporation. All rights reserved.
+
+  This program is free software; you can redistribute it and/or modify 
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but 
+  WITHOUT ANY WARRANTY; without even the implied warranty of 
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License 
+  along with this program; if not, write to the Free Software 
+  Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+  The full GNU General Public License is included in this distribution 
+  in the file called LICENSE.GPL.
+
+  BSD LICENSE 
+
+  Copyright(C) 2005-2018 Intel Corporation. All rights reserved.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+    * Redistributions of source code must retain the above copyright 
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright 
+      notice, this list of conditions and the following disclaimer in 
+      the documentation and/or other materials provided with the 
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its 
+      contributors may be used to endorse or promote products derived 
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ***********************************************************************************************
+*/
+
+
+#include "lwpmudrv_defines.h"
+#include <linux/errno.h>
+#include <linux/types.h>
+#include <asm/page.h>
+#include <asm/io.h>
+
+#include "lwpmudrv_types.h"
+#include "rise_errors.h"
+#include "lwpmudrv_ecb.h"
+#include "socperfdrv.h"
+#include "pci.h"
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn extern int SOCPERF_PCI_Read_From_Memory_Address(addr, val)
+ *
+ * @param    addr    - physical address in mmio
+ * @param   *value  - value at this address
+ *
+ * @return  status
+ *
+ * @brief   Read memory mapped i/o physical location
+ *
+ */
+extern int
+SOCPERF_PCI_Read_From_Memory_Address (
+    U32 addr,
+    U32* val
+)
+{
+    U32 aligned_addr, offset, value;
+    PVOID base;
+
+    if (addr <= 0) {
+        return OS_INVALID;
+    }
+
+    SOCPERF_PRINT_DEBUG("SOCPERF_PCI_Read_From_Memory_Address: reading physical address:%x\n",addr);
+    offset       = addr & ~PAGE_MASK;
+    aligned_addr = addr & PAGE_MASK;
+    SOCPERF_PRINT_DEBUG("SOCPERF_PCI_Read_From_Memory_Address: aligned physical address:%x,offset:%x\n",aligned_addr,offset);
+
+    base = ioremap_nocache(aligned_addr, PAGE_SIZE);
+    if (base == NULL) {
+        return OS_INVALID;
+    }
+
+    value = readl(base+offset);
+    *val = value;
+    SOCPERF_PRINT_DEBUG("SOCPERF_PCI_Read_From_Memory_Address: value at this physical address:%x\n",value);
+
+    iounmap(base);
+
+    return OS_SUCCESS;
+}
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn extern int SOCPERF_PCI_Write_To_Memory_Address(addr, val)
+ *
+ * @param   addr   - physical address in mmio
+ * @param   value  - value to be written
+ *
+ * @return  status
+ *
+ * @brief   Write to memory mapped i/o physical location
+ *
+ */
+extern int
+SOCPERF_PCI_Write_To_Memory_Address (
+    U32 addr,
+    U32 val
+)
+{
+    U32 aligned_addr, offset;
+    PVOID base;
+
+    if (addr <= 0) {
+        return OS_INVALID;
+    }
+
+    SOCPERF_PRINT_DEBUG("SOCPERF_PCI_Write_To_Memory_Address: writing physical address:%x with value:%x\n",addr,val);
+    offset       = addr & ~PAGE_MASK;
+    aligned_addr = addr & PAGE_MASK;
+    SOCPERF_PRINT_DEBUG("SOCPERF_PCI_Write_To_Memory_Address: aligned physical address:%x,offset:%x\n",aligned_addr,offset);
+
+    base = ioremap_nocache(aligned_addr, PAGE_SIZE);
+    if (base == NULL) {
+        return OS_INVALID;
+    }
+
+    writel(val,base+offset);
+
+    iounmap(base);
+
+    return OS_SUCCESS;
+}
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn extern int SOCPERF_PCI_Read_Ulong(pci_address)
+ *
+ * @param    pci_address - PCI configuration address
+ *
+ * @return  value at this location
+ *
+ * @brief   Reads a ULONG from PCI configuration space
+ *
+ */
+extern int
+SOCPERF_PCI_Read_Ulong (
+    U32 pci_address
+)
+{
+    U32 temp_ulong = 0;
+
+    outl(pci_address,PCI_ADDR_IO);
+    temp_ulong = inl(PCI_DATA_IO);
+
+    return temp_ulong;
+}
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn extern int SOCPERF_PCI_Write_Ulong(addr, val)
+ *
+ * @param    pci_address - PCI configuration address
+ * @param    value - Value to be written
+ *
+ * @return  status
+ *
+ * @brief   Writes a ULONG to PCI configuration space
+ *
+ */
+extern void
+SOCPERF_PCI_Write_Ulong (
+    U32 pci_address,
+    U32 value
+)
+{
+    outl(pci_address, PCI_ADDR_IO);
+    outl(value, PCI_DATA_IO);
+
+    return;
+}

--- a/perftools-external/soc_perf_driver/src/soc_uncore.c
+++ b/perftools-external/soc_perf_driver/src/soc_uncore.c
@@ -1,0 +1,903 @@
+/* ***********************************************************************************************
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or 
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(C) 2013-2018 Intel Corporation. All rights reserved.
+
+  This program is free software; you can redistribute it and/or modify 
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but 
+  WITHOUT ANY WARRANTY; without even the implied warranty of 
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License 
+  along with this program; if not, write to the Free Software 
+  Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+  The full GNU General Public License is included in this distribution 
+  in the file called LICENSE.GPL.
+
+  BSD LICENSE 
+
+  Copyright(C) 2013-2018 Intel Corporation. All rights reserved.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+    * Redistributions of source code must retain the above copyright 
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright 
+      notice, this list of conditions and the following disclaimer in 
+      the documentation and/or other materials provided with the 
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its 
+      contributors may be used to endorse or promote products derived 
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ***********************************************************************************************
+*/
+
+
+#include "lwpmudrv_defines.h"
+#include <linux/version.h>
+#include <linux/fs.h>
+
+#include "lwpmudrv_types.h"
+#include "lwpmudrv_ecb.h"
+#include "lwpmudrv_struct.h"
+
+#include "socperfdrv.h"
+#include "control.h"
+#include "soc_uncore.h"
+#include "inc/ecb_iterators.h"
+#include "inc/pci.h"
+
+#if defined (PCI_HELPERS_API)
+#include <asm/intel_mid_pcihelpers.h>
+#elif defined(DRV_CHROMEOS)
+#include <linux/pci.h>
+static struct pci_dev *pci_root = NULL;
+#define PCI_DEVFN(slot, func)   ((((slot) & 0x1f) << 3) | ((func) & 0x07))
+#endif
+
+static U32            counter_overflow[UNCORE_MAX_COUNTERS];
+static U32            counter_port_id         = 0;
+static U64            trace_virtual_address = 0;
+
+
+#if defined(DRV_CHROMEOS)
+/*!
+ * @fn          static VOID get_pci_device_handle(U32   bus_no,
+                                                  U32   dev_no,
+                                                  U32   func_no)
+ *
+ * @brief       Get PCI device handle to be able to read/write
+ *
+ * @param       bus_no      - bus number
+ *              dev_no      - device number
+ *              func_no     - function number
+ *
+ * @return      None
+ *
+ * <I>Special Notes:</I>
+ */
+static void
+get_pci_device_handle (
+    U32   bus_no,
+    U32   dev_no,
+    U32   func_no
+)
+{
+    if (!pci_root) {
+        pci_root = pci_get_bus_and_slot(bus_no, PCI_DEVFN(dev_no, func_no));
+        if (!pci_root) {
+            SOCPERF_PRINT_DEBUG("Unable to get pci device handle");
+        }
+    }
+
+    return;
+}
+#endif
+
+/*!
+ * @fn          static VOID write_To_Register(U32   bus_no,
+                                              U32   dev_no,
+                                              U32   func_no,
+                                              U32   port_id,
+                                              U32   op_code,
+                                              U64   mmio_offset,
+                                              ULONG value)
+ *
+ * @brief       Reads Uncore programming
+ *
+ * @param       bus_no      - bus number
+ *              dev_no      - device number
+ *              func_no     - function number
+ *              port_id     - port id
+ *              op_code     - operation code
+ *              mmio_offset - mmio offset
+ *              value       - data to be written to the register
+ *
+ * @return      None
+ *
+ * <I>Special Notes:</I>
+ */
+static void
+write_To_Register (
+    U32   bus_no,
+    U32   dev_no,
+    U32   func_no,
+    U32   port_id,
+    U32   op_code,
+    U64   mmio_offset,
+    ULONG value
+)
+{
+    U32 cmd  = 0;
+    U32 mmio_offset_lo;
+    U32 mmio_offset_hi;
+#if !defined(DRV_CHROMEOS) && !defined(PCI_HELPERS_API)
+    U32 pci_address;
+#endif
+
+    mmio_offset_hi = mmio_offset & SOC_UNCORE_OFFSET_HI_MASK;
+    mmio_offset_lo = mmio_offset & SOC_UNCORE_OFFSET_LO_MASK;
+    cmd            = (op_code << SOC_UNCORE_OP_CODE_SHIFT) +
+                       (port_id << SOC_UNCORE_PORT_ID_SHIFT) +
+                       (mmio_offset_lo << 8) +
+                       (SOC_UNCORE_BYTE_ENABLES << 4);
+    SOCPERF_PRINT_DEBUG("write off=%llx value=%x\n", mmio_offset, value);
+
+#if defined (PCI_HELPERS_API)
+    intel_mid_msgbus_write32_raw_ext(cmd, mmio_offset_hi, value);
+#elif defined(DRV_CHROMEOS)
+    if (!pci_root) {
+        get_pci_device_handle(bus_no, dev_no, func_no);
+    }
+    pci_write_config_dword(pci_root, SOC_UNCORE_MDR_REG_OFFSET, value);
+    pci_write_config_dword(pci_root, SOC_UNCORE_MCRX_REG_OFFSET, mmio_offset_hi);
+    pci_write_config_dword(pci_root, SOC_UNCORE_MCR_REG_OFFSET, cmd);
+#else
+    pci_address = FORM_PCI_ADDR(bus_no, dev_no, func_no, SOC_UNCORE_MDR_REG_OFFSET);
+    SOCPERF_PCI_Write_Ulong((ULONG)pci_address, (ULONG)value);
+    pci_address = FORM_PCI_ADDR(bus_no, dev_no, func_no, SOC_UNCORE_MCRX_REG_OFFSET);
+    SOCPERF_PCI_Write_Ulong((ULONG)pci_address, mmio_offset_hi);
+    pci_address = FORM_PCI_ADDR(bus_no, dev_no, func_no, SOC_UNCORE_MCR_REG_OFFSET);
+    SOCPERF_PCI_Write_Ulong((ULONG)pci_address, cmd);
+#endif
+
+    return;
+}
+
+/*!
+ * @fn          static ULONG read_From_Register(U32 bus_no,
+                                                U32 dev_no,
+                                                U32 func_no,
+                                                U32 port_id,
+                                                U32 op_code,
+                                                U64 mmio_offset)
+ *
+ * @brief       Reads Uncore programming info
+ *
+ * @param       bus_no      - bus number
+ *              dev_no      - device number
+ *              func_no     - function number
+ *              port_id     - port id
+ *              op_code     - operation code
+ *              mmio_offset - mmio offset
+ *
+ * @return      data from the counter
+ *
+ * <I>Special Notes:</I>
+ */
+static void
+read_From_Register (
+    U32  bus_no,
+    U32  dev_no,
+    U32  func_no,
+    U32  port_id,
+    U32  op_code,
+    U64  mmio_offset,
+    U32 *data_val
+)
+{
+    U32 data = 0;
+    U32 cmd  = 0;
+    U32 mmio_offset_hi;
+    U32 mmio_offset_lo;
+#if !defined(DRV_CHROMEOS) && !defined(PCI_HELPERS_API)
+    U32 pci_address;
+#endif
+
+    mmio_offset_hi = mmio_offset & SOC_UNCORE_OFFSET_HI_MASK;
+    mmio_offset_lo = mmio_offset & SOC_UNCORE_OFFSET_LO_MASK;
+    cmd      = (op_code << SOC_UNCORE_OP_CODE_SHIFT) +
+                (port_id << SOC_UNCORE_PORT_ID_SHIFT) +
+                (mmio_offset_lo << 8) +
+                (SOC_UNCORE_BYTE_ENABLES << 4);
+
+#if defined (PCI_HELPERS_API)
+    data = intel_mid_msgbus_read32_raw_ext(cmd, mmio_offset_hi);
+#elif defined(DRV_CHROMEOS)
+    if (!pci_root) {
+        get_pci_device_handle(bus_no, dev_no, func_no);
+    }
+    pci_write_config_dword(pci_root, SOC_UNCORE_MCRX_REG_OFFSET, mmio_offset_hi);
+    pci_write_config_dword(pci_root, SOC_UNCORE_MCR_REG_OFFSET, cmd);
+    pci_read_config_dword(pci_root, SOC_UNCORE_MDR_REG_OFFSET, &data);
+#else
+    pci_address = FORM_PCI_ADDR(bus_no, dev_no, func_no, SOC_UNCORE_MCRX_REG_OFFSET);
+    SOCPERF_PCI_Write_Ulong((ULONG)pci_address, mmio_offset_hi);
+    pci_address = FORM_PCI_ADDR(bus_no, dev_no, func_no, SOC_UNCORE_MCR_REG_OFFSET);
+    SOCPERF_PCI_Write_Ulong((ULONG)pci_address, cmd);
+    pci_address = FORM_PCI_ADDR(bus_no, dev_no, func_no, SOC_UNCORE_MDR_REG_OFFSET);
+    data = SOCPERF_PCI_Read_Ulong(pci_address);
+#endif
+    SOCPERF_PRINT_DEBUG("read off=%llx value=%x\n", mmio_offset, data);
+    if (data_val) {
+        *data_val = data;
+    }
+
+    return;
+}
+
+/*!
+ * @fn          static VOID uncore_Reset_Counters(U32 dev_idx)
+ *
+ * @brief       Reset counters
+ *
+ * @param       dev_idx - device index
+ *
+ * @return      None
+ *
+ * <I>Special Notes:</I>
+ */
+static VOID
+uncore_Reset_Counters (
+    U32 dev_idx
+)
+{
+    U32 data_reg   = 0;
+
+    if (counter_port_id != 0) {
+        FOR_EACH_PCI_REG_RAW(pecb, i, dev_idx) {
+            if (ECB_entries_reg_type(pecb,i) == PMU_REG_EVENT_SELECT) {
+                data_reg = i + ECB_operations_register_len(pecb, PMU_OPERATION_WRITE);
+                if (ECB_entries_reg_type(pecb,data_reg) == PMU_REG_DATA) {
+                    write_To_Register(ECB_entries_bus_no(pecb, data_reg),
+                                      ECB_entries_dev_no(pecb, data_reg),
+                                      ECB_entries_func_no(pecb, data_reg),
+                                      counter_port_id,
+                                      SOC_COUNTER_WRITE_OP_CODE,
+                                      ECB_entries_pci_id_offset(pecb, data_reg),
+                                      (ULONG)0);
+                }
+                write_To_Register(ECB_entries_bus_no(pecb, i),
+                                  ECB_entries_dev_no(pecb, i),
+                                  ECB_entries_func_no(pecb, i),
+                                  counter_port_id,
+                                  SOC_COUNTER_WRITE_OP_CODE,
+                                  ECB_entries_pci_id_offset(pecb,i),
+                                  (ULONG)SOC_UNCORE_STOP);
+            }
+        } END_FOR_EACH_PCI_REG_RAW;
+    }
+
+    return;
+}
+
+/*!
+ * @fn          static VOID uncore_Write_PMU(VOID*)
+ *
+ * @brief       Initial write of PMU registers
+ *              Walk through the entries and write the value of the register accordingly.
+ *              When current_group = 0, then this is the first time this routine is called,
+ *
+ * @param       param - device index
+ *
+ * @return      None
+ *
+ * <I>Special Notes:</I>
+ */
+static VOID
+uncore_Write_PMU (
+    VOID  *param
+)
+{
+    U32                        dev_idx;
+    ECB                        pecb;
+    DRV_PCI_DEVICE_ENTRY       dpden;
+    U32                        pci_address;
+    U32                        bar_lo;
+    U64                        bar_hi;
+    U64                        final_bar;
+    U64                        physical_address;
+    U32                        dev_index       = 0;
+    S32                        bar_list[SOC_UNCORE_MAX_PCI_DEVICES];
+    U32                        bar_index       = 0;
+    U32                        map_size        = 0;
+    U64                        virtual_address = 0;
+    U32                        bar_name        = 0;
+    DRV_PCI_DEVICE_ENTRY       curr_pci_entry  = NULL;
+    U32                        next_bar_offset = 0;
+    U64                        mmio_offset     = 0;
+    U64                        map_base        = 0;
+    U32                        i               = 0;
+    U32                        cur_grp;
+
+    dev_idx  = *((U32*)param);
+    if (device_uncore == NULL) {
+        SOCPERF_PRINT_ERROR("ERROR: NULL device_uncore!\n");
+        return;
+    }
+    cur_grp = LWPMU_DEVICE_cur_group(device_uncore);
+
+    pecb     = (ECB)LWPMU_DEVICE_PMU_register_data(device_uncore)[cur_grp];
+    if (pecb == NULL) {
+        SOCPERF_PRINT_ERROR("ERROR: null pecb!\n");
+        return;
+    }
+
+    for (dev_index = 0; dev_index < SOC_UNCORE_MAX_PCI_DEVICES; dev_index++) {
+        bar_list[dev_index] = -1;
+    }
+
+    // initialize the per-counter overflow numbers
+    for (i = 0; i < UNCORE_MAX_COUNTERS; i++) {
+        counter_overflow[i]         = 0;
+        socperf_pcb[0].last_uncore_count[i] = 0;
+    }
+
+    ECB_pcidev_entry_list(pecb) = (DRV_PCI_DEVICE_ENTRY)((S8*)pecb + ECB_pcidev_list_offset(pecb));
+    dpden = ECB_pcidev_entry_list(pecb);
+
+    uncore_Reset_Counters(dev_idx);
+
+    for (dev_index = 0; dev_index < ECB_num_pci_devices(pecb); dev_index++) {
+        curr_pci_entry = &dpden[dev_index];
+        bar_name       = DRV_PCI_DEVICE_ENTRY_bar_name(curr_pci_entry);
+        mmio_offset    = DRV_PCI_DEVICE_ENTRY_base_offset_for_mmio(curr_pci_entry);
+
+        if (counter_port_id == 0 && DRV_PCI_DEVICE_ENTRY_prog_type(curr_pci_entry) == UNC_COUNTER) {
+            counter_port_id = DRV_PCI_DEVICE_ENTRY_port_id(curr_pci_entry);
+            uncore_Reset_Counters(dev_idx);
+        }
+        if (DRV_PCI_DEVICE_ENTRY_config_type(curr_pci_entry) == UNC_PCICFG) {
+            if (bar_name == UNC_SOCPCI &&
+                (DRV_PCI_DEVICE_ENTRY_prog_type(curr_pci_entry) == UNC_MUX ||
+                DRV_PCI_DEVICE_ENTRY_prog_type(curr_pci_entry) == UNC_COUNTER) &&
+                DRV_PCI_DEVICE_ENTRY_operation(curr_pci_entry) == UNC_OP_WRITE) {
+                SOCPERF_PRINT_DEBUG("dev_index=%d OFFSET=%x VAL=%x\n", dev_index, DRV_PCI_DEVICE_ENTRY_base_offset_for_mmio(curr_pci_entry), DRV_PCI_DEVICE_ENTRY_value(curr_pci_entry));
+                write_To_Register(DRV_PCI_DEVICE_ENTRY_bus_no(curr_pci_entry),
+                                  DRV_PCI_DEVICE_ENTRY_dev_no(curr_pci_entry),
+                                  DRV_PCI_DEVICE_ENTRY_func_no(curr_pci_entry),
+                                  DRV_PCI_DEVICE_ENTRY_port_id(curr_pci_entry),
+                                  DRV_PCI_DEVICE_ENTRY_op_code(curr_pci_entry),
+                                  DRV_PCI_DEVICE_ENTRY_base_offset_for_mmio(curr_pci_entry),
+                                  (ULONG)DRV_PCI_DEVICE_ENTRY_value(curr_pci_entry));
+            }
+            continue;
+        }
+        // UNC_MMIO programming
+        if (bar_list[bar_name] != -1) {
+            bar_index                                            = bar_list[bar_name];
+            virtual_address                                      = DRV_PCI_DEVICE_ENTRY_virtual_address(&dpden[bar_index]);
+            DRV_PCI_DEVICE_ENTRY_virtual_address(curr_pci_entry) = DRV_PCI_DEVICE_ENTRY_virtual_address(&dpden[bar_index]);
+            writel(DRV_PCI_DEVICE_ENTRY_value(curr_pci_entry), (U32*)(((char*)(UIOP)virtual_address)+mmio_offset));
+            continue;
+        }
+        pci_address     = FORM_PCI_ADDR(DRV_PCI_DEVICE_ENTRY_bus_no(curr_pci_entry),
+                                    DRV_PCI_DEVICE_ENTRY_dev_no(curr_pci_entry),
+                                    DRV_PCI_DEVICE_ENTRY_func_no(curr_pci_entry),
+                                    DRV_PCI_DEVICE_ENTRY_bar_offset(curr_pci_entry));
+        bar_lo          = SOCPERF_PCI_Read_Ulong(pci_address);
+        next_bar_offset = DRV_PCI_DEVICE_ENTRY_bar_offset(curr_pci_entry)+SOC_UNCORE_NEXT_ADDR_OFFSET;
+        pci_address     = FORM_PCI_ADDR(DRV_PCI_DEVICE_ENTRY_bus_no(curr_pci_entry),
+                                    DRV_PCI_DEVICE_ENTRY_dev_no(curr_pci_entry),
+                                    DRV_PCI_DEVICE_ENTRY_func_no(curr_pci_entry),
+                                    next_bar_offset);
+        bar_hi      = SOCPERF_PCI_Read_Ulong(pci_address);
+        final_bar   = (bar_hi << SOC_UNCORE_BAR_ADDR_SHIFT) | bar_lo;
+        final_bar  &= SOC_UNCORE_BAR_ADDR_MASK;
+        DRV_PCI_DEVICE_ENTRY_bar_address(curr_pci_entry) = final_bar;
+        physical_address = DRV_PCI_DEVICE_ENTRY_bar_address(curr_pci_entry);
+        if (physical_address) {
+            map_size = SOC_UNCORE_OTHER_BAR_MMIO_PAGE_SIZE;
+            map_base = (mmio_offset/map_size)*map_size;
+            if (mmio_offset > map_size) {
+                physical_address = physical_address + map_base;
+            }
+        }
+    }
+
+    return;
+}
+
+
+
+/*!
+ * @fn         static VOID uncore_Disable_PMU(PVOID)
+ *
+ * @brief      Unmap the virtual address when sampling/driver stops
+ *
+ * @param      param - device index
+ *
+ * @return     None
+ *
+ * <I>Special Notes:</I>
+ */
+static VOID
+uncore_Disable_PMU (
+    PVOID  param
+)
+{
+    U32 dev_idx   = *((U32*)param);
+
+    if (GLOBAL_STATE_current_phase(socperf_driver_state) == DRV_STATE_PREPARE_STOP) {
+        uncore_Reset_Counters(dev_idx);
+    }
+
+    return;
+}
+
+
+/*!
+ * @fn         static VOID uncore_Stop_Mem(VOID)
+ *
+ * @brief      Stop trace
+ *
+ * @param      param - None
+ *
+ * @return     None
+ *
+ * <I>Special Notes:</I>
+ */
+static VOID
+uncore_Stop_Mem (
+    VOID
+)
+{
+    ECB                   pecb;
+    DRV_PCI_DEVICE_ENTRY  dpden;
+    U32                   bar_name        = 0;
+    DRV_PCI_DEVICE_ENTRY  curr_pci_entry  = NULL;
+    U64                   mmio_offset     = 0;
+    U32                   dev_index       = 0;
+    U32                   data_val        = 0;
+    U32                   cur_grp;
+
+    if (device_uncore == NULL) {
+        SOCPERF_PRINT_ERROR("ERROR: NULL device_uncore!\n");
+        return;
+    }
+    cur_grp = LWPMU_DEVICE_cur_group(device_uncore);
+
+    pecb     = (ECB)LWPMU_DEVICE_PMU_register_data(device_uncore)[cur_grp];
+    if (pecb == NULL) {
+        SOCPERF_PRINT_ERROR("ERROR: null pecb!\n");
+        return;
+    }
+
+    ECB_pcidev_entry_list(pecb) = (DRV_PCI_DEVICE_ENTRY)((S8*)pecb + ECB_pcidev_list_offset(pecb));
+    dpden = ECB_pcidev_entry_list(pecb);
+
+    for (dev_index = 0; dev_index < ECB_num_pci_devices(pecb); dev_index++) {
+        curr_pci_entry = &dpden[dev_index];
+        bar_name       = DRV_PCI_DEVICE_ENTRY_bar_name(curr_pci_entry);
+        mmio_offset    = DRV_PCI_DEVICE_ENTRY_base_offset_for_mmio(curr_pci_entry);
+
+        if (DRV_PCI_DEVICE_ENTRY_prog_type(curr_pci_entry) == UNC_STOP &&
+            DRV_PCI_DEVICE_ENTRY_config_type(curr_pci_entry) == UNC_PCICFG &&
+            bar_name == UNC_SOCPCI &&
+            DRV_PCI_DEVICE_ENTRY_operation(curr_pci_entry) == UNC_OP_READ) {
+                SOCPERF_PRINT_DEBUG("op=%d port=%d offset=%x val=%x\n",
+                                DRV_PCI_DEVICE_ENTRY_op_code(curr_pci_entry),
+                                DRV_PCI_DEVICE_ENTRY_port_id(curr_pci_entry),
+                                mmio_offset,
+                                data_val);
+                read_From_Register(DRV_PCI_DEVICE_ENTRY_bus_no(curr_pci_entry),
+                                   DRV_PCI_DEVICE_ENTRY_dev_no(curr_pci_entry),
+                                   DRV_PCI_DEVICE_ENTRY_func_no(curr_pci_entry),
+                                   DRV_PCI_DEVICE_ENTRY_port_id(curr_pci_entry),
+                                   SOC_COUNTER_READ_OP_CODE,
+                                   mmio_offset,
+                                   &data_val);
+                SOCPERF_PRINT_DEBUG("op=%d port=%d offset=%x val=%x\n",
+                                DRV_PCI_DEVICE_ENTRY_op_code(curr_pci_entry),
+                                DRV_PCI_DEVICE_ENTRY_port_id(curr_pci_entry),
+                                mmio_offset,
+                                data_val);
+                write_To_Register(DRV_PCI_DEVICE_ENTRY_bus_no(curr_pci_entry),
+                                  DRV_PCI_DEVICE_ENTRY_dev_no(curr_pci_entry),
+                                  DRV_PCI_DEVICE_ENTRY_func_no(curr_pci_entry),
+                                  DRV_PCI_DEVICE_ENTRY_port_id(curr_pci_entry),
+                                  SOC_COUNTER_WRITE_OP_CODE,
+                                  mmio_offset,
+                                  (ULONG)(data_val | 0x2000));
+        }
+    }
+
+    return;
+}
+
+/*!
+ * @fn         static VOID uncore_Initialize(PVOID)
+ *
+ * @brief      Initialize any registers or addresses
+ *
+ * @param      param
+ *
+ * @return     None
+ *
+ * <I>Special Notes:</I>
+ */
+static VOID
+uncore_Initialize (
+    VOID  *param
+)
+{
+    return;
+}
+
+
+/*!
+ * @fn         static VOID uncore_Clean_Up(PVOID)
+ *
+ * @brief      Reset any registers or addresses
+ *
+ * @param      param
+ *
+ * @return     None
+ *
+ * <I>Special Notes:</I>
+ */
+static VOID
+uncore_Clean_Up (
+    VOID   *param
+)
+{
+    if (trace_virtual_address) {
+        iounmap((void*)(UIOP)trace_virtual_address);
+        trace_virtual_address = 0;
+    }
+    return;
+}
+
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn uncore_Read_Data()
+ *
+ * @param    None
+ *
+ * @return   None     No return needed
+ *
+ * @brief    Read the counters
+ *
+ */
+static VOID
+uncore_Read_Data (
+    PVOID data_buffer
+)
+{
+    U32              event_id    = 0;
+    U64             *data;
+    int              data_index;
+    U32              data_val    = 0;
+    U32              data_reg    = 0;
+    U64              total_count = 0;
+    U32              event_index = 0;
+    U32              cur_grp;
+
+    if (device_uncore == NULL) {
+        SOCPERF_PRINT_ERROR("ERROR: NULL device_uncore!\n");
+        return;
+    }
+    cur_grp = LWPMU_DEVICE_cur_group(device_uncore);
+
+    if (GLOBAL_STATE_current_phase(socperf_driver_state) == DRV_STATE_UNINITIALIZED ||
+        GLOBAL_STATE_current_phase(socperf_driver_state) == DRV_STATE_IDLE          ||
+        GLOBAL_STATE_current_phase(socperf_driver_state) == DRV_STATE_RESERVED      ||
+        GLOBAL_STATE_current_phase(socperf_driver_state) == DRV_STATE_PREPARE_STOP  ||
+        GLOBAL_STATE_current_phase(socperf_driver_state) == DRV_STATE_STOPPED) {
+        SOCPERF_PRINT_ERROR("ERROR: RETURING EARLY from Read_Data\n");
+        return;
+    }
+
+    data       = data_buffer;
+    data_index = 0;
+
+    preempt_disable();
+
+    // Write GroupID
+    data[data_index] = cur_grp + 1;
+    // Increment the data index as the event id starts from zero
+    data_index++;
+
+    FOR_EACH_PCI_REG_RAW(pecb, i, dev_idx) {
+        if (ECB_entries_reg_type(pecb,i) == PMU_REG_EVENT_SELECT) {
+            write_To_Register(ECB_entries_bus_no(pecb, i),
+                              ECB_entries_dev_no(pecb, i),
+                              ECB_entries_func_no(pecb, i),
+                              counter_port_id,
+                              SOC_COUNTER_WRITE_OP_CODE,
+                              ECB_entries_pci_id_offset(pecb,i),
+                              (ULONG)SOC_UNCORE_SAMPLE_DATA);
+
+            data_reg = i + ECB_operations_register_len(pecb, PMU_OPERATION_WRITE);
+            if (ECB_entries_reg_type(pecb,data_reg) == PMU_REG_DATA) {
+                read_From_Register(ECB_entries_bus_no(pecb, data_reg),
+                                   ECB_entries_dev_no(pecb, data_reg),
+                                   ECB_entries_func_no(pecb, data_reg),
+                                   counter_port_id,
+                                   SOC_COUNTER_READ_OP_CODE,
+                                   ECB_entries_pci_id_offset(pecb,data_reg),
+                                   &data_val);
+                if (data_val < socperf_pcb[0].last_uncore_count[event_index]) {
+                    counter_overflow[event_index]++;
+                }
+                socperf_pcb[0].last_uncore_count[event_index] = data_val;
+                total_count = data_val + counter_overflow[event_index]*UNCORE_MAX_COUNT;
+                event_index++;
+                data[data_index+event_id] = total_count;
+                event_id++;
+            }
+        }
+
+    } END_FOR_EACH_PCI_REG_RAW;
+
+    preempt_enable();
+
+    return;
+}
+
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn uncore_Create_Mem()
+ *
+ * @param    None
+ *
+ * @return   None     No return needed
+ *
+ * @brief    Read the counters
+ *
+ */
+static VOID
+uncore_Create_Mem (
+    U32  memory_size,
+    U64 *trace_buffer
+)
+{
+    ECB                        pecb;
+    DRV_PCI_DEVICE_ENTRY       dpden;
+    U32                        bar_name        = 0;
+    DRV_PCI_DEVICE_ENTRY       curr_pci_entry  = NULL;
+    U64                        mmio_offset     = 0;
+    U32                        dev_index       = 0;
+    U32                        data_val        = 0;
+    U32                        reg_index       = 0;
+    U64                        physical_high   = 0;
+    U64                        odla_physical_address = 0;
+
+    if (device_uncore == NULL) {
+        SOCPERF_PRINT_ERROR("ERROR: NULL device_uncore!\n");
+        return;
+    }
+    pecb     = (ECB)LWPMU_DEVICE_PMU_register_data(device_uncore)[0];
+    if (pecb == NULL) {
+        SOCPERF_PRINT_ERROR("ERROR: null pecb!\n");
+        return;
+    }
+
+    if (!trace_buffer) {
+        return;
+    }
+
+    ECB_pcidev_entry_list(pecb) = (DRV_PCI_DEVICE_ENTRY)((S8*)pecb + ECB_pcidev_list_offset(pecb));
+    dpden = ECB_pcidev_entry_list(pecb);
+
+    for (dev_index = 0; dev_index < ECB_num_pci_devices(pecb); dev_index++) {
+        curr_pci_entry = &dpden[dev_index];
+        bar_name       = DRV_PCI_DEVICE_ENTRY_bar_name(curr_pci_entry);
+        mmio_offset    = DRV_PCI_DEVICE_ENTRY_base_offset_for_mmio(curr_pci_entry);
+
+        if (DRV_PCI_DEVICE_ENTRY_prog_type(curr_pci_entry) == UNC_MEMORY &&
+            DRV_PCI_DEVICE_ENTRY_config_type(curr_pci_entry) == UNC_PCICFG &&
+            bar_name == UNC_SOCPCI &&
+            DRV_PCI_DEVICE_ENTRY_operation(curr_pci_entry) == UNC_OP_WRITE) {
+                read_From_Register(DRV_PCI_DEVICE_ENTRY_bus_no(curr_pci_entry),
+                                   DRV_PCI_DEVICE_ENTRY_dev_no(curr_pci_entry),
+                                   DRV_PCI_DEVICE_ENTRY_func_no(curr_pci_entry),
+                                   DRV_PCI_DEVICE_ENTRY_port_id(curr_pci_entry),
+                                   SOC_COUNTER_READ_OP_CODE,
+                                   mmio_offset,
+                                   &data_val);
+                if (reg_index == 1) {
+                    odla_physical_address = data_val;
+                }
+                else if (reg_index == 2) {
+                    physical_high = data_val;
+                    odla_physical_address = odla_physical_address | (physical_high << 32);
+                }
+                SOCPERF_PRINT_DEBUG("op=%d port=%d offset=%x val=%x\n",
+                                DRV_PCI_DEVICE_ENTRY_op_code(curr_pci_entry),
+                                DRV_PCI_DEVICE_ENTRY_port_id(curr_pci_entry),
+                                mmio_offset,
+                                data_val);
+                reg_index++;
+        }
+        continue;
+    }
+    SOCPERF_PRINT_DEBUG("Physical Address=%llx\n", odla_physical_address);
+    if (odla_physical_address) {
+        trace_virtual_address = (U64) (UIOP) ioremap_nocache(odla_physical_address, 1024*sizeof(U64));
+        SOCPERF_PRINT_DEBUG("PHY=%llx ODLA VIRTUAL ADDRESS=%llx\n", odla_physical_address, trace_virtual_address);
+        if (trace_buffer) {
+           *trace_buffer = odla_physical_address;
+        }
+    }
+
+    return;
+}
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn uncore_Check_Status()
+ *
+ * @param    None
+ *
+ * @return   None     No return needed
+ *
+ * @brief    Read the counters
+ *
+ */
+static VOID
+uncore_Check_Status (
+    U64 *trace_buffer,
+    U32 *num_entries
+)
+{
+    U32                        dev_index       = 0;
+    ECB                        pecb;
+    DRV_PCI_DEVICE_ENTRY       dpden;
+    U32                        bar_name        = 0;
+    DRV_PCI_DEVICE_ENTRY       curr_pci_entry  = NULL;
+    U64                        mmio_offset     = 0;
+    U32                        data_val        = 0;
+    U32                        data_index      = 0;
+
+    if (device_uncore == NULL) {
+        SOCPERF_PRINT_ERROR("ERROR: NULL device_uncore!\n");
+        return;
+    }
+    pecb  = (ECB)LWPMU_DEVICE_PMU_register_data(device_uncore)[0];
+    if (pecb == NULL) {
+        SOCPERF_PRINT_ERROR("ERROR: null pecb!\n");
+        return;
+    }
+    if (!trace_buffer) {
+        return;
+    }
+
+    ECB_pcidev_entry_list(pecb) = (DRV_PCI_DEVICE_ENTRY)((S8*)pecb + ECB_pcidev_list_offset(pecb));
+    dpden = ECB_pcidev_entry_list(pecb);
+
+    for (dev_index = 0; dev_index < ECB_num_pci_devices(pecb); dev_index++) {
+        curr_pci_entry = &dpden[dev_index];
+        bar_name       = DRV_PCI_DEVICE_ENTRY_bar_name(curr_pci_entry);
+        mmio_offset    = DRV_PCI_DEVICE_ENTRY_base_offset_for_mmio(curr_pci_entry);
+
+        if (DRV_PCI_DEVICE_ENTRY_prog_type(curr_pci_entry) == UNC_STATUS &&
+            DRV_PCI_DEVICE_ENTRY_config_type(curr_pci_entry) == UNC_PCICFG &&
+            bar_name == UNC_SOCPCI &&
+            DRV_PCI_DEVICE_ENTRY_operation(curr_pci_entry) == UNC_OP_READ) {
+            read_From_Register(DRV_PCI_DEVICE_ENTRY_bus_no(curr_pci_entry),
+                               DRV_PCI_DEVICE_ENTRY_dev_no(curr_pci_entry),
+                               DRV_PCI_DEVICE_ENTRY_func_no(curr_pci_entry),
+                               DRV_PCI_DEVICE_ENTRY_port_id(curr_pci_entry),
+                               SOC_COUNTER_READ_OP_CODE,
+                               mmio_offset,
+                               &data_val);
+            SOCPERF_PRINT_DEBUG("TRACE STATUS=%x\n", data_val);
+            trace_buffer[data_index]  = data_val;
+            data_index++;
+            continue;
+        }
+    }
+
+    if (num_entries) {
+        *num_entries = data_index;
+    }
+
+    return;
+}
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn uncore_Read_Mem()
+ *
+ * @param    None
+ *
+ * @return   None     No return needed
+ *
+ * @brief    Read the counters
+ *
+ */
+static VOID
+uncore_Read_Mem (
+    U64  start_address,
+    U64 *trace_buffer,
+    U32  num_entries
+)
+{
+    U32 data_index = 0;
+    U32 data_value = 0;
+
+    if (num_entries == 0 || !trace_buffer) {
+        return;
+    }
+    SOCPERF_PRINT_DEBUG("Reading memory for num_entries=%d from address=%llx\n", num_entries, trace_virtual_address);
+    for (data_index = 0; data_index < num_entries; data_index++) {
+        if (trace_virtual_address) {
+            data_value = readl((U64*)(UIOP)trace_virtual_address + data_index);
+
+            SOCPERF_PRINT_DEBUG("DATA VALUE=%llx\n", data_value);
+            *(trace_buffer + data_index) = data_value;
+        }
+    }
+
+    return;
+}
+
+/*
+ * Initialize the dispatch table
+ */
+DISPATCH_NODE  soc_uncore_dispatch =
+{
+    uncore_Initialize,                 // initialize
+    NULL,                              // destroy
+    uncore_Write_PMU,                  // write
+    uncore_Disable_PMU,                // freeze
+    NULL,                              // restart
+    NULL,                              // read
+    NULL,                              // check for overflow
+    NULL,
+    NULL,
+    uncore_Clean_Up,
+    NULL,
+    NULL,
+    NULL,
+    NULL,                              // read counts
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    uncore_Read_Data,
+    uncore_Create_Mem,
+    uncore_Check_Status,
+    uncore_Read_Mem,
+    uncore_Stop_Mem
+};

--- a/perftools-external/soc_perf_driver/src/socperfdrv.c
+++ b/perftools-external/soc_perf_driver/src/socperfdrv.c
@@ -1,0 +1,1591 @@
+/* ***********************************************************************************************
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(C) 2005-2018 Intel Corporation. All rights reserved.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+  The full GNU General Public License is included in this distribution
+  in the file called LICENSE.GPL.
+
+  BSD LICENSE
+
+  Copyright(C) 2005-2018 Intel Corporation. All rights reserved.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ***********************************************************************************************
+*/
+
+
+#include "lwpmudrv_defines.h"
+
+
+#include <linux/version.h>
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/kernel.h>
+#include <linux/slab.h>
+#include <linux/fs.h>
+#include <linux/errno.h>
+#include <linux/types.h>
+#include <asm/page.h>
+#include <linux/cdev.h>
+#include <linux/proc_fs.h>
+#include <linux/fcntl.h>
+#include <linux/device.h>
+#include <linux/sched.h>
+#include <linux/syscalls.h>
+#include <asm/unistd.h>
+#include <linux/compat.h>
+
+#include "lwpmudrv_types.h"
+#include "rise_errors.h"
+#include "lwpmudrv_version.h"
+#include "lwpmudrv_ecb.h"
+#include "lwpmudrv_struct.h"
+#include "lwpmudrv_ioctl.h"
+#include "inc/ecb_iterators.h"
+#include "socperfdrv.h"
+#include "control.h"
+#include "inc/utility.h"
+
+
+MODULE_AUTHOR("Copyright(C) 2007-2018 Intel Corporation");
+MODULE_VERSION(SOCPERF_NAME"_"SOCPERF_VERSION_STR);
+MODULE_LICENSE("Dual BSD/GPL");
+
+typedef struct LWPMU_DEV_NODE_S  LWPMU_DEV_NODE;
+typedef        LWPMU_DEV_NODE   *LWPMU_DEV;
+
+struct LWPMU_DEV_NODE_S {
+  long              buffer;
+  struct semaphore  sem;
+  struct cdev       cdev;
+};
+
+#define LWPMU_DEV_buffer(dev)      (dev)->buffer
+#define LWPMU_DEV_sem(dev)         (dev)->sem
+#define LWPMU_DEV_cdev(dev)        (dev)->cdev
+
+/* Global variables of the driver */
+SOCPERF_VERSION_NODE    socperf_drv_version;
+U64                    *read_unc_ctr_info     = NULL;
+DISPATCH                dispatch_uncore       = NULL;
+EVENT_CONFIG            socperf_global_ec             = NULL;
+volatile S32            socperf_abnormal_terminate    = 0;
+LWPMU_DEV               socperf_control          = NULL;
+
+LWPMU_DEVICE            device_uncore           = NULL;
+CPU_STATE               socperf_pcb                   = NULL;
+size_t                  socperf_pcb_size              = 0;
+
+#if defined(DRV_USE_UNLOCKED_IOCTL)
+static   struct mutex   ioctl_lock;
+#endif
+
+#define  PMU_DEVICES            1   // pmu control
+
+static dev_t     lwpmu_DevNum;  /* the major and minor parts for SOCPERF base */
+
+#if defined (DRV_ANDROID) || defined (DRV_CHROMEOS)
+static struct class         *pmu_class   = NULL;
+#endif
+
+#if defined (DRV_ANDROID)
+#define DRV_DEVICE_DELIMITER "_"
+#elif defined (DRV_CHROMEOS)
+#define DRV_DEVICE_DELIMITER "/"
+#endif
+
+
+#if !defined(DRV_USE_UNLOCKED_IOCTL)
+#define MUTEX_INIT(lock)
+#define MUTEX_LOCK(lock)
+#define MUTEX_UNLOCK(lock)
+#else
+#define MUTEX_INIT(lock)     mutex_init(&(lock));
+#define MUTEX_LOCK(lock)     mutex_lock(&(lock))
+#define MUTEX_UNLOCK(lock)   mutex_unlock(&(lock))
+#endif
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn  static OS_STATUS lwpmudrv_Initialize_State(void)
+ *
+ * @param none
+ *
+ * @return OS_STATUS
+ *
+ * @brief  Allocates the memory needed at load time.  Initializes all the
+ * @brief  necessary state variables with the default values.
+ *
+ * <I>Special Notes</I>
+ */
+static OS_STATUS
+lwpmudrv_Initialize_State (
+    VOID
+)
+{
+    S32 i, max_cpu_id = 0;
+
+    for_each_possible_cpu(i) {
+        if (cpu_present(i)) {
+            if (i > max_cpu_id) {
+                max_cpu_id = i;
+            }
+        }
+    }
+    max_cpu_id++;
+
+    /*
+     *  Machine Initializations
+     *  Abstract this information away into a separate entry point
+     *
+     *  Question:  Should we allow for the use of Hot-cpu
+     *    add/subtract functionality while the driver is executing?
+     */
+    if (max_cpu_id > num_present_cpus()) {
+         GLOBAL_STATE_num_cpus(socperf_driver_state)     = max_cpu_id;
+    }
+    else {
+         GLOBAL_STATE_num_cpus(socperf_driver_state)     = num_present_cpus();
+    }
+    GLOBAL_STATE_active_cpus(socperf_driver_state)       = num_online_cpus();
+    GLOBAL_STATE_cpu_count(socperf_driver_state)         = 0;
+    GLOBAL_STATE_dpc_count(socperf_driver_state)         = 0;
+    GLOBAL_STATE_num_em_groups(socperf_driver_state)     = 0;
+    GLOBAL_STATE_current_phase(socperf_driver_state)     = DRV_STATE_UNINITIALIZED;
+
+    SOCPERF_PRINT_DEBUG("lwpmudrv_Initialize_State: num_cpus=%d, active_cpus=%d\n",
+                    GLOBAL_STATE_num_cpus(socperf_driver_state),
+                    GLOBAL_STATE_active_cpus(socperf_driver_state));
+
+    return OS_SUCCESS;
+}
+
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn       VOID SOCPERF_Read_Data
+ *
+ * @brief    Reads counter data
+ *
+ * @param    param   data_buffer - buffer for reading counter data.
+ *
+ * @return  None
+ *
+ * <I>Special Notes:</I>
+ *              <NONE>
+ */
+extern  VOID
+SOCPERF_Read_Data2 (
+    PVOID data_buffer
+)
+{
+    if (dispatch_uncore && dispatch_uncore->read_current_data) {
+        dispatch_uncore->read_current_data(data_buffer);
+    }
+    SOCPERF_PRINT_DEBUG("SOCPERF_Read_Data called\n");
+    return ;
+}
+EXPORT_SYMBOL(SOCPERF_Read_Data2);
+
+/*********************************************************************
+ *  Internal Driver functions
+ *     Should be called only from the lwpmudrv_DeviceControl routine
+ *********************************************************************/
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn  static OS_STATUS lwpmudrv_Version(IOCTL_ARGS arg)
+ *
+ * @param arg - pointer to the IOCTL_ARGS structure
+ *
+ * @return OS_STATUS
+ *
+ * @brief  Local function that handles the LWPMU_IOCTL_VERSION call.
+ * @brief  Returns the version number of the kernel mode sampling.
+ *
+ * <I>Special Notes</I>
+ */
+static OS_STATUS
+lwpmudrv_Version (
+    IOCTL_ARGS   arg
+)
+{
+    OS_STATUS status;
+
+    // Check if enough space is provided for collecting the data
+    if ((arg->r_len != sizeof(U32))  || (arg->r_buf == NULL)) {
+        return OS_FAULT;
+    }
+
+    status = put_user(SOCPERF_VERSION_NODE_socperf_version(&socperf_drv_version), (U32 *)arg->r_buf);
+
+    return status;
+}
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn  static VOID lwpmudrv_Clean_Up(DRV_BOOL)
+ *
+ * @param  DRV_BOOL finish - Flag to call finish
+ *
+ * @return VOID
+ *
+ * @brief  Cleans up the memory allocation.
+ *
+ * <I>Special Notes</I>
+ */
+static VOID
+lwpmudrv_Clean_Up (
+    DRV_BOOL finish
+)
+{
+    U32  i = 0;
+
+    if (dispatch_uncore && dispatch_uncore->clean_up) {
+        dispatch_uncore->clean_up((VOID*) &i);
+    }
+
+    if (device_uncore) {
+        EVENT_CONFIG  ec;
+        if (LWPMU_DEVICE_PMU_register_data(device_uncore)) {
+            ec =  LWPMU_DEVICE_ec(device_uncore);
+            for (i = 0; i < EVENT_CONFIG_num_groups_unc(ec); i++) {
+                SOCPERF_Free_Memory(LWPMU_DEVICE_PMU_register_data(device_uncore)[i]);
+            }
+        }
+        LWPMU_DEVICE_pcfg(device_uncore) = SOCPERF_Free_Memory(LWPMU_DEVICE_pcfg(device_uncore));
+        LWPMU_DEVICE_ec(device_uncore)   = SOCPERF_Free_Memory(LWPMU_DEVICE_ec(device_uncore));
+        device_uncore = SOCPERF_Free_Memory(device_uncore);
+    }
+
+    socperf_pcb             = SOCPERF_Free_Memory(socperf_pcb);
+    socperf_pcb_size                = 0;
+    GLOBAL_STATE_num_em_groups(socperf_driver_state)   = 0;
+    GLOBAL_STATE_num_descriptors(socperf_driver_state) = 0;
+
+    return;
+}
+
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn  static OS_STATUS lwpmudrv_Initialize_Uncore(PVOID in_buf, U32 in_buf_len)
+ *
+ * @param  in_buf       - pointer to the input buffer
+ * @param  in_buf_len   - size of the input buffer
+ *
+ * @return OS_STATUS
+ *
+ * @brief  Local function that handles the LWPMU_IOCTL_INIT call.
+ * @brief  Sets up the interrupt handler.
+ * @brief  Set up the output buffers/files needed to make the driver
+ * @brief  operational.
+ *
+ * <I>Special Notes</I>
+ */
+static OS_STATUS
+lwpmudrv_Initialize_Uncore (
+    PVOID         in_buf,
+    U32           in_buf_len
+)
+{
+    DRV_CONFIG  pcfg_unc;
+    U32         previous_state;
+    U32  i = 0;
+
+    SOCPERF_PRINT_DEBUG("Entered lwpmudrv_Initialize_UNC\n");
+    previous_state = cmpxchg(&GLOBAL_STATE_current_phase(socperf_driver_state),
+                             DRV_STATE_UNINITIALIZED,
+                             DRV_STATE_IDLE);
+
+    if (previous_state != DRV_STATE_UNINITIALIZED) {
+        SOCPERF_PRINT_ERROR("OS_IN_PROGRESS error!\n");
+        return OS_IN_PROGRESS;
+    }
+    /*
+     *   Program State Initializations:
+     *   Foreach device, copy over pcfg_unc and configure dispatch table
+     */
+    if (in_buf == NULL) {
+        SOCPERF_PRINT_ERROR("in_buff ERROR!\n");
+        return OS_FAULT;
+    }
+    if (in_buf_len != sizeof(DRV_CONFIG_NODE)) {
+        SOCPERF_PRINT_ERROR("Got in_buf_len=%d, expecting size=%d\n", in_buf_len, (int)sizeof(DRV_CONFIG_NODE));
+        return OS_FAULT;
+    }
+
+    device_uncore = SOCPERF_Allocate_Memory(sizeof(LWPMU_DEVICE_NODE));
+    if (!device_uncore) {
+        SOCPERF_PRINT_ERROR("Memory allocation failure for device_uncore!\n");
+        return OS_NO_MEM;
+    }
+    socperf_pcb_size = GLOBAL_STATE_num_cpus(socperf_driver_state)*sizeof(CPU_STATE_NODE);
+    socperf_pcb      = SOCPERF_Allocate_Memory(socperf_pcb_size);
+    if (!socperf_pcb) {
+        SOCPERF_PRINT_ERROR("Memory allocation failure for socperf_pcb!\n");
+        return OS_NO_MEM;
+    }
+
+    // allocate memory
+    LWPMU_DEVICE_pcfg(device_uncore) = SOCPERF_Allocate_Memory(sizeof(DRV_CONFIG_NODE));
+    if (!LWPMU_DEVICE_pcfg(device_uncore)) {
+        SOCPERF_PRINT_ERROR("Memory allocation failure for LWPMU_DEVICE_pcfg(device_uncore)!\n");
+        return OS_NO_MEM;
+    }
+    // copy over pcfg_unc
+    if (copy_from_user(LWPMU_DEVICE_pcfg(device_uncore), in_buf, in_buf_len)) {
+        SOCPERF_PRINT_ERROR("Failed to copy from user");
+        return OS_FAULT;
+    }
+    // configure dispatch from dispatch_id
+    pcfg_unc = (DRV_CONFIG)LWPMU_DEVICE_pcfg(device_uncore);
+
+    LWPMU_DEVICE_dispatch(device_uncore) = SOCPERF_UTILITY_Configure_CPU(DRV_CONFIG_dispatch_id(pcfg_unc));
+    if (LWPMU_DEVICE_dispatch(device_uncore) == NULL) {
+        SOCPERF_PRINT_ERROR("Unable to configure CPU");
+        return OS_FAULT;
+    }
+
+    LWPMU_DEVICE_em_groups_count(device_uncore) = 0;
+    LWPMU_DEVICE_cur_group(device_uncore)       = 0;
+    SOCPERF_PRINT_DEBUG("SocPerf Driver Config : uncore dispatch id   = %d\n", DRV_CONFIG_dispatch_id(pcfg_unc));
+    dispatch_uncore = LWPMU_DEVICE_dispatch(device_uncore);
+    if (dispatch_uncore && dispatch_uncore->init ) {
+        dispatch_uncore->init((VOID*) &i);
+    }
+
+    return OS_SUCCESS;
+}
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn  static OS_STATUS socperf_Terminate(void)
+ *
+ * @param  none
+ *
+ * @return OS_STATUS
+ *
+ * @brief  Local function that handles the LWPMUDRV_IOCTL_TERMINATE call.
+ * @brief  Cleans up the interrupt handler and resets the PMU state.
+ *
+ * <I>Special Notes</I>
+ */
+static OS_STATUS
+socperf_Terminate (
+    VOID
+)
+{
+    U32            previous_state;
+
+    if (GLOBAL_STATE_current_phase(socperf_driver_state) == DRV_STATE_UNINITIALIZED) {
+        return OS_SUCCESS;
+    }
+
+    previous_state = cmpxchg(&GLOBAL_STATE_current_phase(socperf_driver_state),
+                             DRV_STATE_STOPPED,
+                             DRV_STATE_UNINITIALIZED);
+    if (previous_state != DRV_STATE_STOPPED) {
+        SOCPERF_PRINT_ERROR("socperf_Terminate: Sampling is in progress, cannot terminate.\n");
+        return OS_IN_PROGRESS;
+    }
+
+    GLOBAL_STATE_current_phase(socperf_driver_state) = DRV_STATE_UNINITIALIZED;
+    lwpmudrv_Clean_Up(TRUE);
+
+    return OS_SUCCESS;
+}
+
+
+
+
+
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn static OS_STATUS lwpmudrv_Trigger_Read(void)
+ *
+ * @param - none
+ *
+ * @return - OS_STATUS
+ *
+ * @brief Read the Counter Data.
+ *
+ * <I>Special Notes</I>
+ */
+static OS_STATUS
+lwpmudrv_Trigger_Read (
+    VOID
+)
+{
+    dispatch_uncore = LWPMU_DEVICE_dispatch(device_uncore);
+    if (dispatch_uncore && dispatch_uncore->trigger_read ) {
+        dispatch_uncore->trigger_read();
+    }
+
+    return OS_SUCCESS;
+}
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn static OS_STATUS lwpmudrv_Init_PMU(void)
+ *
+ * @param - none
+ *
+ * @return - OS_STATUS
+ *
+ * @brief Initialize the PMU and the driver state in preparation for data collection.
+ *
+ * <I>Special Notes</I>
+ */
+static OS_STATUS
+lwpmudrv_Init_PMU (
+    VOID
+)
+{
+    U32        i = 0;
+
+    if (GLOBAL_STATE_current_phase(socperf_driver_state) != DRV_STATE_IDLE) {
+        return OS_IN_PROGRESS;
+    }
+    dispatch_uncore = LWPMU_DEVICE_dispatch(device_uncore);
+    if (dispatch_uncore && dispatch_uncore->write) {
+        dispatch_uncore->write((VOID *)&i);
+    }
+    SOCPERF_PRINT_DEBUG("lwpmudrv_Init_PMU: IOCTL_Init_PMU - finished initial Write\n");
+
+    return OS_SUCCESS;
+}
+
+
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn static OS_STATUS lwpmudrv_Set_EM_Config_UNC(IOCTL_ARGS arg)
+ *
+ * @param arg - pointer to the IOCTL_ARGS structure
+ *
+ * @return OS_STATUS
+ *
+ * @brief  Set the number of em groups in the global state node.
+ * @brief  Also, copy the EVENT_CONFIG struct that has been passed in,
+ * @brief  into a global location for now.
+ *
+ * <I>Special Notes</I>
+ */
+static OS_STATUS
+lwpmudrv_Set_EM_Config_Uncore (
+    IOCTL_ARGS arg
+)
+{
+    EVENT_CONFIG    ec;
+    SOCPERF_PRINT_DEBUG("enter lwpmudrv_Set_EM_Config_UNC\n");
+    if (GLOBAL_STATE_current_phase(socperf_driver_state) != DRV_STATE_IDLE) {
+        return OS_IN_PROGRESS;
+    }
+
+    if (arg->w_buf == NULL || arg->w_len == 0) {
+        return OS_INVALID;
+    }
+    // allocate memory
+    LWPMU_DEVICE_ec(device_uncore) = SOCPERF_Allocate_Memory(sizeof(EVENT_CONFIG_NODE));
+    if (!LWPMU_DEVICE_ec(device_uncore)) {
+        SOCPERF_PRINT_ERROR("Memory allocation failure for LWPMU_DEVICE_ec(device_uncore)!\n");
+        return OS_NO_MEM;
+    }
+    if (copy_from_user(LWPMU_DEVICE_ec(device_uncore), arg->w_buf, arg->w_len)) {
+        return OS_FAULT;
+    }
+    // configure num_groups from ec of the specific device
+    ec = (EVENT_CONFIG)LWPMU_DEVICE_ec(device_uncore);
+    LWPMU_DEVICE_PMU_register_data(device_uncore) = SOCPERF_Allocate_Memory(EVENT_CONFIG_num_groups_unc(ec) *
+                                                                                   sizeof(VOID *));
+    if (!LWPMU_DEVICE_PMU_register_data(device_uncore)) {
+        SOCPERF_PRINT_ERROR("Memory allocation failure for LWPMU_DEVICE_PMU_register_data(device_uncore)!\n");
+        return OS_NO_MEM;
+    }
+    LWPMU_DEVICE_em_groups_count(device_uncore) = 0;
+
+    return OS_SUCCESS;
+}
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn static OS_STATUS socperf_Configure_Events_Uncore (IOCTL_ARGS arg)
+ *
+ * @param arg - pointer to the IOCTL_ARGS structure
+ *
+ * @return OS_STATUS
+ *
+ * @brief  Make a copy of the uncore registers that need to be programmed
+ * @brief  for the next event set used for event multiplexing
+ *
+ * <I>Special Notes</I>
+ */
+static OS_STATUS
+socperf_Configure_Events_Uncore (
+    IOCTL_ARGS arg
+)
+{
+    VOID              **PMU_register_data_unc;
+    S32               em_groups_count_unc;
+    ECB               ecb;
+    EVENT_CONFIG      ec_unc;
+    U32               group_id = 0;
+    ECB               in_ecb   = NULL;
+
+    if (GLOBAL_STATE_current_phase(socperf_driver_state) != DRV_STATE_IDLE) {
+        return OS_IN_PROGRESS;
+    }
+
+    em_groups_count_unc = LWPMU_DEVICE_em_groups_count(device_uncore);
+    PMU_register_data_unc = LWPMU_DEVICE_PMU_register_data(device_uncore);
+    ec_unc                = LWPMU_DEVICE_ec(device_uncore);
+
+    if (ec_unc == NULL) {
+        SOCPERF_PRINT_ERROR("socperf_Configure_Events_Uncore: ec_unc is NULL!\n");
+        return OS_INVALID;
+    }
+
+    if (em_groups_count_unc >= (S32)EVENT_CONFIG_num_groups_unc(ec_unc)) {
+        SOCPERF_PRINT_ERROR("socperf_Configure_Events_Uncore: Number of Uncore EM groups exceeded the initial configuration.");
+        return OS_INVALID;
+    }
+    if (arg->w_buf == NULL || arg->w_len < sizeof(ECB_NODE)) {
+        SOCPERF_PRINT_ERROR("socperf_Configure_Events_Uncore: args are invalid.");
+        return OS_INVALID;
+    }
+    //       size is in w_len, data is pointed to by w_buf
+    //
+    in_ecb = SOCPERF_Allocate_Memory(arg->w_len);
+    if (!in_ecb) {
+        SOCPERF_PRINT_ERROR("socperf_Configure_Events_Uncore: ECB memory allocation failed\n");
+        return OS_NO_MEM;
+    }
+    if (copy_from_user(in_ecb, arg->w_buf, arg->w_len)) {
+        SOCPERF_PRINT_ERROR("socperf_Configure_Events_Uncore: ECB copy failed\n");
+        in_ecb = SOCPERF_Free_Memory(in_ecb);
+        return OS_NO_MEM;
+    }
+
+    group_id                        = ECB_group_id(in_ecb);
+    if (group_id >= EVENT_CONFIG_num_groups_unc(ec_unc)) {
+        SOCPERF_PRINT_ERROR("socperf_Configure_Events_Uncore: group_id is larger than total number of groups\n");
+        in_ecb = SOCPERF_Free_Memory(in_ecb);
+        return OS_INVALID;
+    }
+
+    PMU_register_data_unc[group_id] = in_ecb;
+    if (!PMU_register_data_unc[group_id]) {
+        SOCPERF_PRINT_ERROR("socperf_Configure_Events_Uncore: ECB memory allocation failed\n");
+        in_ecb = SOCPERF_Free_Memory(in_ecb);
+        return OS_NO_MEM;
+    }
+
+    //
+    // Make a copy of the data for global use.
+    //
+    if (copy_from_user(PMU_register_data_unc[group_id], arg->w_buf, arg->w_len)) {
+        SOCPERF_PRINT_ERROR("socperf_Configure_Events_Uncore: ECB copy failed\n");
+        in_ecb = SOCPERF_Free_Memory(in_ecb);
+        return OS_NO_MEM;
+    }
+
+    // at this point, we know the number of uncore events for this device,
+    // so allocate the results buffer per thread for uncore only for event based uncore counting
+    if (em_groups_count_unc == 0) {
+        ecb = PMU_register_data_unc[0];
+        if (ecb == NULL) {
+            in_ecb = SOCPERF_Free_Memory(in_ecb);
+            return OS_INVALID;
+        }
+        LWPMU_DEVICE_num_events(device_uncore) = ECB_num_events(ecb);
+    }
+    LWPMU_DEVICE_em_groups_count(device_uncore) = group_id + 1;
+
+    return OS_SUCCESS;
+}
+
+
+
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn static OS_STATUS socperf_Start(void)
+ *
+ * @param none
+ *
+ * @return OS_STATUS
+ *
+ * @brief  Local function that handles the LWPMU_IOCTL_START call.
+ * @brief  Set up the OS hooks for process/thread/load notifications.
+ * @brief  Write the initial set of MSRs.
+ *
+ * <I>Special Notes</I>
+ */
+static OS_STATUS
+socperf_Start (
+    VOID
+)
+{
+    OS_STATUS  status       = OS_SUCCESS;
+    U32        previous_state;
+    U32        i = 0;
+
+    /*
+     * To Do: Check for state == STATE_IDLE and only then enable sampling
+     */
+    previous_state = cmpxchg(&GLOBAL_STATE_current_phase(socperf_driver_state),
+                             DRV_STATE_IDLE,
+                             DRV_STATE_RUNNING);
+    if (previous_state != DRV_STATE_IDLE) {
+        SOCPERF_PRINT_ERROR("socperf_Start: Unable to start sampling - State is %d\n",
+                        GLOBAL_STATE_current_phase(socperf_driver_state));
+        return OS_IN_PROGRESS;
+    }
+
+    if (dispatch_uncore && dispatch_uncore->restart) {
+        dispatch_uncore->restart((VOID*)&i);
+    }
+
+    return status;
+}
+
+/*
+ * @fn lwpmudrv_Prepare_Stop();
+ *
+ * @param        NONE
+ * @return       OS_STATUS
+ *
+ * @brief  Local function that handles the LWPMUDRV_IOCTL_STOP call.
+ * @brief  Cleans up the interrupt handler.
+ */
+static OS_STATUS
+socperf_Prepare_Stop (
+    VOID
+)
+{
+    U32 i = 0;
+    U32 current_state       = GLOBAL_STATE_current_phase(socperf_driver_state);
+
+    SOCPERF_PRINT_DEBUG("socperf_Prepare_Stop: About to stop sampling\n");
+    GLOBAL_STATE_current_phase(socperf_driver_state) = DRV_STATE_PREPARE_STOP;
+
+    if (current_state == DRV_STATE_UNINITIALIZED) {
+        return OS_SUCCESS;
+    }
+
+    if (dispatch_uncore && dispatch_uncore->freeze) {
+        dispatch_uncore->freeze((VOID*) &i);
+    }
+
+    return OS_SUCCESS;
+}
+
+/*
+ * @fn socperf_Finish_Stop();
+ *
+ * @param  NONE
+ * @return OS_STATUS
+ *
+ * @brief  Local function that handles the LWPMUDRV_IOCTL_STOP call.
+ * @brief  Cleans up the interrupt handler.
+ */
+static OS_STATUS
+socperf_Finish_Stop (
+    VOID
+)
+{
+    OS_STATUS  status        = OS_SUCCESS;
+
+    GLOBAL_STATE_current_phase(socperf_driver_state) = DRV_STATE_STOPPED;
+
+    return status;
+}
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn static OS_STATUS lwpmudrv_Pause(void)
+ *
+ * @param - none
+ *
+ * @return OS_STATUS
+ *
+ * @brief Pause the collection
+ *
+ * <I>Special Notes</I>
+ */
+static OS_STATUS
+lwpmudrv_Pause (
+    VOID
+)
+{
+    U32        previous_state;
+    U32        i = 0;
+
+    previous_state = cmpxchg(&GLOBAL_STATE_current_phase(socperf_driver_state),
+                             DRV_STATE_RUNNING,
+                             DRV_STATE_PAUSED);
+    if (previous_state == DRV_STATE_RUNNING) {
+        dispatch_uncore = LWPMU_DEVICE_dispatch(device_uncore);
+        if (dispatch_uncore && dispatch_uncore->freeze ) {
+            dispatch_uncore->freeze((VOID *)&i);
+        }
+    }
+    else {
+        if (previous_state == DRV_STATE_PAUSED) {
+            return VT_SAMP_IN_PAUSE_STATE;
+        }
+        SOCPERF_PRINT_ERROR("There is no sampling collection running at this time\n");
+        return VT_SAMP_IN_STOP_STATE;
+    }
+
+    return OS_SUCCESS;
+}
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn static NTSTATUS lwpmudrv_Resume(void)
+ *
+ * @param - none
+ *
+ * @return OS_STATUS
+ *
+ * @brief Resume the sampling after a pause.  Assumption, the pause duration
+ * @brief will be long enough for all interrupts to be processed and no
+ * @brief active sampling to occur.
+ *
+ * <I>Special Notes</I>
+ */
+static OS_STATUS
+lwpmudrv_Resume (
+    VOID
+)
+{
+    U32        previous_state;
+    U32        i = 0;
+
+    previous_state = cmpxchg(&GLOBAL_STATE_current_phase(socperf_driver_state),
+                             DRV_STATE_PAUSED,
+                             DRV_STATE_RUNNING);
+
+
+    if (previous_state == DRV_STATE_PAUSED) {
+        dispatch_uncore = LWPMU_DEVICE_dispatch(device_uncore);
+        if (dispatch_uncore && dispatch_uncore->restart ) {
+            dispatch_uncore->restart((VOID *)&i);
+        }
+        SOCPERF_PRINT_DEBUG("Resuming the sampling collection...\n");
+    }
+    else {
+        SOCPERF_PRINT_DEBUG("There is no paused sampling collection at this time.\n");
+    }
+
+    return OS_SUCCESS;
+}
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn static OS_STATUS lwpmudrv_Read_Uncore_Counts(void out_buf, U32 out_buf_len)
+ *
+ * @param - out_buf       - output buffer
+ *          out_buf_len   - output buffer length
+ *
+ * @return - OS_STATUS
+ *
+ * @brief    Read the Counter Data.
+ *
+ * <I>Special Notes</I>
+ */
+static OS_STATUS
+lwpmudrv_Read_Uncore_Counts (
+    PVOID         out_buf,
+    U32           out_buf_len
+)
+{
+    if (out_buf == NULL) {
+        SOCPERF_PRINT_ERROR("lwpmudrv_Read_Uncore_Counts: counter buffer is NULL\n");
+        return OS_FAULT;
+    }
+
+    if (dispatch_uncore && dispatch_uncore->read_current_data) {
+        dispatch_uncore->read_current_data(out_buf);
+    }
+
+    return OS_SUCCESS;
+}
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn  static OS_STATUS SOCPERF_Switch_Group(void)
+ *
+ * @param none
+ *
+ * @return OS_STATUS
+ *
+ * @brief Switch the current uncore group that is being collected.
+ *
+ * <I>Special Notes</I>
+ *     This routine is called from the user mode code to handle the multiple uncore group
+ *     situation.  4 distinct steps are taken:
+ *     Step 1: Pause the sampling
+ *     Step 2: Increment the current uncore group count
+ *     Step 3: Write the new group to the uncore PMU
+ *     Step 4: Resume sampling
+ */
+OS_STATUS
+SOCPERF_Switch_Group2 (
+    VOID
+)
+{
+    OS_STATUS       status        = OS_SUCCESS;
+    U32            current_state = GLOBAL_STATE_current_phase(socperf_driver_state);
+    U32            i = 0;
+    DRV_CONFIG     pcfg_unc;
+
+    SOCPERF_PRINT_DEBUG("Switching Uncore Group...\n");
+    if (current_state != DRV_STATE_RUNNING &&
+        current_state != DRV_STATE_PAUSED) {
+        return status;
+    }
+    status = lwpmudrv_Pause();
+    LWPMU_DEVICE_cur_group(device_uncore)++;
+    LWPMU_DEVICE_cur_group(device_uncore) %= LWPMU_DEVICE_em_groups_count(device_uncore);
+    dispatch_uncore = LWPMU_DEVICE_dispatch(device_uncore);
+    if (dispatch_uncore && dispatch_uncore->write ) {
+        dispatch_uncore->write((VOID *)&i);
+    }
+
+    pcfg_unc = (DRV_CONFIG)LWPMU_DEVICE_pcfg(device_uncore);
+    if (pcfg_unc && (DRV_CONFIG_start_paused(pcfg_unc) == FALSE)) {
+        status = lwpmudrv_Resume();
+    }
+
+    return status;
+}
+EXPORT_SYMBOL(SOCPERF_Switch_Group2);
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn static OS_STATUS lwpmudrv_Create_Mem(IOCTL_ARGS arg)
+ *
+ * @param - none
+ *
+ * @return - OS_STATUS
+ *
+ * @brief Read the Counter Data.
+ *
+ * <I>Special Notes</I>
+ */
+static OS_STATUS
+lwpmudrv_Create_Mem (
+    IOCTL_ARGS arg
+)
+{
+    U32   memory_size           = 0;
+    U64   trace_phys_address = 0;
+
+    if (arg->w_buf == NULL || arg->w_len == 0) {
+        SOCPERF_PRINT_ERROR("lwpmudrv_Create_Mem: Counter buffer is NULL\n");
+        return OS_FAULT;
+    }
+
+    if (copy_from_user(&memory_size, (U32*)arg->w_buf, sizeof(U32))) {
+        return OS_FAULT;
+    }
+
+    if (arg->r_buf == NULL || arg->r_len == 0) {
+        SOCPERF_PRINT_ERROR("lwpmudrv_Create_Mem: output buffer is NULL\n");
+        return OS_FAULT;
+    }
+    SOCPERF_PRINT_DEBUG("Read size=%llx\n", arg->r_len);
+    SOCPERF_PRINT_DEBUG("Write size=%llx\n", arg->w_len);
+    if (arg->r_len != sizeof(U64)) {
+        return OS_FAULT;
+    }
+
+    dispatch_uncore = LWPMU_DEVICE_dispatch(device_uncore);
+    if (dispatch_uncore && dispatch_uncore->create_mem) {
+        dispatch_uncore->create_mem(memory_size, &trace_phys_address);
+    }
+    else {
+        SOCPERF_PRINT_ERROR("dispatch table could not be called\n");
+    }
+
+    if (copy_to_user(arg->r_buf, (void*)&trace_phys_address, sizeof(U64))) {
+        return OS_FAULT;
+    }
+
+    return OS_SUCCESS;
+}
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn static OS_STATUS lwpmudrv_Check_Status( IOCTL_ARGS arg)
+ *
+ * @param - none
+ *
+ * @return - OS_STATUS
+ *
+ * @brief Read the Counter Data.
+ *
+ * <I>Special Notes</I>
+ */
+static OS_STATUS
+lwpmudrv_Check_Status (
+    IOCTL_ARGS arg
+)
+{
+    U32   num_entries = 0;
+    U64  *status_data = 0;
+
+    if ((arg->r_len == 0) || (arg->r_buf == NULL)) {
+        return OS_FAULT;
+    }
+
+    status_data = SOCPERF_Allocate_Memory(arg->r_len);
+    if (dispatch_uncore && dispatch_uncore->check_status) {
+        dispatch_uncore->check_status(status_data,  &num_entries);
+    }
+
+    if (copy_to_user(arg->r_buf, (void*)status_data, num_entries*sizeof(U64))) {
+        SOCPERF_Free_Memory(status_data);
+        return OS_FAULT;
+    }
+    SOCPERF_Free_Memory(status_data);
+
+    return OS_SUCCESS;
+}
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn static OS_STATUS lwpmudrv_Read_Mem( IOCTL_ARGS arg)
+ *
+ * @param - none
+ *
+ * @return - OS_STATUS
+ *
+ * @brief Read the Counter Data.
+ *
+ * <I>Special Notes</I>
+ */
+static OS_STATUS
+lwpmudrv_Read_Mem (
+ IOCTL_ARGS  arg
+)
+{
+    U64   start_address   = 0;
+    U64  *mem_address     = NULL;
+    U32   mem_size        = 0;
+    U32   num_entries     = 0;
+
+     if (arg->w_buf == NULL || arg->w_len == 0) {
+        SOCPERF_PRINT_ERROR("lwpmudrv_Read_Mem: Counter buffer is NULL\n");
+        return OS_FAULT;
+    }
+
+    if (copy_from_user(&start_address, (U64*)arg->w_buf, sizeof(U64))) {
+        return OS_FAULT;
+    }
+
+    if ((arg->r_len == 0) || (arg->r_buf == NULL)) {
+        return OS_FAULT;
+    }
+    mem_size = (U32) arg->r_len;
+    mem_address = SOCPERF_Allocate_Memory(mem_size);
+    if (!mem_address) {
+        return OS_NO_MEM;
+    }
+
+    num_entries = (U32)(mem_size/sizeof(U64));
+    if (dispatch_uncore && dispatch_uncore->read_mem) {
+        dispatch_uncore->read_mem(start_address, mem_address, num_entries);
+    }
+    if (copy_to_user(arg->r_buf, (void*)mem_address, mem_size)) {
+        SOCPERF_Free_Memory(mem_address);
+        return OS_FAULT;
+    }
+    SOCPERF_Free_Memory(mem_address);
+
+    return OS_SUCCESS;
+}
+
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn static VOID lwpmudrv_Stop_Mem(void)
+ *
+ * @param - none
+ *
+ * @return - none
+ *
+ * @brief Stop Mem
+ *
+ * <I>Special Notes</I>
+ */
+extern VOID
+lwpmudrv_Stop_Mem (
+    VOID
+)
+{
+    SOCPERF_PRINT_DEBUG("Entered lwpmudrv_Stop_Mem\n");
+
+    if (dispatch_uncore && dispatch_uncore->stop_mem) {
+        dispatch_uncore->stop_mem();
+    }
+
+    SOCPERF_PRINT_DEBUG("Exited lwpmudrv_Stop_Mem\n");
+
+    return;
+}
+
+
+/*******************************************************************************
+ *  External Driver functions - Open
+ *      This function is common to all drivers
+ *******************************************************************************/
+
+static int
+socperf_Open (
+    struct inode *inode,
+    struct file  *filp
+)
+{
+    SOCPERF_PRINT_DEBUG("lwpmu_Open called on maj:%d, min:%d\n",
+            imajor(inode), iminor(inode));
+    filp->private_data = container_of(inode->i_cdev, LWPMU_DEV_NODE, cdev);
+
+    return 0;
+}
+
+/*******************************************************************************
+ *  External Driver functions
+ *      These functions are registered into the file operations table that
+ *      controls this device.
+ *      Open, Close, Read, Write, Release
+ *******************************************************************************/
+
+static ssize_t
+socperf_Read (
+    struct file  *filp,
+    char         *buf,
+    size_t        count,
+    loff_t       *f_pos
+)
+{
+    unsigned long retval;
+
+    /* Transfering data to user space */
+    SOCPERF_PRINT_DEBUG("lwpmu_Read dispatched with count=%d\n", (S32)count);
+    if (copy_to_user(buf, &LWPMU_DEV_buffer(socperf_control), 1)) {
+        retval = OS_FAULT;
+        return retval;
+    }
+    /* Changing reading position as best suits */
+    if (*f_pos == 0) {
+        *f_pos+=1;
+        return 1;
+    }
+
+    return 0;
+}
+
+static ssize_t
+socperf_Write (
+    struct file  *filp,
+    const  char  *buf,
+    size_t        count,
+    loff_t       *f_pos
+)
+{
+    unsigned long retval;
+
+    SOCPERF_PRINT_DEBUG("lwpmu_Write dispatched with count=%d\n", (S32)count);
+    if (copy_from_user(&LWPMU_DEV_buffer(socperf_control), buf+count-1, 1)) {
+        retval = OS_FAULT;
+        return retval;
+    }
+
+    return 1;
+}
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn  extern IOCTL_OP_TYPE socperf_Service_IOCTL(IOCTL_USE_NODE, filp, cmd, arg)
+ *
+ * @param   IOCTL_USE_INODE       - Used for pre 2.6.32 kernels
+ * @param   struct   file   *filp - file pointer
+ * @param   unsigned int     cmd  - IOCTL command
+ * @param   unsigned long    arg  - args to the IOCTL command
+ *
+ * @return OS_STATUS
+ *
+ * @brief  Worker function that handles IOCTL requests from the user mode.
+ *
+ * <I>Special Notes</I>
+ */
+extern IOCTL_OP_TYPE
+socperf_Service_IOCTL (
+    IOCTL_USE_INODE
+    struct   file   *filp,
+    unsigned int     cmd,
+    IOCTL_ARGS_NODE  local_args
+)
+{
+    int status = OS_SUCCESS;
+
+    switch (cmd) {
+
+       /*
+        * Common IOCTL commands
+        */
+        case  DRV_OPERATION_VERSION:
+            SOCPERF_PRINT_DEBUG(" DRV_OPERATION_VERSION\n");
+            status = lwpmudrv_Version(&local_args);
+            break;
+
+        case  DRV_OPERATION_RESERVE:
+            SOCPERF_PRINT_DEBUG(" DRV_OPERATION_RESERVE\n");
+            break;
+
+        case  DRV_OPERATION_INIT_PMU:
+            SOCPERF_PRINT_DEBUG(" DRV_OPERATION_INIT_PMU\n");
+            status = lwpmudrv_Init_PMU();
+            break;
+
+        case  DRV_OPERATION_START:
+            SOCPERF_PRINT_DEBUG(" DRV_OPERATION_START\n");
+            status = socperf_Start();
+            break;
+
+        case  DRV_OPERATION_STOP:
+            SOCPERF_PRINT_DEBUG(" DRV_OPERATION_STOP\n");
+            status = socperf_Prepare_Stop();
+            break;
+
+        case  DRV_OPERATION_PAUSE:
+            SOCPERF_PRINT_DEBUG(" DRV_OPERATION_PAUSE\n");
+            status = lwpmudrv_Pause();
+            break;
+
+        case  DRV_OPERATION_RESUME:
+            SOCPERF_PRINT_DEBUG(" DRV_OPERATION_RESUME\n");
+            status = lwpmudrv_Resume();
+            break;
+
+        case  DRV_OPERATION_TERMINATE:
+            SOCPERF_PRINT_DEBUG(" DRV_OPERATION_TERMINATE\n");
+            status = socperf_Terminate();
+            break;
+
+        case  DRV_OPERATION_INIT_UNCORE:
+            SOCPERF_PRINT_DEBUG(" DRV_OPERATION_INIT_UNCORE\n");
+            status = lwpmudrv_Initialize_Uncore(local_args.w_buf, local_args.w_len);
+            break;
+        case  DRV_OPERATION_EM_GROUPS_UNCORE:
+            SOCPERF_PRINT_DEBUG(" DRV_OPERATION_EM_GROUPS_UNC\n");
+            status = lwpmudrv_Set_EM_Config_Uncore(&local_args);
+            break;
+
+        case  DRV_OPERATION_EM_CONFIG_NEXT_UNCORE:
+            SOCPERF_PRINT_DEBUG(" DRV_OPERATION_EM_CONFIG_NEXT_UNC\n");
+            status = socperf_Configure_Events_Uncore(&local_args);
+            break;
+
+        case  DRV_OPERATION_TIMER_TRIGGER_READ:
+            lwpmudrv_Trigger_Read();
+            break;
+
+       case  DRV_OPERATION_READ_UNCORE_DATA:
+            SOCPERF_PRINT_DEBUG(" DRV_OPERATION_READ_UNCORE_DATA\n");
+            status = lwpmudrv_Read_Uncore_Counts(local_args.r_buf, local_args.r_len);
+            break;
+
+
+        case  DRV_OPERATION_CREATE_MEM:
+            SOCPERF_PRINT_DEBUG(" DRV_OPERATION_CREATE_MEM\n");
+            lwpmudrv_Create_Mem(&local_args);
+            break;
+
+        case  DRV_OPERATION_READ_MEM:
+            SOCPERF_PRINT_DEBUG(" DRV_OPERATION_READ_MEM\n");
+            lwpmudrv_Read_Mem(&local_args);
+            break;
+
+        case  DRV_OPERATION_CHECK_STATUS:
+            SOCPERF_PRINT_DEBUG(" DRV_OPERATION_CHECK_STATUS\n");
+            lwpmudrv_Check_Status(&local_args);
+            break;
+
+        case  DRV_OPERATION_STOP_MEM:
+            SOCPERF_PRINT_DEBUG(" DRV_OPERATION_STOP_MEM\n");
+            lwpmudrv_Stop_Mem();
+            break;
+
+       /*
+        * if none of the above, treat as unknown/illegal IOCTL command
+        */
+        default:
+            SOCPERF_PRINT_ERROR("Unknown IOCTL magic:%d number:%d\n",
+                    _IOC_TYPE(cmd), _IOC_NR(cmd));
+            status = OS_ILLEGAL_IOCTL;
+            break;
+    }
+
+    if (cmd ==  DRV_OPERATION_STOP &&
+        GLOBAL_STATE_current_phase(socperf_driver_state) == DRV_STATE_PREPARE_STOP) {
+        status = socperf_Finish_Stop();
+    }
+
+    return status;
+}
+
+extern long
+socperf_Device_Control (
+    IOCTL_USE_INODE
+    struct   file   *filp,
+    unsigned int     cmd,
+    unsigned long    arg
+)
+{
+    int              status = OS_SUCCESS;
+    IOCTL_ARGS_NODE  local_args;
+
+#if !defined(DRV_USE_UNLOCKED_IOCTL)
+    SOCPERF_PRINT_DEBUG("lwpmu_DeviceControl(0x%x) called on inode maj:%d, min:%d\n",
+            cmd, imajor(inode), iminor(inode));
+#endif
+    SOCPERF_PRINT_DEBUG("type: %d, subcommand: %d\n", _IOC_TYPE(cmd), _IOC_NR(cmd));
+
+    if (_IOC_TYPE(cmd) != LWPMU_IOC_MAGIC) {
+        SOCPERF_PRINT_ERROR("Unknown IOCTL magic:%d\n", _IOC_TYPE(cmd));
+        return OS_ILLEGAL_IOCTL;
+    }
+
+    MUTEX_LOCK(ioctl_lock);
+    if (arg) {
+        status = copy_from_user(&local_args, (IOCTL_ARGS)arg, sizeof(IOCTL_ARGS_NODE));
+    }
+
+    status = socperf_Service_IOCTL (IOCTL_USE_INODE filp, _IOC_NR(cmd), local_args);
+    MUTEX_UNLOCK(ioctl_lock);
+
+    return  status;
+}
+
+
+#if defined(CONFIG_COMPAT) && defined(DRV_EM64T)
+extern long
+socperf_Device_Control_Compat (
+    struct   file   *filp,
+    unsigned int     cmd,
+    unsigned long    arg
+)
+{
+    int                     status = OS_SUCCESS;
+    IOCTL_COMPAT_ARGS_NODE  local_args_compat;
+    IOCTL_ARGS_NODE         local_args;
+
+    memset(&local_args_compat, 0, sizeof(IOCTL_COMPAT_ARGS_NODE));
+    SOCPERF_PRINT_DEBUG("Compat: type: %d, subcommand: %d\n", _IOC_TYPE(cmd), _IOC_NR(cmd));
+
+    if (_IOC_TYPE(cmd) != LWPMU_IOC_MAGIC) {
+        SOCPERF_PRINT_ERROR("Unknown IOCTL magic:%d\n", _IOC_TYPE(cmd));
+        return OS_ILLEGAL_IOCTL;
+    }
+
+    MUTEX_LOCK(ioctl_lock);
+    if (arg) {
+        status = copy_from_user(&local_args_compat, (IOCTL_COMPAT_ARGS)arg, sizeof(IOCTL_COMPAT_ARGS_NODE));
+    }
+    local_args.r_len = local_args_compat.r_len;
+    local_args.w_len = local_args_compat.w_len;
+    local_args.r_buf = (char *) compat_ptr(local_args_compat.r_buf);
+    local_args.w_buf = (char *) compat_ptr(local_args_compat.w_buf);
+
+    status = socperf_Service_IOCTL (filp, _IOC_NR(cmd), local_args);
+    MUTEX_UNLOCK(ioctl_lock);
+
+    return status;
+}
+#endif
+
+/*
+ * @fn        SOCPERF_Abnormal_Terminate(void)
+ *
+ * @brief     This routine is called from linuxos_Exit_Task_Notify if the user process has
+ *            been killed by an uncatchable signal (example kill -9).  The state variable
+ *            abormal_terminate is set to 1 and the clean up routines are called.  In this
+ *            code path the OS notifier hooks should not be unloaded.
+ *
+ * @param     None
+ *
+ * @return    OS_STATUS
+ *
+ * <I>Special Notes:</I>
+ *     <none>
+ */
+extern int
+SOCPERF_Abnormal_Terminate (
+    void
+)
+{
+    int              status = OS_SUCCESS;
+
+    socperf_abnormal_terminate = 1;
+    SOCPERF_PRINT_DEBUG("Abnormal-Termination: Calling socperf_Prepare_Stop\n");
+    status = socperf_Prepare_Stop();
+    SOCPERF_PRINT_DEBUG("Abnormal-Termination: Calling socperf_Finish_Stop\n");
+    status = socperf_Finish_Stop();
+    SOCPERF_PRINT_DEBUG("Abnormal-Termination: Calling lwpmudrv_Terminate\n");
+    status = socperf_Terminate();
+
+    return status;
+}
+
+
+/*****************************************************************************************
+ *
+ *   Driver Entry / Exit functions that will be called on when the driver is loaded and
+ *   unloaded
+ *
+ ****************************************************************************************/
+
+/*
+ * Structure that declares the usual file access functions
+ * First one is for lwpmu_c, the control functions
+ */
+static struct file_operations socperf_Fops = {
+    .owner =   THIS_MODULE,
+    IOCTL_OP = socperf_Device_Control,
+#if defined(CONFIG_COMPAT) && defined(DRV_EM64T)
+    .compat_ioctl = socperf_Device_Control_Compat,
+#endif
+    .read =    socperf_Read,
+    .write =   socperf_Write,
+    .open =    socperf_Open,
+    .release = NULL,
+    .llseek =  NULL,
+};
+
+/*!
+ * @fn  static int lwpmudrv_setup_cdev(dev, fops, dev_number)
+ *
+ * @param LWPMU_DEV               dev  - pointer to the device object
+ * @param struct file_operations *fops - pointer to the file operations struct
+ * @param dev_t                   dev_number - major/monor device number
+ *
+ * @return OS_STATUS
+ *
+ * @brief  Set up the device object.
+ *
+ * <I>Special Notes</I>
+ */
+static int
+lwpmu_setup_cdev (
+    LWPMU_DEV               dev,
+    struct file_operations *fops,
+    dev_t                   dev_number
+)
+{
+    cdev_init(&LWPMU_DEV_cdev(dev), fops);
+    LWPMU_DEV_cdev(dev).owner = THIS_MODULE;
+    LWPMU_DEV_cdev(dev).ops   = fops;
+
+    return cdev_add(&LWPMU_DEV_cdev(dev), dev_number, 1);
+}
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn  static int socperf_Load(void)
+ *
+ * @param none
+ *
+ * @return STATUS
+ *
+ * @brief  Load the driver module into the kernel.  Set up the driver object.
+ * @brief  Set up the initial state of the driver and allocate the memory
+ * @brief  needed to keep basic state information.
+ */
+static int
+socperf_Load (
+    VOID
+)
+{
+    int        num_cpus;
+    OS_STATUS  status      = OS_SUCCESS;
+
+    SOCPERF_Memory_Tracker_Init();
+
+    /* Get one major device number and one minor number. */
+    /*   The result is formatted as major+minor(0) */
+    /*   One minor number is for control (lwpmu_c), */
+    SOCPERF_PRINT("SocPerf Driver loading...\n");
+    SOCPERF_PRINT("SocPerf Driver about to register chrdev...\n");
+
+    lwpmu_DevNum = MKDEV(0, 0);
+    status = alloc_chrdev_region(&lwpmu_DevNum, 0, PMU_DEVICES, SOCPERF_DRIVER_NAME);
+    SOCPERF_PRINT("SocPerf Driver: result of alloc_chrdev_region is %d\n", status);
+    if (status<0) {
+        SOCPERF_PRINT_ERROR("SocPerf driver failed to alloc chrdev_region!\n");
+        return status;
+    }
+    SOCPERF_PRINT("SocPerf Driver: major number is %d\n", MAJOR(lwpmu_DevNum));
+    status = lwpmudrv_Initialize_State();
+    if (status<0) {
+        SOCPERF_PRINT_ERROR("SocPerf driver failed to initialize state!\n");
+        return status;
+    }
+    num_cpus = GLOBAL_STATE_num_cpus(socperf_driver_state);
+    SOCPERF_PRINT("SocPerf Driver: detected %d CPUs in lwpmudrv_Load\n", num_cpus);
+
+    /* Allocate memory for the control structures */
+    socperf_control = SOCPERF_Allocate_Memory(sizeof(LWPMU_DEV_NODE));
+
+    if (!socperf_control) {
+        SOCPERF_Free_Memory(socperf_control);
+        return OS_NO_MEM;
+    }
+
+    /* Register the file operations with the OS */
+
+#if defined (DRV_ANDROID) || defined (DRV_CHROMEOS)
+    SOCPERF_PRINT("SocPerf Driver: ANDROID_DEVICE %s...\n", SOCPERF_DRIVER_NAME DRV_DEVICE_DELIMITER"c");
+    pmu_class = class_create(THIS_MODULE, SOCPERF_DRIVER_NAME);
+    if (IS_ERR(pmu_class)) {
+        SOCPERF_PRINT_ERROR("Error registering SocPerf control class\n");
+    }
+    device_create(pmu_class, NULL, lwpmu_DevNum, NULL, SOCPERF_DRIVER_NAME DRV_DEVICE_DELIMITER"c");
+#endif
+
+    status = lwpmu_setup_cdev(socperf_control,&socperf_Fops,lwpmu_DevNum);
+    if (status) {
+        SOCPERF_PRINT_ERROR("Error %d adding lwpmu as char device\n", status);
+        return status;
+    }
+
+    MUTEX_INIT(ioctl_lock);
+
+    /*
+     *  Initialize the SocPerf driver version (done once at driver load time)
+     */
+    SOCPERF_VERSION_NODE_major(&socperf_drv_version) = SOCPERF_MAJOR_VERSION;
+    SOCPERF_VERSION_NODE_minor(&socperf_drv_version) = SOCPERF_MINOR_VERSION;
+    SOCPERF_VERSION_NODE_api(&socperf_drv_version)   = SOCPERF_API_VERSION;
+    //
+    // Display driver version information
+    //
+    SOCPERF_PRINT("SocPerf Driver v%d.%d.%d has been loaded.\n",
+              SOCPERF_VERSION_NODE_major(&socperf_drv_version),
+              SOCPERF_VERSION_NODE_minor(&socperf_drv_version),
+              SOCPERF_VERSION_NODE_api(&socperf_drv_version));
+
+    return status;
+}
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn  static int lwpmu_Unload(void)
+ *
+ * @param none
+ *
+ * @return none
+ *
+ * @brief  Remove the driver module from the kernel.
+ */
+static VOID
+socperf_Unload (
+    VOID
+)
+{
+    SOCPERF_PRINT("SocPerf Driver unloading...\n");
+
+    socperf_pcb                 = SOCPERF_Free_Memory(socperf_pcb);
+    socperf_pcb_size            = 0;
+
+#if defined (DRV_ANDROID) || defined (DRV_CHROMEOS)
+    unregister_chrdev(MAJOR(lwpmu_DevNum), SOCPERF_DRIVER_NAME);
+    device_destroy(pmu_class, lwpmu_DevNum);
+    device_destroy(pmu_class, lwpmu_DevNum+1);
+#endif
+
+    cdev_del(&LWPMU_DEV_cdev(socperf_control));
+    unregister_chrdev_region(lwpmu_DevNum, PMU_DEVICES);
+
+#if defined (DRV_ANDROID) || defined (DRV_CHROMEOS)
+    class_destroy(pmu_class);
+#endif
+
+    socperf_control  = SOCPERF_Free_Memory(socperf_control);
+
+    SOCPERF_Memory_Tracker_Free();
+
+    //
+    // Display driver version information
+    //
+    SOCPERF_PRINT("SocPerf Driver v%d.%d.%d has been unloaded.\n",
+              SOCPERF_VERSION_NODE_major(&socperf_drv_version),
+              SOCPERF_VERSION_NODE_minor(&socperf_drv_version),
+              SOCPERF_VERSION_NODE_api(&socperf_drv_version));
+
+    return;
+}
+
+/* Declaration of the init and exit functions */
+module_init(socperf_Load);
+module_exit(socperf_Unload);

--- a/perftools-external/soc_perf_driver/src/utility.c
+++ b/perftools-external/soc_perf_driver/src/utility.c
@@ -1,0 +1,194 @@
+/* ***********************************************************************************************
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or 
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(C) 2005-2018 Intel Corporation. All rights reserved.
+
+  This program is free software; you can redistribute it and/or modify 
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but 
+  WITHOUT ANY WARRANTY; without even the implied warranty of 
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU 
+  General Public License for more details.
+
+  You should have received a copy of the GNU General Public License 
+  along with this program; if not, write to the Free Software 
+  Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+  The full GNU General Public License is included in this distribution 
+  in the file called LICENSE.GPL.
+
+  BSD LICENSE 
+
+  Copyright(C) 2005-2018 Intel Corporation. All rights reserved.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without 
+  modification, are permitted provided that the following conditions 
+  are met:
+
+    * Redistributions of source code must retain the above copyright 
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright 
+      notice, this list of conditions and the following disclaimer in 
+      the documentation and/or other materials provided with the 
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its 
+      contributors may be used to endorse or promote products derived 
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  ***********************************************************************************************
+*/
+
+
+#include "lwpmudrv_defines.h"
+#include <linux/version.h>
+#include <linux/fs.h>
+#include <asm/msr.h>
+#include <linux/ptrace.h>
+
+#include "lwpmudrv_types.h"
+#include "rise_errors.h"
+#include "lwpmudrv_ecb.h"
+#include "socperfdrv.h"
+#include "utility.h"
+#if defined(DRV_SOFIA)
+#include "noc_uncore.h"
+#elif defined(DRV_BUTTER)
+#include "axi_uncore.h"
+#else
+#include "soc_uncore.h"
+#include "haswellunc_sa.h"
+#include "npk_uncore.h"
+#endif
+
+volatile int config_done;
+
+
+extern VOID
+SOCPERF_UTILITY_Read_TSC (
+    U64* pTsc
+)
+{
+    rdtscll(*(pTsc));
+
+    return;
+}
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn       VOID SOCPERF_UTILITY_Read_Cpuid
+ *
+ * @brief    executes the cpuid_function of cpuid and returns values
+ *
+ * @param  IN   cpuid_function
+ *         OUT  rax  - results of the cpuid instruction in the
+ *         OUT  rbx  - corresponding registers
+ *         OUT  rcx
+ *         OUT  rdx
+ *
+ * @return   none
+ *
+ * <I>Special Notes:</I>
+ *              <NONE>
+ *
+ */
+extern VOID
+SOCPERF_UTILITY_Read_Cpuid (
+    U64   cpuid_function,
+    U64  *rax_value,
+    U64  *rbx_value,
+    U64  *rcx_value,
+    U64  *rdx_value
+)
+{
+    U32 function = (U32) cpuid_function;
+    U32 *eax     = (U32 *) rax_value;
+    U32 *ebx     = (U32 *) rbx_value;
+    U32 *ecx     = (U32 *) rcx_value;
+    U32 *edx     = (U32 *) rdx_value;
+
+    *eax = function;
+
+    __asm__("cpuid"
+            : "=a" (*eax),
+              "=b" (*ebx),
+              "=c" (*ecx),
+              "=d" (*edx)
+            : "a"  (function),
+              "b"  (*ebx),
+              "c"  (*ecx),
+              "d"  (*edx));
+
+    return;
+}
+
+/* ------------------------------------------------------------------------- */
+/*!
+ * @fn       VOID SOCPERF_UTILITY_Configure_CPU
+ *
+ * @brief    Reads the CPU information from the hardware
+ *
+ * @param    param   dispatch_id -  The id of the dispatch table.
+ *
+ * @return   Pointer to the correct dispatch table for the CPU architecture
+ *
+ * <I>Special Notes:</I>
+ *              <NONE>
+ */
+extern  DISPATCH
+SOCPERF_UTILITY_Configure_CPU (
+    U32 dispatch_id
+)
+{
+    DISPATCH     dispatch = NULL;
+    switch (dispatch_id) {
+#if defined(DRV_SOFIA)
+        case 1000:
+            SOCPERF_PRINT_DEBUG("Set up the SoC Uncore NOC dispatch table\n");
+            dispatch = &noc_dispatch;
+            break;
+#elif defined(DRV_BUTTER)
+        case 1100:
+            SOCPERF_PRINT_DEBUG("Set up the SoC Uncore AXI dispatch table\n");
+            dispatch = &axi_dispatch;
+            break;
+#else
+        case 230:
+            SOCPERF_PRINT_DEBUG("Set up the Haswell SA dispatch table\n");
+            dispatch = &socperf_hswunc_sa_dispatch;
+            break;
+        case 700:
+            SOCPERF_PRINT_DEBUG("Set up the SOC Uncore dispatch table\n");
+            dispatch = &soc_uncore_dispatch;
+            break;
+        case 701:
+            SOCPERF_PRINT_DEBUG("Set up the SoC Uncore NPK dispatch table\n");
+            dispatch = &npk_dispatch;
+            break;
+#endif
+        default:
+            dispatch = NULL;
+            SOCPERF_PRINT_ERROR("Architecture not supported (dispatch_id=%d)\n", dispatch_id);
+            break;
+    }
+
+    return dispatch;
+}
+
+

--- a/perftools-external/socwatch_driver/Makefile
+++ b/perftools-external/socwatch_driver/Makefile
@@ -1,0 +1,129 @@
+# This file is provided under a dual BSD/GPLv2 license.When using or
+# redistributing this file, you may do so under either license.
+
+# GPL LICENSE SUMMARY
+
+# Copyright(c) 2015 - 2017 Intel Corporation.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of version 2 of the GNU General Public License as
+# published by the Free Software Foundation.
+
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the GNU
+# General Public License for more details.
+
+# Contact Information:
+# SoC Watch Developer Team <socwatchdevelopers@intel.com>
+# Intel Corporation,
+# 1906 Fox Drive,
+# Champaign, IL 61820
+
+# BSD LICENSE
+
+# Copyright(c) 2015 - 2017 Intel Corporation.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+
+# * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in
+# the documentation and/or other materials provided with the
+# distribution.
+# * Neither the name of Intel Corporation nor the names of its
+# contributors may be used to endorse or promote products derived
+# from this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ifeq ($(DO_ANDROID),)
+DO_ANDROID := "1"
+endif
+ifeq ($(DO_SOCPERF),)
+    DO_SOCPERF := "1"
+endif
+ifeq ($(DO_DEBUG_BUILD),)
+    DO_DEBUG_BUILD := "1"
+endif
+ifeq ($(DO_PROFILING),)
+    DO_PROFILING := "0"
+endif
+
+#modified for celadon src tree
+INCDIR_1=$(M)/include
+INCDIR_2=$(M)/inc
+
+EXTRA_CFLAGS:=-I$(INCDIR_1)
+EXTRA_CFLAGS += -I$(INCDIR_2)
+
+EXTRA_CFLAGS += -DDO_ANDROID=$(DO_ANDROID)
+
+EXTRA_CFLAGS += -DDO_SOCPERF=$(DO_SOCPERF)
+
+EXTRA_CFLAGS += -DDO_DRIVER_PROFILING=$(DO_PROFILING)
+
+EXTRA_CFLAGS += -Werror=strict-prototypes
+EXTRA_CFLAGS += -Werror=pointer-to-int-cast
+EXTRA_CFLAGS += -Werror=int-to-pointer-cast
+EXTRA_CFLAGS += -Werror=format
+EXTRA_CFLAGS += -Werror=attributes
+ifeq ($(DO_DEBUG_BUILD),1)
+    EXTRA_CFLAGS += -Werror
+endif
+
+#modified for celadon src tree
+#KBUILD_EXTRA_SYMBOLS:=$(MODULE_SYMVERS_FILE)
+
+obj-m := socwatch2_6.o
+
+socwatch2_6-objs := ./src/sw_driver.o \
+            ./src/sw_hardware_io.o \
+            ./src/sw_output_buffer.o \
+            ./src/sw_tracepoint_handlers.o \
+            ./src/sw_collector.o \
+            ./src/sw_mem.o \
+            ./src/sw_internal.o \
+            ./src/sw_file_ops.o \
+            ./src/sw_ops_provider.o \
+            ./src/sw_trace_notifier_provider.o \
+            ./src/sw_reader.o \
+            ./src/sw_telem.o
+
+.PHONY: kernel_check
+
+kernel_check:
+ifeq "$(KERNEL_SRC_DIR)" ""
+	@echo "Error: makefile MUST NOT be invoked directly! Use the \"build_driver\" script instead."
+	@exit 255
+endif
+
+default: kernel_check
+	@echo "************************************************************"
+	@echo "KERNEL_SRC_DIR=$(KERNEL_SRC_DIR)"
+	@echo "APWR_RED_HAT=$(APWR_RED_HAT)"
+	@echo "DO_WAKELOCK_SAMPLE=$(WAKELOCK_SAMPLE)"
+	@echo "DO_ANDROID=$(DO_ANDROID)"
+	@echo "DO_SOCPERF=$(DO_SOCPERF)"
+	@echo "MODULE_SYMVERS_FILE=$(MODULE_SYMVERS_FILE)"
+	@echo "DO_DRIVER_PROFILING=$(DO_PROFILING)"
+	@echo "INCDIR_1=$(INCDIR_1)"
+	@echo "INCDIR_2=$(INCDIR_2)"
+	@echo "************************************************************"
+	$(MAKE) -C $(KERNEL_SRC_DIR) M=$(PWD) modules PWD=$(PWD)
+
+clean: kernel_check
+	make -C $(KERNEL_SRC_DIR) M=$(PWD) clean

--- a/perftools-external/socwatch_driver/build_linux_driver.sh
+++ b/perftools-external/socwatch_driver/build_linux_driver.sh
@@ -1,0 +1,218 @@
+#!/bin/sh
+
+# Description: Script to build the SOCWatch driver
+# Version: 1.0
+
+# **********************************************************************************
+#  This file is provided under a dual BSD/GPLv2 license.  When using or
+#  redistributing this file, you may do so under either license.
+
+#  GPL LICENSE SUMMARY
+
+#  Copyright(c) 2017 Intel Corporation.
+
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of version 2 of the GNU General Public License as
+#  published by the Free Software Foundation.
+
+#  This program is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  General Public License for more details.
+
+#  Contact Information:
+#  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+#  Intel Corporation,
+#  1906 Fox Drive,
+#  Champaign, IL 61820
+
+#  BSD LICENSE
+
+#  Copyright(c) 2017 Intel Corporation.
+
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in
+#      the documentation and/or other materials provided with the
+#      distribution.
+#    * Neither the name of Intel Corporation nor the names of its
+#      contributors may be used to endorse or promote products derived
+#      from this software without specific prior written permission.
+
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# **********************************************************************************
+
+
+MAKE="make"
+MAKEFILE_NAME="Makefile"
+
+KERNEL_BUILD_DIR=""
+DEFAULT_KERNEL_BUILD_DIR="/lib/modules/`uname -r`/build"
+
+DO_CLEAN=0;
+DO_LINUX=0;
+DO_SOC=0;
+DO_SOCPERF="1";
+DO_INTEL_INTERNAL=0;
+DO_DEBUG_BUILD=0;
+DEFAULT_FILE_NAME="sw_driver";
+FILE_NAME=${DEFAULT_FILE_NAME};
+DO_PROFILING=0;
+COMMON_INC_DIR="";
+DEFAULT_INC_DIR="${PWD}/../common/include"
+DEFAULT_C_COMPILER=gcc
+
+usage()
+{
+    echo "Usage: sh ./build_driver <options>";
+    echo "Where options are:";
+    echo -e "\t-k, --kernel-build-dir [dir-name]: specify the kernel build directory (defaults to $DEFAULT_KERNEL_BUILD_DIR if not specified)."
+    echo -e "\t-h, --help: print this usage message";
+    echo -e "\t-c, --c-compiler [Path to c compiler]: Specify an alternate compiler; default is $DEFAULT_C_COMPILER"
+    echo -e "\t    --make-args: extra arguments to pass to make command"
+    echo -e "\t-l, --linux: compile the driver for a device running Linux.";
+    echo -e "\t-d, --debug: do a debug build, with \"-Werror\" turned ON";
+    echo -e "\t-n, --no-socperf: remove socperf support from the driver. Use this option only if you're sure you won't collect bandwidth or DRAM Self Refresh metrics";
+    echo -e "\t-s, --symvers [path to Module.symvers file]: specify a \"Module.symvers\" file to extract symbols from; MUST be FULL PATH!";
+    echo -e "\t    --clean: Run a make clean"
+    return 0;
+}
+
+while [ $# -gt 0 ] ; do
+    case "$1" in
+        -h | --help)
+            usage; exit 0;;
+        -k | --kernel-build-dir)
+            KERNEL_BUILD_DIR=$2; shift;;
+        -l | --linux)
+            DO_LINUX=1;;
+        -i | --internal)
+            DO_INTEL_INTERNAL=1;;
+        -d | --debug)
+            DO_DEBUG_BUILD=1;;
+        -n | --no-socperf)
+            DO_SOCPERF="0";;
+        -s | --symvers)
+            MODULE_SYMVERS_FILE=$2; shift;;
+        -c | --c-compiler)
+            C_COMPILER=$2; shift;;
+        --make-args)
+            MAKE_ARGS=$2; shift;;
+        --clean)
+            DO_CLEAN=1;;
+        -f | --file-name) # hidden option
+            FILE_NAME=$2; shift;;
+        -p | --profile) # hidden option
+            DO_PROFILING=1;;
+        --common-inc-dir) # hidden option
+            COMMON_INC_DIR=$2; shift;;
+        *) usage; exit 255;;
+    esac
+    shift
+done
+
+if [ "X$C_COMPILER" = "X" ]; then
+    C_COMPILER=$DEFAULT_C_COMPILER;
+else
+    # User specified a compiler to use. Check validity:
+    # 1. File should exist
+    # 2. File should be executable
+    C_COMPILER_FULL=`which $C_COMPILER`
+    if [ ! -f "$C_COMPILER_FULL" ]; then
+        echo "Invalid c-compiler specified: ${C_COMPILER} is not a valid path!";
+        exit 255;
+    fi
+    # OK, file exists, but is it an executable?
+    if [ ! -x "$C_COMPILER_FULL" ]; then
+        echo "Invalid c-compiler specified: ${C_COMPILER} is not executable!";
+        exit 255;
+    fi
+fi
+export CC=${C_COMPILER}
+echo "Using C compiler = ${CC}";
+
+if [ "X$KERNEL_BUILD_DIR" = "X" ]; then
+    KERNEL_BUILD_DIR=$DEFAULT_KERNEL_BUILD_DIR;
+fi
+
+echo "Using kernel build dir = $KERNEL_BUILD_DIR"
+
+if [ "X$MODULE_SYMVERS_FILE" = "X" ] ; then
+    echo "No module symvers file found";
+else
+    echo "Using symvers file = $MODULE_SYMVERS_FILE"
+fi
+
+echo "Using common_inc_dir=${COMMON_INC_DIR}s"
+
+if [ "X$COMMON_INC_DIR" = "X" ]; then
+    COMMON_INC_DIR="$DEFAULT_INC_DIR"
+fi
+
+echo "Using common inc dir = $COMMON_INC_DIR"
+
+APWR_RED_HAT="0"
+
+# check which distro
+# taken from the 'boot-script'
+if [ -e "/etc/issue" ]; then
+    is_redhat=`cat /etc/issue | grep -i "red hat"`;
+    if [ "$is_redhat" != "" ]; then
+		APWR_RED_HAT=1
+		echo "Using RedHat-specific hack for kernel version number..."
+    fi
+fi
+
+WAKELOCK_SAMPLE="0"
+wakelock_file=${KERNEL_BUILD_DIR}/source/include/trace/events/wakelock.h
+if [ -f $wakelock_file ] ; then
+  echo "\"$wakelock_file\" exists!"
+  WAKELOCK_SAMPLE=1
+else
+  echo "\"$wakelock_file\" does NOT exist!"
+  pm_wakeup_file=${KERNEL_BUILD_DIR}/source/include/linux/pm_wakeup.h
+  if [ -f $pm_wakeup_file ] ; then
+    echo "\"$pm_wakeup_file\" exists!"
+    WAKELOCK_SAMPLE=1
+  else
+    echo "\"$pm_wakeup_file\" does NOT exist!"
+  fi
+fi
+
+DO_ANDROID="1"
+if [ $DO_LINUX -eq 1 ]; then
+    DO_ANDROID="0"
+fi
+
+#DO_SOCPERF="0"
+
+PW_DO_DEBUG_BUILD="0"
+if [ $DO_DEBUG_BUILD -eq 1 ]; then
+    PW_DO_DEBUG_BUILD="1"
+fi
+
+echo "Using file name ${FILE_NAME}"
+
+MAKE_ARGS="KERNEL_SRC_DIR=$KERNEL_BUILD_DIR APWR_RED_HAT=$APWR_RED_HAT WAKELOCK_SAMPLE=$WAKELOCK_SAMPLE DO_ANDROID=$DO_ANDROID DO_SOCPERF=$DO_SOCPERF DO_INTEL_INTERNAL=$DO_INTEL_INTERNAL DO_DEBUG_BUILD=$PW_DO_DEBUG_BUILD DO_PROFILING=$DO_PROFILING COMMON_INC_DIR=$COMMON_INC_DIR MODULE_SYMVERS_FILE=$MODULE_SYMVERS_FILE FILE_NAME=${FILE_NAME} $MAKE_ARGS"
+echo "Make args = $MAKE_ARGS"
+if [ $DO_CLEAN -eq 1 ]; then
+    ${MAKE} -f ${MAKEFILE_NAME} $MAKE_ARGS clean
+else
+    ${MAKE} CC=$CC -f ${MAKEFILE_NAME} $MAKE_ARGS clean default
+fi
+

--- a/perftools-external/socwatch_driver/inc/sw_collector.h
+++ b/perftools-external/socwatch_driver/inc/sw_collector.h
@@ -1,0 +1,125 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#ifndef __SW_COLLECTOR_H__
+
+#include "sw_internal.h"
+
+/*
+ * Forward declaration
+ */
+struct sw_hw_ops;
+
+// TODO: convert from 'list_head' to 'hlist_head'
+/**
+ * struct - sw_collector_data
+ * Information about the collector to be invoked at collection time.
+ *
+ * The collector_lists array holds linked lists of collectors to
+ * be exercised at specific points in time during the collection
+ * (e.g. begin, poll, end, etc.).  At a trigger time, the driver walks
+ * that time's list of nodes, and exercises the collectors on that list.
+ *
+ * @list:                   List/link implementation
+ * @cpumask:                Collect if cpu matches mask
+ * @info:                   Ptr to metric info
+ * @ops:                    Ptr to collector's operations
+ * @last_update_jiffies:    Indicates when this node was last exercised.
+ * @per_msg_payload_size:   Data size
+ * @msg:                    Ptr to collected data
+ */
+typedef struct sw_collector_data {
+    SW_LIST_ENTRY(list, sw_collector_data);
+    struct cpumask                  cpumask;
+    struct sw_driver_interface_info *info;
+    const struct sw_hw_ops          **ops;
+    size_t                          per_msg_payload_size;
+    u64                             last_update_jiffies;
+    struct sw_driver_msg *msg;
+} sw_collector_data_t;
+#define GET_MSG_SLOT_FOR_CPU(msgs, cpu, size) ( (struct sw_driver_msg *) &(((char *)(msgs))[(cpu) * (sizeof(struct sw_driver_msg) + (size))]) )
+
+struct sw_collector_data *sw_alloc_collector_node(void);
+void sw_free_collector_node(struct sw_collector_data *node);
+int sw_handle_collector_node(struct sw_collector_data *data);
+int sw_handle_collector_node_on_cpu(struct sw_collector_data *data, int cpu);
+int sw_write_collector_node(struct sw_collector_data *data);
+
+void sw_init_collector_list(void *list_head);
+void sw_destroy_collector_list(void *list_head);
+int sw_handle_collector_list(void *list_head, int (*func)(struct sw_collector_data *data));
+int sw_handle_collector_list_on_cpu(void *list_head, int (*func)(struct sw_collector_data *data, int cpu), int cpu);
+
+int sw_handle_driver_io_descriptor(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, const struct sw_hw_ops *hw_ops);
+int sw_init_driver_io_descriptor(struct sw_driver_io_descriptor *descriptor);
+int sw_reset_driver_io_descriptor(struct sw_driver_io_descriptor *descriptor);
+
+int sw_add_driver_info(void *list_head, const struct sw_driver_interface_info *info);
+
+void sw_handle_per_cpu_msg(void *info);
+void sw_handle_per_cpu_msg_no_sched(void *info);
+void sw_handle_per_cpu_msg_on_cpu(int cpu, void *info);
+
+void sw_set_collector_ops(const struct sw_hw_ops *hw_ops);
+
+/**
+ * Process all messages for the given time.
+ * @param[in]   when    The time period e.g. 'BEGIN' or 'END'
+ *
+ * @returns     0   on success, non-zero on error
+ */
+extern int sw_process_snapshot(enum sw_when_type when);
+extern int sw_process_snapshot_on_cpu(enum sw_when_type when, int cpu);
+#endif // __SW_COLLECTOR_H__

--- a/perftools-external/socwatch_driver/inc/sw_file_ops.h
+++ b/perftools-external/socwatch_driver/inc/sw_file_ops.h
@@ -1,0 +1,70 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#ifndef __SW_FILE_OPS_H__
+#define __SW_FILE_OPS_H__
+
+enum sw_driver_collection_cmd;
+struct sw_file_ops {
+    long (*ioctl_handler)(unsigned int ioctl_num, void *local_args);
+    int (*stop_handler)(void);
+    enum sw_driver_collection_cmd (*get_current_cmd)(void);
+    bool (*should_flush)(void);
+};
+
+int sw_register_dev(struct sw_file_ops *ops);
+void sw_unregister_dev(void);
+
+#endif // __SW_FILE_OPS_H__

--- a/perftools-external/socwatch_driver/inc/sw_hardware_io.h
+++ b/perftools-external/socwatch_driver/inc/sw_hardware_io.h
@@ -1,0 +1,112 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#ifndef __SW_HARDWARE_IO_H__
+#define __SW_HARDWARE_IO_H__
+
+#include "sw_structs.h"
+
+typedef int (*sw_io_desc_init_func_t)(struct sw_driver_io_descriptor *descriptor);
+typedef void (*sw_hardware_op_func_t)(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes);
+typedef int (*sw_io_desc_print_func_t)(const struct sw_driver_io_descriptor *descriptor);
+typedef int (*sw_io_desc_reset_func_t)(const struct sw_driver_io_descriptor *descriptor);
+typedef bool (*sw_io_desc_available_func_t)(void);
+typedef bool (*sw_hw_op_post_config_func_t)(void);
+
+/**
+ * struct sw_hw_ops - Operations for each of the HW collection mechanisms
+ *                    in swkernelcollector.
+ * @name:           A descriptive name used to identify this particular operation.
+ * @init:           Initialize a metric's collection.
+ * @read:           Read a metric's data.
+ * @write:          Write to the HW for the metric(?).
+ * @print:          Print out the data.
+ * @reset:          Opposite of init--called after we're done collecting.
+ * @available:      Decide whether this H/W op is available on the current platform.
+ * @post_config:    Perform any post-configuration steps.
+ */
+struct sw_hw_ops {
+    const char *name;
+    sw_io_desc_init_func_t       init;
+    sw_hardware_op_func_t        read;
+    sw_hardware_op_func_t        write;
+    sw_io_desc_print_func_t      print;
+    sw_io_desc_reset_func_t      reset;
+    sw_io_desc_available_func_t  available;
+    sw_hw_op_post_config_func_t  post_config;
+};
+
+bool sw_is_valid_hw_op_id(int id);
+int sw_get_hw_op_id(const struct sw_hw_ops *op);
+const struct sw_hw_ops *sw_get_hw_ops_for(int id);
+const char *sw_get_hw_op_abstract_name(const struct sw_hw_ops *op);
+
+int sw_for_each_hw_op(int (*func)(const struct sw_hw_ops *op, void *priv),
+                      void *priv, bool return_on_error);
+
+/**
+ * Add an operation to the list of providers.
+ */
+int sw_register_hw_op(const struct sw_hw_ops *ops);
+/**
+ * Register all H/W operations.
+ */
+int sw_register_hw_ops(void);
+/**
+ * Unregister previously registered H/W operations.
+ */
+void sw_free_hw_ops(void);
+
+#endif // __SW_HARDWARE_IO_H__

--- a/perftools-external/socwatch_driver/inc/sw_internal.h
+++ b/perftools-external/socwatch_driver/inc/sw_internal.h
@@ -1,0 +1,135 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#ifndef __SW_DATA_STRUCTS_H__
+#define __SW_DATA_STRUCTS_H__
+
+/*
+ * Taken from 'sw_driver'
+ * TODO: move to separate file?
+ */
+#include <linux/module.h>
+#include <linux/moduleparam.h>
+#include <linux/kernel.h>
+#include <linux/slab.h>
+#include <linux/cpumask.h>
+#include <linux/hrtimer.h>
+#include <linux/fs.h>      // inode
+#include <linux/device.h>  // class_create
+#include <linux/cdev.h>    // cdev_alloc
+#include <linux/vmalloc.h> // vmalloc
+#include <linux/sched.h>   // TASK_INTERRUPTIBLE
+#include <linux/wait.h>    // wait_event_interruptible
+#include <linux/pci.h>     // pci_get_bus_and_slot
+#include <linux/version.h> // LINUX_VERSION_CODE
+#include <linux/sfi.h>     // For SFI F/W version
+#include <asm/hardirq.h>
+#include <linux/cpufreq.h>
+#include <asm/local.h>     // local_t
+#include <linux/hardirq.h> // "in_atomic"
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,12,0)
+    #include <asm/uaccess.h>   // copy_to_user
+#else
+    #include <linux/uaccess.h>   // copy_to_user
+#endif // LINUX_VERSION_CODE
+
+#ifdef CONFIG_X86_WANT_INTEL_MID
+    #include <asm/intel-mid.h>
+#endif // CONFIG_X86_WANT_INTEL_MID
+/*
+ * End taken from sw_driver
+ */
+
+#include "sw_structs.h"
+#include "sw_ioctl.h"
+#include "sw_list.h"
+
+/* ******************************************
+ * Compile time constants
+ * ******************************************
+ */
+#define GET_POLLED_CPU() (sw_max_num_cpus)
+
+/* ******************************************
+ * Function declarations.
+ * ******************************************
+ */
+/*
+ * Output to user.
+ */
+unsigned long sw_copy_to_user(void *dst, char *src, size_t bytes_to_copy);
+bool sw_check_output_buffer_params(void *buffer, size_t bytes_to_read, size_t buff_size);
+/*
+ * smp call function.
+ */
+void sw_schedule_work(const struct cpumask *mask, void (*work)(void *), void *data);
+/*
+ * Save IRQ flags and retrieve cpu number.
+ */
+int sw_get_cpu(unsigned long *flags);
+/*
+ * Restore IRQ flags.
+ */
+void sw_put_cpu(unsigned long flags);
+/*
+ * Set module scope for cpu frequencies.
+ */
+int sw_set_module_scope_for_cpus(void);
+/*
+ * reset module scope for cpu frequencies.
+ */
+int sw_reset_module_scope_for_cpus(void);
+
+#endif // __SW_DATA_STRUCTS_H__

--- a/perftools-external/socwatch_driver/inc/sw_list.h
+++ b/perftools-external/socwatch_driver/inc/sw_list.h
@@ -1,0 +1,74 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#ifndef __SW_LIST_H__
+#define __SW_LIST_H__
+
+#include <linux/list.h>
+
+#define SW_DEFINE_LIST_HEAD(name, dummy)            struct list_head name
+#define SW_DECLARE_LIST_HEAD(name, dummy)           extern struct list_head name
+#define SW_LIST_ENTRY(name, dummy)                  struct list_head name
+#define SW_LIST_HEAD_VAR(dummy)                     struct list_head
+#define SW_LIST_HEAD_INIT(head)                     INIT_LIST_HEAD(head)
+#define SW_LIST_ENTRY_INIT(node, field)             INIT_LIST_HEAD(&node->field)
+#define SW_LIST_ADD(head, node, field)              list_add_tail(&node->field, head)
+#define SW_LIST_GET_HEAD_ENTRY(head, type, field)   list_first_entry(head, struct type, field)
+#define SW_LIST_UNLINK(node, field)                 list_del(&node->field)
+#define SW_LIST_FOR_EACH_ENTRY(node, head, field)   list_for_each_entry(node, head, field)
+#define SW_LIST_EMPTY(head)                         list_empty(head)
+#define SW_LIST_HEAD_INITIALIZER(head)              LIST_HEAD_INIT(head)
+
+#endif // __SW_LIST_H__

--- a/perftools-external/socwatch_driver/inc/sw_lock_defs.h
+++ b/perftools-external/socwatch_driver/inc/sw_lock_defs.h
@@ -1,0 +1,96 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+/*
+ * Description: file containing locking routines
+ * used by the power driver.
+ */
+
+#ifndef __SW_LOCK_DEFS_H__
+#define __SW_LOCK_DEFS_H__
+
+#define SW_DEFINE_SPINLOCK(s)   DEFINE_SPINLOCK(s)
+#define SW_DECLARE_SPINLOCK(s)  static spinlock_t s
+
+#define SW_INIT_SPINLOCK(s)     spin_lock_init(&s)
+#define SW_DESTROY_SPINLOCK(s)  /* NOP */
+
+#define LOCK(l) { \
+    unsigned long _tmp_l_flags; \
+    spin_lock_irqsave(&(l), _tmp_l_flags);
+
+#define UNLOCK(l) \
+    spin_unlock_irqrestore(&(l), _tmp_l_flags); \
+    }
+
+#define READ_LOCK(l) { \
+    unsigned long _tmp_l_flags; \
+    read_lock_irqsave(&(l), _tmp_l_flags);
+
+#define READ_UNLOCK(l) \
+    read_unlock_irqrestore(&(l), _tmp_l_flags); \
+    }
+
+#define WRITE_LOCK(l) { \
+    unsigned long _tmp_l_flags; \
+    write_lock_irqsave(&(l), _tmp_l_flags);
+
+#define WRITE_UNLOCK(l) \
+    write_unlock_irqrestore(&(l), _tmp_l_flags); \
+    }
+
+
+#endif // __SW_LOCK_DEFS_H__

--- a/perftools-external/socwatch_driver/inc/sw_mem.h
+++ b/perftools-external/socwatch_driver/inc/sw_mem.h
@@ -1,0 +1,81 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+/*
+ * Description: file containing memory management routines
+ * used by the power driver.
+ */
+
+#ifndef _SW_MEM_H_
+#define _SW_MEM_H_ 1
+
+#include "sw_types.h"
+
+void *sw_kmalloc(size_t size, unsigned flags);
+void sw_kfree(const void *obj);
+/*
+ * Allocate free pages.
+ */
+unsigned long sw_allocate_pages(unsigned int flags, unsigned int alloc_size_in_bytes);
+/*
+ * Free up previously allocated pages.
+ */
+void sw_release_pages(unsigned long addr, unsigned int alloc_size_in_bytes);
+
+u64 sw_get_total_bytes_alloced(void);
+u64 sw_get_max_bytes_alloced(void);
+u64 sw_get_curr_bytes_alloced(void);
+#endif // _SW_MEM_H_

--- a/perftools-external/socwatch_driver/inc/sw_ops_provider.h
+++ b/perftools-external/socwatch_driver/inc/sw_ops_provider.h
@@ -1,0 +1,62 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#ifndef __SW_OPS_PROVIDER_H__
+#define __SW_OPS_PROVIDER_H__
+
+int sw_register_ops_providers(void);
+void sw_free_ops_providers(void);
+
+#endif // __SW_OPS_PROVIDER_H__

--- a/perftools-external/socwatch_driver/inc/sw_output_buffer.h
+++ b/perftools-external/socwatch_driver/inc/sw_output_buffer.h
@@ -1,0 +1,135 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef _SW_OUTPUT_BUFFER_H_
+#define _SW_OUTPUT_BUFFER_H_ 1
+/*
+ * Special mask for the case where all buffers have been flushed.
+ */
+// #define sw_ALL_WRITES_DONE_MASK 0xffffffff
+#define SW_ALL_WRITES_DONE_MASK ((u32)-1)
+/*
+ * Special mask for the case where no data is available to be read.
+ */
+#define SW_NO_DATA_AVAIL_MASK ((u32)-2)
+
+/*
+ * Forward declarations.
+ */
+struct sw_driver_msg;
+
+/*
+ * Data structures.
+ */
+enum sw_wakeup_action {
+    SW_WAKEUP_ACTION_DIRECT,
+    SW_WAKEUP_ACTION_TIMER,
+    SW_WAKEUP_ACTION_NONE,
+};
+
+/*
+ * Variable declarations.
+ */
+extern u64 sw_num_samples_produced, sw_num_samples_dropped;
+extern unsigned long sw_buffer_alloc_size;
+extern int sw_max_num_cpus;
+extern wait_queue_head_t sw_reader_queue;
+
+/*
+ * Public API.
+ */
+int sw_init_per_cpu_buffers(void);
+void sw_destroy_per_cpu_buffers(void);
+void sw_reset_per_cpu_buffers(void);
+
+void sw_count_samples_produced_dropped(void);
+
+int sw_produce_generic_msg(struct sw_driver_msg *, enum sw_wakeup_action);
+
+bool sw_any_seg_full(u32 *val, bool is_flush_mode);
+size_t sw_consume_data(u32 mask, void *buffer, size_t bytes_to_read);
+
+unsigned int sw_get_output_buffer_size(void);
+
+void sw_wait_once(void);
+void sw_wakeup(void);
+
+void sw_print_output_buffer_overheads(void);
+
+/*
+ * Init reader queue.
+ */
+int sw_init_reader_queue(void);
+/*
+ * Destroy reader queue.
+ */
+void sw_destroy_reader_queue(void);
+/*
+ * Wakeup client waiting for a full buffer.
+ */
+void sw_wakeup_reader(enum sw_wakeup_action);
+/*
+ * Wakeup client waiting for a full buffer, and
+ * cancel any timers initialized by the reader
+ * subsys.
+ */
+void sw_cancel_reader(void);
+/*
+ * Print some stats about the reader subsys.
+ */
+void sw_print_reader_stats(void);
+
+#endif // _SW_OUTPUT_BUFFER_H_

--- a/perftools-external/socwatch_driver/inc/sw_overhead_measurements.h
+++ b/perftools-external/socwatch_driver/inc/sw_overhead_measurements.h
@@ -1,0 +1,175 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+/*
+ * Description: file containing overhead measurement
+ * routines used by the power driver.
+ */
+
+#ifndef _PW_OVERHEAD_MEASUREMENTS_H_
+#define _PW_OVERHEAD_MEASUREMENTS_H_
+
+/*
+ * Helper macro to declare variables required
+ * for conducting overhead measurements.
+ */
+/*
+ * For each function that you want to profile,
+ * do the following (e.g. function 'foo'):
+ * **************************************************
+ * DECLARE_OVERHEAD_VARS(foo);
+ * **************************************************
+ * This will declare the two variables required
+ * to keep track of overheads incurred in
+ * calling/servicing 'foo'. Note that the name
+ * that you declare here *MUST* match the function name!
+ */
+
+#if DO_OVERHEAD_MEASUREMENTS
+
+#ifndef __get_cpu_var
+    /*
+     * Kernels >= 3.19 don't include a definition
+     * of '__get_cpu_var'. Create one now.
+     */
+    #define __get_cpu_var(var) *this_cpu_ptr(&var)
+#endif // __get_cpu_var
+#ifndef __raw_get_cpu_var
+    /*
+     * Kernels >= 3.19 don't include a definition
+     * of '__raw_get_cpu_var'. Create one now.
+     */
+    #define __raw_get_cpu_var(var) *raw_cpu_ptr(&var)
+#endif // __get_cpu_var
+
+extern u64 sw_timestamp(void);
+
+#define DECLARE_OVERHEAD_VARS(name)					\
+    static DEFINE_PER_CPU(u64, name##_elapsed_time) = 0;				\
+    static DEFINE_PER_CPU(local_t, name##_num_iters) = LOCAL_INIT(0);		\
+									\
+    static inline u64 get_my_cumulative_elapsed_time_##name(void){		\
+	return *(&__get_cpu_var(name##_elapsed_time));			\
+    }									\
+    static inline int get_my_cumulative_num_iters_##name(void){		\
+	return local_read(&__get_cpu_var(name##_num_iters));		\
+    }									\
+									\
+    static inline u64 name##_get_cumulative_elapsed_time_for(int cpu){	\
+	return *(&per_cpu(name##_elapsed_time, cpu));			\
+    }									\
+									\
+    static inline int name##_get_cumulative_num_iters_for(int cpu){	\
+    	return local_read(&per_cpu(name##_num_iters, cpu));		\
+    }									\
+									\
+    static inline void name##_get_cumulative_overhead_params(u64 *time,	\
+							     int *iters){ \
+	int cpu = 0;							\
+	*time = 0; *iters = 0;						\
+	for_each_online_cpu(cpu){					\
+	    *iters += name##_get_cumulative_num_iters_for(cpu);		\
+	    *time += name##_get_cumulative_elapsed_time_for(cpu);	\
+	}								\
+	return;								\
+    }									\
+	\
+static inline void name##_print_cumulative_overhead_params(const char *str){\
+	int num = 0; \
+	u64 time = 0; \
+	name##_get_cumulative_overhead_params(&time, &num); \
+	printk(KERN_INFO "%s: %d iters took %llu nano seconds!\n", str, num, time); \
+}
+
+#define DO_PER_CPU_OVERHEAD_FUNC(func, ...) do{		\
+	u64 *__v = &__raw_get_cpu_var(func##_elapsed_time);	\
+	u64 tmp_1 = 0, tmp_2 = 0;			\
+	local_inc(&__raw_get_cpu_var(func##_num_iters));	\
+	tmp_1 = sw_timestamp();				\
+	{						\
+	    func(__VA_ARGS__);				\
+	}						\
+	tmp_2 = sw_timestamp();				\
+	*(__v) += (tmp_2 - tmp_1);			\
+    }while(0)
+
+#define DO_PER_CPU_OVERHEAD_FUNC_RET(type, func, ...) ({	\
+        type __ret;                                     \
+	u64 *__v = &__raw_get_cpu_var(func##_elapsed_time);	\
+	u64 tmp_1 = 0, tmp_2 = 0;				\
+	local_inc(&__raw_get_cpu_var(func##_num_iters));        \
+	tmp_1 = sw_timestamp();				        \
+	{							\
+	    __ret = func(__VA_ARGS__);				\
+	}							\
+	tmp_2 = sw_timestamp();				        \
+	*(__v) += (tmp_2 - tmp_1);				\
+        __ret;                                                  \
+    })
+
+#else // !DO_OVERHEAD_MEASUREMENTS
+#define DECLARE_OVERHEAD_VARS(name) \
+    static inline void name##_print_cumulative_overhead_params(const char *str) { /* NOP */ }
+
+#define DO_PER_CPU_OVERHEAD_FUNC(func, ...) func(__VA_ARGS__)
+#define DO_PER_CPU_OVERHEAD_FUNC_RET(type, func, ...) func(__VA_ARGS__)
+
+#endif // DO_OVERHEAD_MEASUREMENTS
+
+#define PRINT_CUMULATIVE_OVERHEAD_PARAMS(name, str) \
+    name##_print_cumulative_overhead_params(str)
+
+#endif // _PW_OVERHEAD_MEASUREMENTS_H_

--- a/perftools-external/socwatch_driver/inc/sw_telem.h
+++ b/perftools-external/socwatch_driver/inc/sw_telem.h
@@ -1,0 +1,75 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef _SW_TELEM_H_
+#define _SW_TELEM_H_ 1
+
+#include "sw_structs.h"      // sw_driver_io_descriptor
+#include "sw_types.h"        // u8 and other types
+
+int sw_telem_init_func(struct sw_driver_io_descriptor *descriptor);
+void sw_read_telem_info(char *dst_vals, int cpu,
+                          const struct sw_driver_io_descriptor *descriptor,
+                          u16 counter_size_in_bytes);
+void sw_write_telem_info(char *dst_vals, int cpu,
+                           const struct sw_driver_io_descriptor *descriptor,
+                           u16 counter_size_in_bytes);
+int sw_reset_telem(const struct sw_driver_io_descriptor *descriptor);
+bool sw_telem_available(void);
+bool sw_telem_post_config(void);
+
+
+#endif /* SW_TELEM_H */

--- a/perftools-external/socwatch_driver/inc/sw_trace_notifier_provider.h
+++ b/perftools-external/socwatch_driver/inc/sw_trace_notifier_provider.h
@@ -1,0 +1,81 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#ifndef __SW_TRACE_NOTIFIER_PROVIDER_H__
+#define __SW_TRACE_NOTIFIER_PROVIDER_H__
+
+/*
+ * Some architectures and OS versions require a "discovery"
+ * phase for tracepoints and/or notifiers. Allow for that here.
+ */
+int sw_extract_trace_notifier_providers(void);
+/*
+ * Reset trace/notifier providers at the end
+ * of a collection.
+ */
+void sw_reset_trace_notifier_providers(void);
+/*
+ * Print statistics on trace/notifier provider overheads.
+ */
+void sw_print_trace_notifier_provider_overheads(void);
+/*
+ * Add all trace/notifier providers.
+ */
+int sw_add_trace_notifier_providers(void);
+/*
+ * Remove previously added providers.
+ */
+void sw_remove_trace_notifier_providers(void);
+#endif // __SW_TRACE_NOTIFIER_PROVIDER_H__

--- a/perftools-external/socwatch_driver/inc/sw_tracepoint_handlers.h
+++ b/perftools-external/socwatch_driver/inc/sw_tracepoint_handlers.h
@@ -1,0 +1,127 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#ifndef __SW_TRACEPOINT_HANDLERS_H__
+#define __SW_TRACEPOINT_HANDLERS_H__
+
+#include "sw_internal.h"
+
+extern pw_u16_t sw_min_polling_interval_msecs;
+
+enum sw_trace_data_type {
+    SW_TRACE_COLLECTOR_TRACEPOINT,
+    SW_TRACE_COLLECTOR_NOTIFIER
+};
+
+struct sw_trace_notifier_name {
+    const char *kernel_name; // The tracepoint name; used by the kernel to identify tracepoints
+    const char *abstract_name; // An abstract name used by plugins to specify tracepoints-of-interest; shared with Ring-3
+};
+
+typedef struct sw_trace_notifier_data sw_trace_notifier_data_t;
+typedef int (*sw_trace_notifier_register_func)(struct sw_trace_notifier_data *node);
+typedef int (*sw_trace_notifier_unregister_func)(struct sw_trace_notifier_data *node);
+
+struct sw_trace_notifier_data {
+    enum sw_trace_data_type type; // Tracepoint or Notifier
+    const struct sw_trace_notifier_name *name; // Tracepoint name(s)
+    sw_trace_notifier_register_func probe_register; // probe register function
+    sw_trace_notifier_unregister_func probe_unregister; // probe unregister function
+    struct tracepoint *tp;
+    bool always_register; // Set to TRUE if this tracepoint/notifier must ALWAYS be registered, regardless
+                          // of whether the user has specified anything to collect
+    bool was_registered;
+    SW_DEFINE_LIST_HEAD(list, sw_collector_data); // List of 'sw_collector_data' instances for this tracepoint or notifier
+};
+
+struct sw_topology_node {
+    struct sw_driver_topology_change change;
+    SW_LIST_ENTRY(list, sw_topology_node);
+};
+SW_DECLARE_LIST_HEAD(sw_topology_list, sw_topology_node); // List of entries tracking changes in CPU topology
+extern size_t sw_num_topology_entries; // Size of the 'sw_topology_list'
+
+int sw_extract_tracepoints(void);
+int sw_register_trace_notifiers(void);
+int sw_unregister_trace_notifiers(void);
+
+/*
+ * Register a single TRACE/NOTIFY provider.
+ */
+int sw_register_trace_notify_provider(struct sw_trace_notifier_data *tnode);
+/*
+ * Add all TRACE/NOTIFY providers.
+ */
+int sw_add_trace_notify(void);
+void sw_remove_trace_notify(void);
+
+void sw_reset_trace_notifier_lists(void);
+
+void sw_print_trace_notifier_overheads(void);
+
+int sw_for_each_tracepoint_node(int (*func)(struct sw_trace_notifier_data *node, void *priv), void *priv, bool return_on_error);
+int sw_for_each_notifier_node(int (*func)(struct sw_trace_notifier_data *node, void *priv), void *priv, bool return_on_error);
+
+int sw_get_trace_notifier_id(struct sw_trace_notifier_data *node);
+
+const char *sw_get_trace_notifier_kernel_name(struct sw_trace_notifier_data *node);
+const char *sw_get_trace_notifier_abstract_name(struct sw_trace_notifier_data *node);
+
+/*
+ * Clear out the topology list.
+ */
+void sw_clear_topology_list(void);
+
+#endif // __SW_TRACEPOINT_HANDLERS_H__

--- a/perftools-external/socwatch_driver/include/sw_defines.h
+++ b/perftools-external/socwatch_driver/include/sw_defines.h
@@ -1,0 +1,156 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef _PW_DEFINES_H_
+#define _PW_DEFINES_H_ 1
+
+#include "sw_version.h"
+
+/* ***************************************************
+ * Common to kernel and userspace.
+ * ***************************************************
+ */
+#define PW_SUCCESS              0
+#define PW_ERROR                1
+#define PW_SUCCESS_NO_COLLECT   2
+
+/*
+ * Helper macro to convert 'u64' to 'unsigned long long' to avoid gcc warnings.
+ */
+#define TO_ULL(x) (unsigned long long)(x)
+/*
+* Convert an arg to 'long long'
+*/
+#define TO_LL(x) (long long)(x)
+/*
+ * Convert an arg to 'unsigned long'
+ */
+#define TO_UL(x) (unsigned long)(x)
+/*
+ * Helper macro for string representation of a boolean value.
+ */
+#define GET_BOOL_STRING(b) ( (b) ? "TRUE" : "FALSE" )
+
+/*
+ * Circularly increment 'i' MODULO 'l'.
+ * ONLY WORKS IF 'l' is (power of 2 - 1) ie.
+ * l == (2 ^ x) - 1
+ */
+#define CIRCULAR_INC(index, mask) ( ( (index) + 1) & (mask) )
+#define CIRCULAR_ADD(index, val, mask) ( ( (index) + (val) ) & (mask) )
+/*
+ * Circularly decrement 'i'.
+ */
+#define CIRCULAR_DEC(i,m) ({int __tmp1 = (i); if(--__tmp1 < 0) __tmp1 = (m); __tmp1;})
+/*
+ * Should the driver count number of dropped samples?
+ */
+#define DO_COUNT_DROPPED_SAMPLES 1
+/*
+ * Retrieve size of an array.
+ */
+#define SW_ARRAY_SIZE(array) ( sizeof(array) / sizeof((array)[0]) )
+/*
+ * Extract F/W major, minor versions.
+ * Assumes version numbers are 8b unsigned ints.
+ */
+#define SW_GET_SCU_FW_VERSION_MAJOR(ver) ( ( (ver) >> 8 ) & 0xff )
+#define SW_GET_SCU_FW_VERSION_MINOR(ver) ( (ver) & 0xff )
+/*
+ * Max size of process name retrieved from kernel.
+ */
+#define SW_MAX_PROC_NAME_SIZE 16
+
+/*
+ * Number of SOCPERF counters.
+ * Needed by both Ring-0 and Ring-3
+ */
+#define SW_NUM_SOCPERF_COUNTERS 9
+
+/*
+ * Max size of process name retrieved from kernel space.
+ */
+#define SW_MAX_PROC_NAME_SIZE 16
+/*
+ * Max size of kernel wakelock name.
+ */
+#define SW_MAX_KERNEL_WAKELOCK_NAME_SIZE 100
+
+/* Data value read when a telemetry data read fails. */
+#define SW_TELEM_READ_FAIL_VALUE 0xF00DF00DF00DF00D
+
+#ifdef __KERNEL__
+    #include "sw_kernel_defines.h"
+#else // __KERNEL__
+    #include "sw_user_defines.h"
+#endif // __KERNEL__
+
+#ifdef SWW_MERGE
+typedef enum {
+    SW_STOP_EVENT = 0,
+    SW_CS_EXIT_EVENT,
+    SW_COUNTER_RESET_EVENT,
+    SW_COUNTER_HOTKEY_EVENT,
+    SW_MAX_COLLECTION_EVENT
+} collector_stop_event_t;
+#endif // SWW_MERGE
+
+#define MAX_UNSIGNED_16_BIT_VALUE 0xFFFF
+#define MAX_UNSIGNED_24_BIT_VALUE 0xFFFFFF
+#define MAX_UNSIGNED_32_BIT_VALUE 0xFFFFFFFF
+#define MAX_UNSIGNED_64_BIT_VALUE 0xFFFFFFFFFFFFFFFF
+
+#endif // _PW_DEFINES_H_

--- a/perftools-external/socwatch_driver/include/sw_ioctl.h
+++ b/perftools-external/socwatch_driver/include/sw_ioctl.h
@@ -1,0 +1,249 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2018 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2018 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#ifndef __SW_IOCTL_H__
+#define __SW_IOCTL_H__ 1
+
+#if defined (__linux__) || defined (__QNX__)
+    #if __KERNEL__
+        #include <linux/ioctl.h>
+        #if defined(CONFIG_COMPAT) && defined(CONFIG_X86_64)
+            #include <asm/compat.h>
+            #include <linux/compat.h>
+        #endif // COMPAT && x64
+    #else // !__KERNEL__
+        #include <sys/ioctl.h>
+    #endif // __KERNEL__
+#endif // __linux__
+/*
+ * Ensure we pull in definition of 'DO_COUNT_DROPPED_SAMPLES'!
+ */
+#include "sw_defines.h"
+
+#ifdef ONECORE
+#ifndef __KERNEL__
+#include <winioctl.h>
+#endif //__KERNEL__
+#endif // ONECORE
+
+/*
+ * The APWR-specific IOCTL magic
+ * number -- used to ensure IOCTLs
+ * are delivered to the correct
+ * driver.
+ */
+// #define APWR_IOCTL_MAGIC_NUM 0xdead
+#define APWR_IOCTL_MAGIC_NUM 100
+
+/*
+ * The name of the device file
+ */
+// #define DEVICE_FILE_NAME "/dev/pw_driver_char_dev"
+#define PW_DEVICE_FILE_NAME "/dev/apwr_driver_char_dev"
+#define PW_DEVICE_NAME "apwr_driver_char_dev"
+
+enum sw_ioctl_cmd {
+    sw_ioctl_cmd_none=0,
+    sw_ioctl_cmd_config,
+    sw_ioctl_cmd_cmd,
+    sw_ioctl_cmd_poll,
+    sw_ioctl_cmd_immediate_io,
+    sw_ioctl_cmd_scu_version,
+    sw_ioctl_cmd_read_immediate,
+    sw_ioctl_cmd_driver_version,
+    sw_ioctl_cmd_avail_trace,
+    sw_ioctl_cmd_avail_notify,
+    sw_ioctl_cmd_avail_collect,
+    sw_ioctl_cmd_topology_changes,
+};
+/*
+ * The actual IOCTL commands.
+ *
+ * From the kernel documentation:
+ * "_IOR" ==> Read IOCTL
+ * "_IOW" ==> Write IOCTL
+ * "_IOWR" ==> Read/Write IOCTL
+ *
+ * Where "Read" and "Write" are from the user's perspective
+ * (similar to the file "read" and "write" calls).
+ */
+#ifdef SWW_MERGE // Windows
+     //
+     // Device type           -- in the "User Defined" range."
+     //
+    #define POWER_I_CONF_TYPE 40000
+
+    // List assigned tracepoint id
+    #define CSIR_TRACEPOINT_ID_MASK            1
+    #define DEVICE_STATE_TRACEPOINT_ID_MASK    2
+    #define CSIR_SEPARATE_TRACEPOINT_ID_MASK   3
+    #define RESET_TRACEPOINT_ID_MASK           4
+    #define DISPLAY_ON_TRACEPOINT_ID_MASK      5
+
+#ifdef SWW_MERGE
+    //
+    // TELEM BAR CONFIG
+    //
+    #define MAX_TELEM_BAR_CFG 3
+    #define TELEM_MCHBAR_CFG 0
+    #define TELEM_IPC1BAR_CFG 1
+    #define TELEM_SSRAMBAR_CFG 2
+#endif
+
+    //
+    // The IOCTL function codes from 0x800 to 0xFFF are for customer use.
+    //
+    #define PW_IOCTL_CONFIG \
+        CTL_CODE( POWER_I_CONF_TYPE, 0x900, METHOD_BUFFERED, FILE_ANY_ACCESS  )
+    #define PW_IOCTL_START_COLLECTION \
+        CTL_CODE(POWER_I_CONF_TYPE, 0x901, METHOD_BUFFERED, FILE_ANY_ACCESS)
+    #define PW_IOCTL_STOP_COLLECTION \
+        CTL_CODE(POWER_I_CONF_TYPE, 0x902, METHOD_BUFFERED, FILE_ANY_ACCESS)
+
+    // TODO: pause, resume, cancel not supported yet
+    #define PW_IOCTL_PAUSE_COLLECTION \
+        CTL_CODE(POWER_I_CONF_TYPE, 0x903, METHOD_BUFFERED, FILE_ANY_ACCESS)
+    #define PW_IOCTL_RESUME_COLLECTION \
+        CTL_CODE(POWER_I_CONF_TYPE, 0x904, METHOD_BUFFERED, FILE_ANY_ACCESS)
+    #define PW_IOCTL_CANCEL_COLLECTION \
+        CTL_CODE(POWER_I_CONF_TYPE, 0x905, METHOD_BUFFERED, FILE_ANY_ACCESS)
+
+    #define PW_IOCTL_GET_PROCESSOR_GROUP_TOPOLOGY \
+        CTL_CODE(POWER_I_CONF_TYPE, 0x906, METHOD_BUFFERED, FILE_ANY_ACCESS)
+    #define PW_IOCTL_TOPOLOGY \
+        CTL_CODE(POWER_I_CONF_TYPE, 0x907, METHOD_BUFFERED, FILE_ANY_ACCESS)
+    #define PW_IOCTL_GET_AVAILABLE_COLLECTORS \
+        CTL_CODE(POWER_I_CONF_TYPE, 0x908, METHOD_BUFFERED, FILE_ANY_ACCESS)
+    #define PW_IOCTL_IMMEDIATE_IO \
+        CTL_CODE(POWER_I_CONF_TYPE, 0x909, METHOD_BUFFERED, FILE_ANY_ACCESS)
+    #define PW_IOCTL_DRV_CLEANUP \
+        CTL_CODE(POWER_I_CONF_TYPE, 0x90A, METHOD_BUFFERED, FILE_ANY_ACCESS)
+    #define PW_IOCTL_SET_COLLECTION_EVENT \
+        CTL_CODE(POWER_I_CONF_TYPE, 0x90B, METHOD_BUFFERED, FILE_ANY_ACCESS)
+    #define PW_IOCTL_TRY_STOP_EVENT \
+        CTL_CODE(POWER_I_CONF_TYPE, 0x90C, METHOD_BUFFERED, FILE_ANY_ACCESS)
+    #define PW_IOCTL_SET_PCH_ACTIVE_INTERVAL \
+        CTL_CODE(POWER_I_CONF_TYPE, 0x90D, METHOD_BUFFERED, FILE_ANY_ACCESS)
+    #define PW_IOCTL_SET_TELEM_BAR \
+        CTL_CODE(POWER_I_CONF_TYPE, 0x90E, METHOD_BUFFERED, FILE_ANY_ACCESS)
+    #define PW_IOCTL_METADATA \
+        CTL_CODE(POWER_I_CONF_TYPE, 0x90F, METHOD_BUFFERED, FILE_ANY_ACCESS)
+    #define PW_IOCTL_SET_GBE_INTERVAL \
+        CTL_CODE(POWER_I_CONF_TYPE, 0x910, METHOD_BUFFERED, FILE_ANY_ACCESS)
+    #define PW_IOCTL_ENABLE_COLLECTION \
+        CTL_CODE(POWER_I_CONF_TYPE, 0x911, METHOD_BUFFERED, FILE_ANY_ACCESS)
+    #define PW_IOCTL_DISABLE_COLLECTION \
+        CTL_CODE(POWER_I_CONF_TYPE, 0x912, METHOD_BUFFERED, FILE_ANY_ACCESS)
+    #define PW_IOCTL_DRIVER_BUILD_DATE \
+        CTL_CODE(POWER_I_CONF_TYPE, 0x913, METHOD_BUFFERED, FILE_ANY_ACCESS)
+
+#elif !defined (__APPLE__)
+    #define PW_IOCTL_CONFIG _IOW(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_config, struct sw_driver_ioctl_arg *)
+    #if DO_COUNT_DROPPED_SAMPLES
+        #define PW_IOCTL_CMD _IOWR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_cmd, struct sw_driver_ioctl_arg *)
+    #else
+        #define PW_IOCTL_CMD _IOW(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_cmd, struct sw_driver_ioctl_arg *)
+    #endif // DO_COUNT_DROPPED_SAMPLES
+    #define PW_IOCTL_POLL _IO(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_poll)
+    #define PW_IOCTL_IMMEDIATE_IO _IOWR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_immediate_io, struct sw_driver_ioctl_arg *)
+    #define PW_IOCTL_GET_SCU_FW_VERSION _IOR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_scu_version, struct sw_driver_ioctl_arg *)
+    #define PW_IOCTL_READ_IMMEDIATE _IOWR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_read_immediate, struct sw_driver_ioctl_arg *)
+    #define PW_IOCTL_GET_DRIVER_VERSION _IOR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_driver_version, struct sw_driver_ioctl_arg *)
+    #define PW_IOCTL_GET_AVAILABLE_TRACEPOINTS _IOR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_avail_trace, struct sw_driver_ioctl_arg *)
+    #define PW_IOCTL_GET_AVAILABLE_NOTIFIERS _IOR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_avail_notify, struct sw_driver_ioctl_arg *)
+    #define PW_IOCTL_GET_AVAILABLE_COLLECTORS _IOR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_avail_collect, struct sw_driver_ioctl_arg *)
+    #define PW_IOCTL_GET_TOPOLOGY_CHANGES _IOR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_topology_changes, struct sw_driver_ioctl_arg *)
+#else // __APPLE__
+    #define PW_IOCTL_CONFIG _IOW(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_config, struct sw_driver_ioctl_arg)
+    #if DO_COUNT_DROPPED_SAMPLES
+        #define PW_IOCTL_CMD _IOWR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_cmd, struct sw_driver_ioctl_arg)
+    #else
+        #define PW_IOCTL_CMD _IOW(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_cmd, struct sw_driver_ioctl_arg)
+    #endif // DO_COUNT_DROPPED_SAMPLES
+    #define PW_IOCTL_POLL _IO(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_poll)
+    #define PW_IOCTL_IMMEDIATE_IO _IOWR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_immediate_io, struct sw_driver_ioctl_arg)
+    #define PW_IOCTL_GET_SCU_FW_VERSION _IOWR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_scu_version, struct sw_driver_ioctl_arg)
+    #define PW_IOCTL_READ_IMMEDIATE _IOWR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_read_immediate, struct sw_driver_ioctl_arg)
+    #define PW_IOCTL_GET_DRIVER_VERSION _IOWR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_driver_version, struct sw_driver_ioctl_arg)
+    #define PW_IOCTL_GET_AVAILABLE_TRACEPOINTS _IOWR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_avail_trace, struct sw_driver_ioctl_arg)
+    #define PW_IOCTL_GET_AVAILABLE_NOTIFIERS _IOWR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_avail_notify, struct sw_driver_ioctl_arg)
+    #define PW_IOCTL_GET_AVAILABLE_COLLECTORS _IOWR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_avail_collect, struct sw_driver_ioctl_arg)
+    #define PW_IOCTL_GET_TOPOLOGY_CHANGES _IOWR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_topology_changes, struct sw_driver_ioctl_arg)
+#endif // __APPLE__
+
+/*
+ * 32b-compatible version of the above
+ * IOCTL numbers. Required ONLY for
+ * 32b compatibility on 64b systems,
+ * and ONLY by the driver.
+ */
+#if defined(CONFIG_COMPAT) && defined(CONFIG_X86_64)
+    #define PW_IOCTL_CONFIG32 _IOW(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_config, compat_uptr_t)
+#if DO_COUNT_DROPPED_SAMPLES
+        #define PW_IOCTL_CMD32 _IOWR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_cmd, compat_uptr_t)
+#else
+        #define PW_IOCTL_CMD32 _IOW(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_cmd, compat_uptr_t)
+#endif // DO_COUNT_DROPPED_SAMPLES
+    #define PW_IOCTL_POLL32 _IO(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_poll)
+    #define PW_IOCTL_IMMEDIATE_IO32 _IOWR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_immediate_io, compat_uptr_t)
+    #define PW_IOCTL_GET_SCU_FW_VERSION32 _IOR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_scu_version, compat_uptr_t)
+    #define PW_IOCTL_READ_IMMEDIATE32 _IOWR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_read_immediate, compat_uptr_t)
+    #define PW_IOCTL_GET_DRIVER_VERSION32 _IOR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_driver_version, compat_uptr_t)
+    #define PW_IOCTL_GET_AVAILABLE_TRACEPOINTS32 _IOR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_avail_trace, compat_uptr_t)
+    #define PW_IOCTL_GET_AVAILABLE_NOTIFIERS32 _IOR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_avail_notify, compat_uptr_t)
+    #define PW_IOCTL_GET_AVAILABLE_COLLECTORS32 _IOR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_avail_collect, compat_uptr_t)
+    #define PW_IOCTL_GET_TOPOLOGY_CHANGES32 _IOR(APWR_IOCTL_MAGIC_NUM, sw_ioctl_cmd_topology_changes, compat_uptr_t)
+#endif // defined(CONFIG_COMPAT) && defined(CONFIG_X86_64)
+#endif // __SW_IOCTL_H__

--- a/perftools-external/socwatch_driver/include/sw_kernel_defines.h
+++ b/perftools-external/socwatch_driver/include/sw_kernel_defines.h
@@ -1,0 +1,170 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#ifndef _PW_KERNEL_DEFINES_H_
+#define _PW_KERNEL_DEFINES_H_ 1
+
+#ifdef __KERNEL__
+
+/* ***************************************************
+ * The following is only valid for kernel code.
+ * ***************************************************
+ */
+
+#if defined (__APPLE__)
+    #define likely(x)   (x)
+    #define unlikely(x) (x)
+#endif // __APPLE__
+
+#if !defined(__APPLE__)
+    #define CPU() (raw_smp_processor_id())
+    #define RAW_CPU() (raw_smp_processor_id())
+#else
+    #define CPU() (cpu_number())
+    #define RAW_CPU() (cpu_number())
+#endif // __APPLE__
+
+#define TID() (current->pid)
+#define PID() (current->tgid)
+#define NAME() (current->comm)
+#define PKG(c) ( cpu_data(c).phys_proc_id )
+#define IT_REAL_INCR() (current->signal->it_real_incr.tv64)
+
+#define ATOMIC_CAS(ptr, old_val, new_val) ( cmpxchg( (ptr), (old_val), (new_val) ) == (old_val) )
+
+/*
+ * Should we measure overheads?
+ * '1' ==> YES
+ * '0' ==> NO
+ */
+#define DO_OVERHEAD_MEASUREMENTS 0
+/*
+ * Should we track memory usage?
+ * '1' ==> YES
+ * '0' ==> NO
+ */
+#define DO_TRACK_MEMORY_USAGE 0
+/*
+ * Are we compiling with driver profiling support
+ * turned ON? If YES then force 'DO_OVERHEAD_MEASUREMENTS'
+ * and 'DO_TRACK_MEMORY_USAGE' to be TRUE.
+ */
+#if DO_DRIVER_PROFILING
+    #if !DO_OVERHEAD_MEASUREMENTS
+        #undef DO_OVERHEAD_MEASUREMENTS
+        #define DO_OVERHEAD_MEASUREMENTS 1
+    #endif // DO_OVERHEAD_MEASUREMENTS
+    #if !DO_TRACK_MEMORY_USAGE
+        #undef DO_TRACK_MEMORY_USAGE
+        #define DO_TRACK_MEMORY_USAGE 1
+    #endif // DO_TRACK_MEMORY_USAGE
+#endif // DO_DRIVER_PROFILING
+/*
+ * Should we allow debug output.
+ * Set to: "1" ==> 'OUTPUT' is enabled.
+ *         "0" ==> 'OUTPUT' is disabled.
+ */
+#define DO_DEBUG_OUTPUT 0
+/*
+ * Control whether to output driver ERROR messages.
+ * These are independent of the 'OUTPUT' macro
+ * (which controls debug messages).
+ * Set to '1' ==> Print driver error messages (to '/var/log/messages')
+ *        '0' ==> Do NOT print driver error messages
+ */
+#define DO_PRINT_DRIVER_ERROR_MESSAGES 1
+/*
+ * Macros to control output printing.
+ */
+#if !defined(__APPLE__)
+    #if DO_DEBUG_OUTPUT
+        #define pw_pr_debug(...) printk(KERN_INFO __VA_ARGS__)
+        #define pw_pr_warn(...) printk(KERN_WARNING __VA_ARGS__)
+    #else
+        #define pw_pr_debug(...)
+        #define pw_pr_warn(...)
+    #endif
+    #define pw_pr_force(...) printk(KERN_INFO __VA_ARGS__)
+#else
+    #if DO_DEBUG_OUTPUT
+        #define pw_pr_debug(...) IOLog(__VA_ARGS__)
+        #define pw_pr_warn(...) IOLog(__VA_ARGS__)
+    #else
+        #define pw_pr_debug(...)
+        #define pw_pr_warn(...)
+    #endif
+    #define pw_pr_force(...) IOLog(__VA_ARGS__)
+#endif // __APPLE__
+
+/*
+ * Macro for driver error messages.
+ */
+#if !defined(__APPLE__)
+    #if (DO_PRINT_DRIVER_ERROR_MESSAGES || DO_DEBUG_OUTPUT)
+        #define pw_pr_error(...) printk(KERN_ERR __VA_ARGS__)
+    #else
+        #define pw_pr_error(...)
+    #endif
+#else
+    #if (DO_PRINT_DRIVER_ERROR_MESSAGES || DO_DEBUG_OUTPUT)
+        #define pw_pr_error(...) IOLog(__VA_ARGS__)
+    #else
+        #define pw_pr_error(...)
+    #endif
+#endif // __APPLE__
+
+#endif // __KERNEL__
+
+#endif // _PW_KERNEL_DEFINES_H_

--- a/perftools-external/socwatch_driver/include/sw_structs.h
+++ b/perftools-external/socwatch_driver/include/sw_structs.h
@@ -1,0 +1,478 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#ifndef __SW_STRUCTS_H__
+#define __SW_STRUCTS_H__ 1
+
+#include "sw_types.h"
+
+/*
+ * An enumeration of MSR types.
+ * Required if we want to differentiate
+ * between different types of MSRs.
+ */
+enum sw_msr_type {
+    SW_MSR_TYPE_THREAD,
+    SW_MSR_TYPE_CORE,
+    SW_MSR_TYPE_MODULE,
+    SW_MSR_TYPE_PACKAGE,
+    SW_MSR_TYPE_SOC,
+    SW_MSR_TYPE_MAX,
+};
+
+/*
+ * Convenience for a 'string' data type.
+ * Not strictly required.
+ */
+#pragma pack(push, 1)
+typedef struct sw_string_type {
+    pw_u16_t len;
+    char data[1];
+} sw_string_type_t;
+#pragma pack(pop)
+#define SW_STRING_TYPE_HEADER_SIZE() (sizeof(struct sw_string_type) - sizeof(char[1]))
+
+#pragma pack(push, 1)
+struct sw_key_value_payload {
+    pw_u16_t m_numKeyValuePairs;
+    char data[1];
+};
+#pragma pack(pop)
+#define SW_KEY_VALUE_PAYLOAD_HEADER_SIZE() (sizeof(struct sw_key_value_payload) - sizeof(char[1]))
+
+typedef enum sw_kernel_wakelock_type {
+    SW_WAKE_LOCK        =0, // A kernel wakelock was acquired
+    SW_WAKE_UNLOCK      =1, // A kernel wakelock was released
+    SW_WAKE_LOCK_TIMEOUT=2, // A kernel wakelock was acquired with a timeout
+    SW_WAKE_LOCK_INITIAL=3, // A kernel wakelock was acquired before the
+                            //   collection started
+    SW_WAKE_UNLOCK_ALL  =4, // All previously held kernel wakelocks were
+                            //   released -- used in ACPI S3 notifications
+} sw_kernel_wakelock_type_t;
+
+typedef enum sw_when_type {
+    SW_WHEN_TYPE_BEGIN=0, /* Start snapshot */
+    SW_WHEN_TYPE_POLL,
+    SW_WHEN_TYPE_NOTIFIER,
+    SW_WHEN_TYPE_TRACEPOINT,
+    SW_WHEN_TYPE_END, /* Stop snapshot */
+    SW_WHEN_TYPE_NONE
+} sw_when_type_t;
+
+/**
+ * trigger_bits is defined to use type pw_u8_t that makes only upto 8 types possible 
+ */
+#define SW_TRIGGER_BEGIN_MASK()      (1U << SW_WHEN_TYPE_BEGIN)
+#define SW_TRIGGER_END_MASK()        (1U << SW_WHEN_TYPE_END)
+#define SW_TRIGGER_POLL_MASK()       (1U << SW_WHEN_TYPE_POLL)
+#define SW_TRIGGER_TRACEPOINT_MASK() (1U << SW_WHEN_TYPE_TRACEPOINT)
+#define SW_TRIGGER_NOTIFIER_MASK()   (1U << SW_WHEN_TYPE_NOTIFIER)
+#define SW_GET_TRIGGER_MASK_VALUE(m) (1U << (m))
+#define SW_TRIGGER_MASK_ALL()        (0xFF)
+
+enum sw_io_cmd {
+    SW_IO_CMD_READ=0,
+    SW_IO_CMD_WRITE,
+    SW_IO_CMD_MAX
+};
+
+
+#pragma pack(push, 1)
+struct sw_driver_msr_io_descriptor {
+    pw_u64_t address;
+    enum sw_msr_type type;
+};
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+struct sw_driver_ipc_mmio_io_descriptor {
+    union {
+        struct {
+            pw_u16_t command;
+            pw_u16_t sub_command;
+        };
+        union {
+            pw_u32_t ipc_command; // (sub_command << 12) | (command)
+            pw_u8_t is_gbe; // Used only for GBE MMIO
+        };
+    };
+    // TODO: add a section for 'ctrl_address' and 'ctrl_remapped_address'
+    union {
+        pw_u64_t data_address; // Will be "io_remapped"
+        pw_u64_t data_remapped_address;
+    };
+};
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+struct sw_driver_pci_io_descriptor {
+    pw_u32_t bus;
+    pw_u32_t device;
+    pw_u32_t function;
+#ifdef __QNX__
+    union {
+        pw_u32_t offset;
+        pw_u32_t index;
+    };
+#else /* __QNX__ */
+    pw_u32_t offset;
+#endif /* __QNX__ */
+};
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+struct sw_driver_configdb_io_descriptor {
+    // pw_u32_t port;
+    // pw_u32_t offset;
+    pw_u32_t address;
+};
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+struct sw_driver_trace_args_io_descriptor {
+    pw_u8_t num_args; // Number of valid entries in the 'args' array, below; 1 <= num_args <= 7
+    pw_u8_t args[7]; // Max of 7 args can be recorded
+};
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+/**
+ * struct - sw_driver_telem_io_descriptor - Telemetry Metric descriptor
+ *
+ * @id:    (Client & Driver) Telemetry ID of the counter to read.
+ * @idx:   (Driver only) index into telem array to read, or the row
+ *            of the telem_indirect table to lookup the telem array index.
+ * @unit:  Unit from which to collect:  0 = PMC, 1 = PUNIT
+ *              Values come from the telemetry_unit enum.
+ * @scale_op:  When there are multiple instances of a telem value (e.g.
+ *              module C-states) the operation to use when scaling the CPU ID
+ *              and adding it to the telemetry data ID.
+ * @scale_val: Amount to scale an ID (when scaling one.)
+ *
+ * Like all hardware mechanism descriptors, the client uses this to pass
+ * metric hardware properties (unit and ID) to the driver.  The driver
+ * uses it to program the telemetry unit.
+ *
+ * Users can specify that IDs should be scaled based on the CPU id, using
+ * the equation: ID = ID_value + (cpuid <scaling_op> <scaling_val>)
+ * where <scaling_op> is one of +, *, /, or %, and scaling_val is an integer
+ * value.  This gives you:
+ *            Operation             scale_op     scale_val
+ *       Single instance of an ID       *            0
+ *       Sequentially increasing
+ *          CPU-specific values         *            1
+ *       Per module cpu-specific
+ *          values (2 cores/module)     /            2
+ *       Round Robin assignment         %         cpu_count
+ *
+ * Note that scaling_value of 0 implies that no scaling should be
+ * applied.  While (*, 1) is equivalent to (+, 0), the scaling value of 0
+ * is reserved/defined to mean "no scaling", and is disallowed.
+ *
+ * If you're really tight on space, you could always fold unit and
+ * scale_op into a single byte without a lot of pain or even effort.
+ */
+struct sw_driver_telem_io_descriptor {
+    union {
+        pw_u16_t id;
+        pw_u8_t  idx;
+    };
+    pw_u8_t   unit;
+    pw_u8_t   scale_op;
+    pw_u16_t  scale_val;
+};
+#pragma pack(pop)
+enum telemetry_unit { TELEM_PUNIT = 0, TELEM_PMC, TELEM_UNIT_NONE };
+#define TELEM_MAX_ID    0xFFFF  /* Maximum value of a Telemtry event ID. */
+#define TELEM_MAX_SCALE 0xFFFF  /* Maximum ID scaling value. */
+#define TELEM_OP_ADD    '+'     /* Addition operator */
+#define TELEM_OP_MULT   '*'     /* Multiplication operator */
+#define TELEM_OP_DIV    '/'     /* Division operator */
+#define TELEM_OP_MOD    '%'     /* Modulus operator */
+#define TELEM_OP_NONE   'X'     /* No operator--Not a scaled ID */
+
+#pragma pack(push, 1)
+struct sw_driver_mailbox_io_descriptor {
+    union {
+        /*
+         * Will be "io_remapped"
+         */
+        pw_u64_t interface_address;
+        pw_u64_t interface_remapped_address;
+    };
+    union {
+        /*
+         * Will be "io_remapped"
+         */
+        pw_u64_t data_address;
+        pw_u64_t data_remapped_address;
+    };
+    pw_u64_t command;
+    pw_u64_t command_mask;
+    pw_u16_t run_busy_bit;
+    pw_u16_t is_msr_type;
+};
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+struct sw_driver_pch_mailbox_io_descriptor {
+    union {
+        /*
+         * Will be "io_remapped"
+         */
+        pw_u64_t mtpmc_address;
+        pw_u64_t mtpmc_remapped_address;
+    };
+    union {
+        /*
+         * Will be "io_remapped"
+         */
+        pw_u64_t msg_full_sts_address;
+        pw_u64_t msg_full_sts_remapped_address;
+    };
+    union {
+        /*
+         * Will be "io_remapped"
+         */
+        pw_u64_t mfpmc_address;
+        pw_u64_t mfpmc_remapped_address;
+    };
+    pw_u32_t data_address;
+};
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+typedef struct sw_driver_io_descriptor {
+    pw_u16_t collection_type;
+    // TODO: specify READ/WRITE
+    pw_s16_t collection_command; // One of 'enum sw_io_cmd'
+    pw_u16_t counter_size_in_bytes; // The number of bytes to READ or WRITE
+    union {
+        struct sw_driver_msr_io_descriptor        msr_descriptor;
+        struct sw_driver_ipc_mmio_io_descriptor   ipc_descriptor;
+        struct sw_driver_ipc_mmio_io_descriptor   mmio_descriptor;
+        struct sw_driver_pci_io_descriptor        pci_descriptor;
+        struct sw_driver_configdb_io_descriptor   configdb_descriptor;
+        struct sw_driver_trace_args_io_descriptor trace_args_descriptor;
+        struct sw_driver_telem_io_descriptor      telem_descriptor;
+        struct sw_driver_pch_mailbox_io_descriptor pch_mailbox_descriptor;
+        struct sw_driver_mailbox_io_descriptor    mailbox_descriptor;
+    };
+    pw_u64_t write_value; // The value to WRITE
+} sw_driver_io_descriptor_t;
+#pragma pack(pop)
+
+/**
+ * sw_driver_interface_info is used to map data collected by kernel-level
+ * collectors to metrics.  The client passes one of these structs to the
+ * driver for each metric the driver should collect.  The driver tags the
+ * collected data (messages) using info from this struct. When processing
+ * data from the driver, the client uses its copy of this data to
+ * identify the plugin, metric, and message IDs of each message.
+ */
+#pragma pack(push, 1)
+struct sw_driver_interface_info {
+    pw_u64_t tracepoint_id_mask;
+    pw_u64_t notifier_id_mask;
+    pw_s16_t cpu_mask;  // On which CPU(s) should the driver read the data?
+                        // Currently:  -2 ==> read on ALL CPUs,
+                        //             -1 ==> read on ANY CPU,
+                        //           >= 0 ==> the specific CPU to read on
+    pw_s16_t plugin_id; // Metric Plugin SID
+    pw_s16_t metric_id; // Domain-specific ID assigned by each Metric Plugin
+    pw_s16_t msg_id;    // Msg ID retrieved from the SoC Watch config file
+    pw_u16_t num_io_descriptors; // Number of descriptors in the array, below.
+    pw_u8_t  trigger_bits;  // Mask of 'when bits' to fire this collector.
+    pw_u16_t sampling_interval_msec; // Sampling interval, in msecs
+    pw_u8_t  descriptors[1];     // Array of sw_driver_io_descriptor structs.
+};
+#pragma pack(pop)
+
+#define SW_DRIVER_INTERFACE_INFO_HEADER_SIZE() (sizeof(struct sw_driver_interface_info) - sizeof(pw_u8_t[1]))
+
+#pragma pack(push, 1)
+struct sw_driver_interface_msg {
+    pw_u16_t num_infos; // Number of 'sw_driver_interface_info' structs contained within the 'infos' variable, below
+    pw_u16_t min_polling_interval_msecs; // Min time to wait before polling; used exclusively
+                                         // with the low overhead, context-switch based
+                                         // polling mode
+    // pw_u16_t infos_size_bytes; // Size of data inlined within the 'infos' variable, below
+    pw_u8_t infos[1];
+};
+#pragma pack(pop)
+#define SW_DRIVER_INTERFACE_MSG_HEADER_SIZE() (sizeof(struct sw_driver_interface_msg) - sizeof(pw_u8_t[1]))
+
+typedef enum sw_name_id_type {
+    SW_NAME_TYPE_TRACEPOINT,
+    SW_NAME_TYPE_NOTIFIER,
+    SW_NAME_TYPE_COLLECTOR,
+    SW_NAME_TYPE_MAX,
+} sw_name_id_type_t;
+
+#pragma pack(push, 1)
+struct sw_name_id_pair {
+    pw_u16_t id;
+    pw_u16_t type; // One of 'sw_name_id_type'
+    struct sw_string_type name;
+};
+#pragma pack(pop)
+#define SW_NAME_ID_HEADER_SIZE() (sizeof(struct sw_name_id_pair) - sizeof(struct sw_string_type))
+
+#pragma pack(push, 1)
+struct sw_name_info_msg {
+    pw_u16_t num_name_id_pairs;
+    pw_u16_t payload_len;
+    pw_u8_t pairs[1];
+};
+#pragma pack(pop)
+
+/**
+ * This is the basic data structure for passing data collected by the
+ * kernel-level collectors up to the client.  In addition to the data
+ * (payload), it contains the minimum metadata required for the client
+ * to identify the source of that data.
+ */
+#pragma pack(push, 1)
+typedef struct sw_driver_msg {
+    pw_u64_t tsc;
+    pw_u16_t cpuidx;
+    pw_u8_t  plugin_id;     // Cannot have more than 256 plugins
+    pw_u8_t  metric_id;     // Each plugin cannot handle more than 256 metrics
+    pw_u8_t  msg_id;        // Each metric cannot have more than 256 components
+    pw_u16_t payload_len;
+    // pw_u64_t p_payload;  // Ptr to payload
+    union {
+        pw_u64_t __dummy;   // Ensure size of struct is consistent on x86, x64
+        char    *p_payload; // Ptr to payload (collected data values).
+    };
+} sw_driver_msg_t;
+#pragma pack(pop)
+#define SW_DRIVER_MSG_HEADER_SIZE() (sizeof(struct sw_driver_msg) - sizeof(pw_u64_t))
+
+typedef enum sw_driver_collection_cmd {
+    SW_DRIVER_START_COLLECTION=1,
+    SW_DRIVER_STOP_COLLECTION=2,
+    SW_DRIVER_PAUSE_COLLECTION=3,
+    SW_DRIVER_RESUME_COLLECTION=4,
+    SW_DRIVER_CANCEL_COLLECTION=5,
+} sw_driver_collection_cmd_t;
+
+#pragma pack(push, 1)
+struct sw_driver_version_info {
+    pw_u16_t major;
+    pw_u16_t minor;
+    pw_u16_t other;
+};
+#pragma pack(pop)
+
+enum cpu_action {
+    SW_CPU_ACTION_NONE,
+    SW_CPU_ACTION_OFFLINE,
+    SW_CPU_ACTION_ONLINE_PREPARE,
+    SW_CPU_ACTION_ONLINE,
+    SW_CPU_ACTION_MAX,
+};
+#pragma pack(push, 1)
+struct sw_driver_topology_change {
+    pw_u64_t timestamp; // timestamp
+    enum cpu_action type; // One of 'enum cpu_action'
+    pw_u16_t cpu; // logical cpu
+    pw_u16_t core; // core id
+    pw_u16_t pkg; // pkg/physical id
+};
+struct sw_driver_topology_msg {
+    pw_u16_t num_entries;
+    pw_u8_t topology_entries[1];
+};
+#pragma pack(pop)
+
+/**
+ * An enumeration of possible pm states that
+ * SoC Watch is interested in
+ */
+enum sw_pm_action {
+    SW_PM_ACTION_NONE,
+    SW_PM_ACTION_SUSPEND_ENTER,
+    SW_PM_ACTION_SUSPEND_EXIT,
+    SW_PM_ACTION_HIBERNATE_ENTER,
+    SW_PM_ACTION_HIBERNATE_EXIT,
+    SW_PM_ACTION_MAX,
+};
+
+/*
+ * Wrapper for ioctl arguments.
+ * EVERY ioctl MUST use this struct!
+ */
+#pragma pack(push, 1)
+struct sw_driver_ioctl_arg {
+    pw_s32_t in_len;
+    pw_s32_t out_len;
+    // pw_u64_t p_in_arg; // Pointer to input arg
+    // pw_u64_t p_out_arg; // Pointer to output arg
+    char *in_arg;
+    char *out_arg;
+};
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+typedef struct sw_driver_msg_interval {
+    pw_u8_t  plugin_id;     // Cannot have more than 256 plugins
+    pw_u8_t  metric_id;     // Each plugin cannot handle more than 256 metrics
+    pw_u8_t  msg_id;        // Each metric cannot have more than 256 components
+    pw_u16_t interval;      // collection interval
+} sw_driver_msg_interval_t;
+#pragma pack(pop)
+
+#endif // __SW_STRUCTS_H__

--- a/perftools-external/socwatch_driver/include/sw_types.h
+++ b/perftools-external/socwatch_driver/include/sw_types.h
@@ -1,0 +1,152 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef _PW_TYPES_H_
+#define _PW_TYPES_H_
+
+#if defined (__linux__) || defined (__APPLE__) || defined (__QNX__)
+
+#ifndef __KERNEL__
+/*
+ * Called from Ring-3.
+ */
+#include <stdint.h> // Grab 'uint64_t' etc.
+#include <unistd.h> // Grab 'pid_t'
+/*
+ * UNSIGNED types...
+ */
+typedef uint8_t  u8;
+typedef uint16_t u16;
+typedef uint32_t u32;
+typedef uint64_t u64;
+/*
+ * SIGNED types...
+ */
+typedef int8_t s8;
+typedef int16_t s16;
+typedef int32_t s32;
+typedef int64_t s64;
+
+#else // __KERNEL__
+#if !defined (__APPLE__)
+#include <linux/types.h>
+#else // __APPLE__
+#include <sys/types.h>
+#include <stdint.h> // Grab 'uint64_t' etc.
+
+typedef uint8_t  u8;
+typedef uint16_t u16;
+typedef uint32_t u32;
+typedef uint64_t u64;
+/*
+* SIGNED types...
+*/
+typedef int8_t s8;
+typedef int16_t s16;
+typedef int32_t s32;
+typedef int64_t s64;
+#endif // __APPLE__
+#endif // __KERNEL__
+
+#elif defined (_WIN32)
+typedef __int32 int32_t;
+typedef unsigned __int32 uint32_t;
+typedef __int64 int64_t;
+typedef unsigned __int64 uint64_t;
+
+/*
+ * UNSIGNED types...
+ */
+typedef unsigned char u8;
+typedef unsigned short u16;
+typedef unsigned int u32;
+typedef unsigned long long u64;
+
+/*
+ * SIGNED types...
+ */
+typedef signed char s8;
+typedef signed short s16;
+typedef signed int s32;
+typedef signed long long s64;
+typedef s32 pid_t;
+typedef s32 ssize_t;
+
+#endif // _WIN32
+
+/* ************************************
+ * Common to both operating systems.
+ * ************************************
+ */
+/*
+ * UNSIGNED types...
+ */
+typedef u8 pw_u8_t;
+typedef u16 pw_u16_t;
+typedef u32 pw_u32_t;
+typedef u64 pw_u64_t;
+
+/*
+ * SIGNED types...
+ */
+typedef s8 pw_s8_t;
+typedef s16 pw_s16_t;
+typedef s32 pw_s32_t;
+typedef s64 pw_s64_t;
+
+typedef pid_t pw_pid_t;
+
+#endif // _PW_TYPES_H_

--- a/perftools-external/socwatch_driver/include/sw_user_defines.h
+++ b/perftools-external/socwatch_driver/include/sw_user_defines.h
@@ -1,0 +1,404 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2017 - 2018 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2017 - 2018 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef _PW_USER_DEFINES_H_
+#define _PW_USER_DEFINES_H_ 1
+#ifndef __KERNEL__
+
+#include <stdio.h> // for "FILE *"
+#include <errno.h> // for "PW_PERROR"
+#include <string.h> // for "PW_PERROR"
+#include <fstream> // for "std::ofstream"
+#ifndef _WIN32
+    #include <sys/time.h> // for "gettimeofday"
+#endif // windows
+#if defined (__APPLE__)
+    #include <mach/clock.h>
+    #include <mach/mach.h>
+#endif // __APPLE__
+#include "sw_types.h"
+#include "plugin_environment.h"
+
+
+/* ***************************************************
+ * The following is valid only for userspace code.
+ * ***************************************************
+ */
+/*
+ * Default output file name -- the extensions depend on
+ * which program is executing: wuwatch output files have
+ * a ".sw1" extension, while wudump output files have a
+ * ".txt" extension. The extensions are added in by the
+ * respective programs i.e. wuwatch/wudump.
+ */
+#define DEFAULT_WUWATCH_OUTPUT_FILE_NAME "wuwatch_output"
+/*
+ * Default wuwatch config file name.
+ */
+#define DEFAULT_WUWATCH_CONFIG_FILE_NAME "wuwatch_config.txt"
+/*
+ * Default SWA 2.0 output file prefix. Actual file will
+ * be called 'SoCWatchOutput.sw2'
+ */
+#define DEFAULT_SWA_OUTPUT_FILE_PREFIX "SoCWatchOutput"
+/*
+ * Default SWA 2.0 config file name.
+ */
+#define DEFAULT_SWA_CONFIG_FILE_NAME "SOCWatchConfig.txt"
+/*
+ * Default SWA 2.0 config file directory.
+ */
+#ifdef SWW_MERGE
+#define DEFAULT_SWA_CONFIG_FILE_DIRECTORY "configs\\"
+#define DEFAULT_OUTPUT_CONFIG_FILE_DIRECTORY "output_configs\\"
+#define SW_COLLECTION_FILE_EXTENSION ".etl" // sww
+#define SWW_COLLECTION_FILE_PREFIX "_infoSession"
+#else
+#define DEFAULT_SWA_CONFIG_FILE_DIRECTORY "configs/"
+#define DEFAULT_OUTPUT_CONFIG_FILE_DIRECTORY "output_configs/"
+#define SW_COLLECTION_FILE_EXTENSION ".sw2" // swa
+#endif
+
+/*
+ * Default SWA 2.0 polling interval.
+ */
+#define DEFAULT_SWA_POLLING_INTERVAL_MSECS 100
+
+
+
+/*
+ * Macro to convert a {major.minor.other} version into a
+ * single 32-bit unsigned version number.
+ * This is useful when comparing versions, for example.
+ * Pretty much identical to the 'KERNEL_VERSION(...)' macro.
+ */
+//#define WUWATCH_VERSION(major, minor, other) ( (2^16) * (major) + (2^8) * (minor) + (other) )
+// #define COLLECTOR_VERSION(major, minor, other) ( (2^16) * (major) + (2^8) * (minor) + (other) )
+#define COLLECTOR_VERSION(major, minor, other) ( ((pw_u32_t)(major) << 16) + ((pw_u32_t)(minor) << 8) + (pw_u32_t)(other) )
+
+#define PW_SWA_RESULT_FILE_MAGIC_HEADER (0x8000000000000000ULL)
+#define PW_EXTRACT_SWA_MAGIC_HEADER(m) ( (m) & PW_SWA_RESULT_FILE_MAGIC_HEADER )
+#define PW_EXTRACT_SWA_VERSION_NUMBER(m) (pw_u32_t)( (m) & ~PW_SWA_RESULT_FILE_MAGIC_HEADER )
+#define PW_GET_MAJOR_FROM_COLLECTOR(v) (pw_u8_t) ( (v) >> 16 & 0xff )
+#define PW_GET_MINOR_FROM_COLLECTOR(v) (pw_u8_t) ( (v) >> 8 & 0xff )
+#define PW_GET_OTHER_FROM_COLLECTOR(v) (pw_u8_t) ( (v) & 0xff )
+#define PW_CONVERT_COLLECTOR_VERSION_TO_STRING(v) ([&]{std::stringstream __stream; \
+        __stream << (int)PW_GET_MAJOR_FROM_COLLECTOR(v) << "." << (int)PW_GET_MINOR_FROM_COLLECTOR(v) \
+        << "." << (int)PW_GET_OTHER_FROM_COLLECTOR(v); return __stream.str();}())
+/*
+ * Stringify.
+ */
+#define __STRING(x) #x
+#define TO_STRING(x) __STRING(x)
+/*
+ * Iterate over vectors, deques and ranges.
+ */
+#define for_each_ptr_in_vector(ptr, vector) for (size_t __curr=0, __end=(vector).size(); __curr!=__end && (ptr=(vector)[__curr]); ++__curr)
+/*
+ * Find a string 'str' in an array of 'std::string' instances
+ */
+#define FIND_STRING_IN_ARRAY(ptr, str, array) \
+    ([&]() { \
+        int s = SW_ARRAY_SIZE(array); \
+        bool found = (ptr = std::find((array), (array)+s, (str))) != &((array)[s]); \
+        return found; }())
+
+/* **************************************
+ * Debugging tools.
+ * **************************************
+ */
+enum pw_log_level_t {
+    PW_LOG_LEVEL_FATAL=0, /* Print FATALs */
+    PW_LOG_LEVEL_ERROR=1, /* Print ERRORs */
+    PW_LOG_LEVEL_WARNING=2, /* Print ERRORs + WARNINGs */
+    PW_LOG_LEVEL_DEBUG=3, /* Print ERRORs + WARNINGs + DEBUGs */
+    PW_LOG_LEVEL_INFO=4, /* Print ERRORs + WARNINGs + DEBUGs + INFORMATIONALs */
+#ifdef SWW_MERGE
+    // Windows cannot stringize a macro and then use the result to stringize
+    // another macro like g++ can.
+    PW_LOG_LEVEL_0 = PW_LOG_LEVEL_FATAL,
+    PW_LOG_LEVEL_1 = PW_LOG_LEVEL_ERROR,
+    PW_LOG_LEVEL_2 = PW_LOG_LEVEL_WARNING,
+    PW_LOG_LEVEL_3 = PW_LOG_LEVEL_DEBUG,
+    PW_LOG_LEVEL_4 = PW_LOG_LEVEL_INFO
+#endif // SWW_MERGE
+};
+
+//Defines to make the macros below work
+// #define PW_LOG_LEVEL_FATAL PW_LOG_LEVEL_ERROR
+#define s_FATALLogFP g_pluginEnvironment->getErrorLogFP()
+#define s_ERRORLogFP g_pluginEnvironment->getErrorLogFP()
+#define s_INFOLogFP g_pluginEnvironment->getDebugLogFP()
+#define s_WARNINGLogFP g_pluginEnvironment->getDebugLogFP()
+#define s_DEBUGLogFP g_pluginEnvironment->getDebugLogFP()
+#define PW_FATAL_STREAM std::cerr
+#define PW_ERROR_STREAM std::cerr
+#define PW_WARNING_STREAM std::cerr
+#define PW_INFO_STREAM std::cout
+#define PW_DEBUG_STREAM std::cout
+
+#ifdef SWW_MERGE
+    // Windows cannot stringize a macro and then use the result to stringize
+    // another macro like g++ can. NOTE: The numbers must match the pw_log_level_t enum!
+    #define PW_0_STREAM PW_FATAL_STREAM
+    #define PW_1_STREAM PW_ERROR_STREAM
+    #define PW_2_STREAM PW_WARNING_STREAM
+    #define PW_3_STREAM PW_INFO_STREAM
+    #define PW_4_STREAM PW_DEBUG_STREAM
+#endif // SWW_MERGE
+
+#define PW_LOG_OUTPUT(level, fp, format, ...) do { if (unlikely((level) <= g_pluginEnvironment->getVerbosity())){ fprintf(fp, format, ##__VA_ARGS__); fflush(fp);}} while(0);
+#define PW_GET_STREAM_HELPER(level, stream) ( (g_pluginEnvironment->getVerbosity() && (level) <= g_pluginEnvironment->getVerbosity()) ? (stream) : g_pluginEnvironment->getNullStream())
+/*
+ * Helper macros to print information
+ */
+#define PW_LOG_FATAL(format, ...) PW_LOG_OUTPUT(PW_LOG_LEVEL_FATAL, g_pluginEnvironment->getErrorLogFP(), "FATAL: " format, ##__VA_ARGS__);
+#define PW_LOG_ERROR(format, ...) PW_LOG_OUTPUT(PW_LOG_LEVEL_ERROR, g_pluginEnvironment->getErrorLogFP(), "ERROR: " format, ##__VA_ARGS__);
+#define PW_LOG_FATAL_LINE(format, ...) \
+    do { \
+        PW_LOG_OUTPUT(PW_LOG_LEVEL_FATAL, g_pluginEnvironment->getErrorLogFP(), "FATAL: " format, ##__VA_ARGS__); \
+        PW_LOG_OUTPUT(PW_LOG_LEVEL_DEBUG, g_pluginEnvironment->getErrorLogFP(), "         at %s:%d\n", __FILE__, __LINE__);\
+    } while (0);
+#define PW_LOG_ERROR_LINE(format, ...) \
+    do { \
+        PW_LOG_OUTPUT(PW_LOG_LEVEL_ERROR, g_pluginEnvironment->getErrorLogFP(), "ERROR: " format, ##__VA_ARGS__); \
+        PW_LOG_OUTPUT(PW_LOG_LEVEL_DEBUG, g_pluginEnvironment->getErrorLogFP(), "         at %s:%d\n", __FILE__, __LINE__);\
+    } while (0);
+#define PW_LOG_WARNING(format, ...) PW_LOG_OUTPUT(PW_LOG_LEVEL_WARNING, g_pluginEnvironment->getDebugLogFP(), "WARNING: " format, ##__VA_ARGS__)
+#define PW_LOG_DEBUG(format, ...) PW_LOG_OUTPUT(PW_LOG_LEVEL_DEBUG, g_pluginEnvironment->getDebugLogFP(),     "DEBUG: " format, ##__VA_ARGS__)
+#define PW_LOG_INFO(format, ...) PW_LOG_OUTPUT(PW_LOG_LEVEL_INFO, g_pluginEnvironment->getDebugLogFP(),       "INFO: " format, ##__VA_ARGS__)
+#define PW_LOG(type, ...) PW_LOG_OUTPUT(PW_LOG_LEVEL_##type, s_##type##LogFP, __VA_ARGS__)
+#define PW_LOG_FORCE(format, ...) fprintf(g_pluginEnvironment->getDebugLogFP(), format, ##__VA_ARGS__) /* Force a debug printf */
+
+/*
+ * For "conditional" logging i.e. logging if the log prefix
+ * matches one of the strings passed in by the user
+ */
+#define PW_COND_LOG(type, prefix, ...) do { \
+    FILE *_fp = s_##type##LogFP; \
+    if ((PW_LOG_LEVEL_##type) <= g_pluginEnvironment->getVerbosity() || g_pluginEnvironment->isDebugLoggingEnabledFor(prefix)) { \
+        fprintf(_fp, ##__VA_ARGS__); fflush(_fp); \
+    } \
+} while (0);
+
+#define PW_COND_LOG_ERROR(prefix, format, ...) PW_COND_LOG(ERROR, prefix, "ERROR: " format, ##__VA_ARGS__)
+#define PW_COND_LOG_WARNING(prefix, format, ...) PW_COND_LOG(WARNING, prefix, "WARNING: " format, ##__VA_ARGS__)
+#define PW_COND_LOG_DEBUG(prefix, format, ...) PW_COND_LOG(DEBUG, prefix, "DEBUG: " format, ##__VA_ARGS__)
+#define PW_COND_LOG_INFO(prefix, format, ...) PW_COND_LOG(INFO, prefix, "INFO: " format, ##__VA_ARGS__)
+#define PW_COND_LOG_FATAL(prefix, format, ...) PW_COND_LOG(FATAL, prefix, "FATAL: " format, ##__VA_ARGS__)
+#define PW_COND_LOG_FORCE(prefix, format, ...) PW_COND_LOG(FATAL, prefix, format, ##__VA_ARGS__)
+
+/*
+ * Macro to queue a text message to be sent to writer plugins once
+ * they are initialized.
+ * TODO: Find a way for the "PW_LOG_TEXT_MESSAGE" macro to either queue the input string, or create
+ * a 'TextMessage' instance depending on whether or not writer plugins have been initialized.
+ */
+#define PW_LOG_TEXT_MESSAGE(str) g_pluginEnvironment->queueMessage(str)
+/*
+ * Macro to display a text message to the console as well as queue the
+ * text message to be sent to writer plugins once they are initialized.
+ */
+#define PW_LOG_MESSAGE(str) do { \
+    PW_LOG_FORCE("%s\n", (str)); \
+    PW_LOG_TEXT_MESSAGE(str); \
+} while (0)
+
+#define PW_GET_FATAL_STREAM() PW_GET_STREAM_HELPER(PW_LOG_LEVEL_FATAL, std::cerr << "FATAL: ")
+#define PW_GET_ERROR_STREAM() PW_GET_STREAM_HELPER(PW_LOG_LEVEL_ERROR, std::cerr << "ERROR: ")
+#define PW_GET_WARNING_STREAM() PW_GET_STREAM_HELPER(PW_LOG_LEVEL_WARNING, std::cerr << "WARNING: ")
+#define PW_GET_DEBUG_STREAM() PW_GET_STREAM_HELPER(PW_LOG_LEVEL_DEBUG, std::cout << "DEBUG: ")
+#define PW_GET_INFO_STREAM() PW_GET_STREAM_HELPER(PW_LOG_LEVEL_INFO, std::cout << "INFO: ")
+#define PW_GET_STREAM(type) PW_GET_STREAM_HELPER(PW_LOG_LEVEL_##type, PW_##type##_STREAM)
+#define PW_GET_FORCE_STREAM() (std::cerr)
+
+/*
+ * Macros to copy and or assert.
+ */
+#define PW_DEBUG_COPY(level, ...) do { \
+    if (unlikely(g_pluginEnvironment->getVerbosity() && (PW_LOG_LEVEL_##level) <= g_pluginEnvironment->getVerbosity())) { \
+        std::copy(__VA_ARGS__); \
+    } \
+} while (0)
+#define PW_DEBUG_ASSERT(level, cond, ...) do { \
+    if (unlikely(g_pluginEnvironment->getVerbosity() && (PW_LOG_LEVEL_##level) <= g_pluginEnvironment->getVerbosity() && !(cond))) { \
+        PW_LOG_ERROR(__VA_ARGS__); \
+        PW_ASSERT(false); \
+    } \
+} while (0)
+
+/*
+ * Helper macro to calculate the diff between current and previous value and handle counter wrap around
+ */
+#define COUNTER_DELTA(next, prev, mask) (((next) >= (prev)) ? ((next)-(prev)) : ((mask)-(prev)+(next)+1))
+
+/*
+ * Check if a TSC indicates a counter reset.
+ */
+#define IS_RESET_TSC(msg)       (g_pluginEnvironment->isSystemReset((msg)->plugin_id, (msg)->metric_id, (msg)->msg_id, (msg)->tsc))
+
+/*
+ * Macros to trace function enters and exits.
+ */
+#if DEVELOPMENT_MODE // Development code; NOT meant for production
+    #define PW_TRACE_FUNCTION_ENTER() do { \
+        PW_LOG_INFO("Entering function %s\n", __FUNCTION__); \
+    } while(0)
+
+    #define PW_TRACE_FUNCTION_EXIT() do { \
+        PW_LOG_INFO("Exiting function %s\n", __FUNCTION__); \
+    } while(0)
+
+    #define PW_TRACE_FUNCTION_ENTER_VERBOSE() do { \
+        PW_LOG_INFO("Entering function %s\n", __PRETTY_FUNCTION__); \
+    } while(0)
+
+    #define PW_TRACE_FUNCTION_EXIT_VERBOSE() do { \
+        PW_LOG_INFO("Exiting function %s\n", __PRETTY_FUNCTION__); \
+    } while(0)
+    /*
+     * Basic timer-based profiling functions.
+     * Every 'ENTER' MUST be accompanied by
+     * a corresponding 'EXIT'!
+     */
+    #define PW_TIME_FUNCTION_ENTER() { \
+        PW_LOG_INFO("Entering function %s\n", __PRETTY_FUNCTION__); \
+        pwr::Timer __timer(__FUNCTION__);
+
+    #define PW_TIME_FUNCTION_EXIT() \
+        PW_LOG_INFO("Exiting function %s\n", __PRETTY_FUNCTION__); \
+    }
+#else // Production code
+    #define PW_TRACE_FUNCTION_ENTER() /* NOP */
+
+    #define PW_TRACE_FUNCTION_EXIT() /* NOP */
+
+    #define PW_TRACE_FUNCTION_ENTER_VERBOSE() /* NOP */
+
+    #define PW_TRACE_FUNCTION_EXIT_VERBOSE() /* NOP */
+
+    #define PW_TIME_FUNCTION_ENTER() { /* NOP */
+
+    #define PW_TIME_FUNCTION_EXIT() } /* NOP */
+#endif // DEVELOPMENT_MODE
+
+#define PW_DO_REPORT_FILE_ERROR(msg, path) do { \
+    PW_LOG_WARNING(msg, (path).c_str(), strerror(errno)); \
+} while(0)
+
+#define PW_TODO_MSG(msg) do { \
+    PW_LOG_WARNING("%s functionality is TODO!\n", (msg)); \
+} while(0)
+
+#ifdef SWW_MERGE
+#define __PRETTY_FUNCTION__ __FUNCTION__
+#endif // SWW_MERGE
+
+#define PW_TODO() do { \
+    PW_TODO_MSG(__PRETTY_FUNCTION__); \
+} while(0)
+
+#define PW_PERROR_LEVEL(msg, level) do { \
+    PW_GET_STREAM(level) << msg << ": " << strerror(errno) << std::endl; \
+} while(0)
+
+#define PW_PERROR(msg) PW_PERROR_LEVEL(msg, WARNING)
+
+/*
+ * A convenience macro to return the number
+ * of micro seconds elapsed since the epoch.
+ */
+#define PW_GET_CURR_TIME_USECS() ((double)pwr::getTimevalNano() / 1000.0)
+
+/*
+ * Macros corresponding to the kernel versions of 'likely()'
+ * and 'unlikely()' -- GCC SPECIFIC ONLY!
+ */
+#if defined (__linux__) || defined (__QNX__)
+    #define likely(x) __builtin_expect(!!(x), 1)
+    #define unlikely(x) __builtin_expect(!!(x), 0)
+#elif defined (__APPLE__)
+    #define likely(x)   (x)
+    #define unlikely(x) (x)
+#else // windows
+    #define likely(x) (!!(x))
+    #define unlikely(x) (!!(x))
+
+    #define __attribute__(a) // ignore __attribute__ macros on Windows
+#endif // linux
+
+/* Nanoseconds in a second */
+#define NANOSEC_PER_SEC (1000000000ULL)
+#define MILLISEC_PER_SEC (1000ULL)
+#define SEC_PER_MILLISEC ((double)1.0/MILLISEC_PER_SEC)
+#ifndef USEC_PER_SEC /* avoid redefinition in driver build */
+#define USEC_PER_SEC (1000000ULL)
+#endif
+#define SEC_PER_USEC ((double)1.0/USEC_PER_SEC)
+
+#endif // __KERNEL__
+
+#ifdef SWW_MERGE
+#define DOS_DIR_SEPARATOR_CHAR '\\'
+#define DOS_DIR_SEPARATOR_STR "\\"
+#define DOS_CUR_DIR ".\\"
+#endif
+
+#define DIR_SEPARATOR_CHAR '/'
+#define DIR_SEPARATOR_STR "/"
+#define CUR_DIR "./"
+
+#endif // _PW_USER_DEFINES_H_

--- a/perftools-external/socwatch_driver/include/sw_version.h
+++ b/perftools-external/socwatch_driver/include/sw_version.h
@@ -1,0 +1,74 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2018 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2018 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef __SW_VERSION_H__
+#define __SW_VERSION_H__ 1
+
+/*
+ * SOCWatch driver version
+ */
+#define SW_DRIVER_VERSION_MAJOR 2
+#define SW_DRIVER_VERSION_MINOR 6
+#define SW_DRIVER_VERSION_OTHER 1
+
+/*
+ * Every SOC Watch userspace component shares the same version number.
+ */
+#define SOCWATCH_VERSION_MAJOR 2
+#define SOCWATCH_VERSION_MINOR 6
+#define SOCWATCH_VERSION_OTHER 1
+
+#endif // __SW_VERSION_H__

--- a/perftools-external/socwatch_driver/src/sw_collector.c
+++ b/perftools-external/socwatch_driver/src/sw_collector.c
@@ -1,0 +1,642 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#include "sw_internal.h"
+#include "sw_structs.h"
+#include "sw_collector.h"
+#include "sw_defines.h"
+#include "sw_mem.h"
+#include "sw_types.h"
+#include "sw_hardware_io.h"
+#include "sw_output_buffer.h"
+
+/* -------------------------------------------------
+ * Local function declarations.
+ * -------------------------------------------------
+ */
+void sw_free_driver_interface_info_i(struct sw_driver_interface_info *info);
+const struct sw_hw_ops **sw_alloc_ops_i(pw_u16_t num_io_descriptors);
+void sw_free_ops_i(const struct sw_hw_ops **ops);
+struct sw_driver_interface_info *sw_copy_driver_interface_info_i(
+      const struct sw_driver_interface_info *info);
+int sw_init_driver_interface_info_i(struct sw_driver_interface_info *info);
+int sw_reset_driver_interface_info_i(struct sw_driver_interface_info *info);
+int sw_init_ops_i(const struct sw_hw_ops **ops, const struct sw_driver_interface_info *info);
+sw_driver_msg_t *sw_alloc_collector_msg_i(const struct sw_driver_interface_info *info, size_t per_msg_payload_size);
+void sw_free_collector_msg_i(sw_driver_msg_t *msg);
+size_t sw_get_payload_size_i(const struct sw_driver_interface_info *info);
+void sw_handle_per_cpu_msg_i(void *info, enum sw_wakeup_action action);
+/* -------------------------------------------------
+ * Variables.
+ * -------------------------------------------------
+ */
+const static struct sw_hw_ops *s_hw_ops = NULL;
+/* -------------------------------------------------
+ * Function definitions.
+ * -------------------------------------------------
+ */
+/*
+ * Driver interface info functions.
+ */
+
+/**
+ * sw_add_driver_info() - Add a collector node to the list called at this
+ *                      "when type".
+ * @head:   The collector node list to add the new node to.
+ * @info:   Driver information to add to the list.
+ *
+ *  This function allocates and links in a "collector node" for each
+ *  collector based on the collector info in the info parameter.
+ *  The function allocates the new node, and links it to a local copy
+ *  of the passed-in driver interface info.  If the collector has an
+ *  init function among its operations, it iterates through the
+ *  descriptors in info, passing each one to the init function.
+ *
+ *  Finally, it allocates and initializes the "collector message" which
+ *  buffers a data sample that this collector gathers during the run.
+ *
+ * Returns:  -PW_ERROR on failure, PW_SUCCESS on success.
+ */
+int sw_add_driver_info(void *list_head,
+                       const struct sw_driver_interface_info *info)
+{
+    SW_LIST_HEAD_VAR(sw_collector_data) *head = list_head;
+    struct sw_collector_data *node = sw_alloc_collector_node();
+    if (!node) {
+        pw_pr_error("ERROR allocating collector node!\n");
+        return -PW_ERROR;
+    }
+
+    node->info = sw_copy_driver_interface_info_i(info);
+    if (!node->info) {
+        pw_pr_error("ERROR allocating or copying driver_interface_info!\n");
+        sw_free_collector_node(node);
+        return -PW_ERROR;
+    }
+    /*
+     * Initialize the collectors in the node's descriptors.
+     */
+    if (sw_init_driver_interface_info_i(node->info)) {
+        pw_pr_error("ERROR initializing a driver_interface_info node!\n");
+        sw_free_collector_node(node);
+        return -PW_ERROR;
+    }
+    /*
+     * Allocate the ops array. We do this one time as an optimization
+     * (we could always just repeatedly call 'sw_get_hw_ops_for()'
+     * during the collection but we want to avoid that overhead)
+     */
+    node->ops = sw_alloc_ops_i(info->num_io_descriptors);
+    if (!node->ops || sw_init_ops_i(node->ops, info)) {
+        pw_pr_error("ERROR initializing the ops array!\n");
+        sw_free_collector_node(node);
+        return -PW_ERROR;
+    }
+    /*
+     * Allocate and initialize the "collector message".
+     */
+    node->per_msg_payload_size = sw_get_payload_size_i(info);
+    pw_pr_debug("Debug: Per msg payload size = %u\n",
+                (unsigned)node->per_msg_payload_size);
+    node->msg = sw_alloc_collector_msg_i(info, node->per_msg_payload_size);
+    if (!node->msg) {
+        pw_pr_error("ERROR allocating space for a collector msg!\n");
+        sw_free_collector_node(node);
+        return -PW_ERROR;
+    }
+    pw_pr_debug("NODE = %p, NODE->MSG = %p\n", node, node->msg);
+    cpumask_clear(&node->cpumask);
+    {
+        /*
+         * For now, use following protocol:
+         * cpu_mask == -2 ==> Collect on ALL CPUs
+         * cpu_mask == -1 ==> Collect on ANY CPU
+         * cpu_mask >= 0 ==> Collect on a specific CPU
+         */
+        if (node->info->cpu_mask >= 0) {
+            /*
+             * Collect data on 'node->info->cpu_mask'
+             */
+            cpumask_set_cpu(node->info->cpu_mask, &node->cpumask);
+            pw_pr_debug("OK: set CPU = %d\n", node->info->cpu_mask);
+        } else if (node->info->cpu_mask == -1) {
+            /*
+             * Collect data on ANY CPU.  Leave empty as a flag to
+             * signify user wishes to collect data on 'ANY' cpu.
+             */
+            pw_pr_debug("OK: set ANY CPU\n");
+        } else {
+            /*
+             * Collect data on ALL cpus.
+             */
+            cpumask_copy(&node->cpumask, cpu_present_mask);
+            pw_pr_debug("OK: set ALL CPUs\n");
+        }
+    }
+    SW_LIST_ADD(head, node, list);
+    return PW_SUCCESS;
+}
+
+const struct sw_hw_ops **sw_alloc_ops_i(pw_u16_t num_io_descriptors)
+{
+    size_t size = num_io_descriptors * sizeof(struct sw_hw_ops *);
+    const struct sw_hw_ops **ops = sw_kmalloc(size, GFP_KERNEL);
+    if (ops) {
+        memset(ops, 0, size);
+    }
+    return ops;
+}
+
+void sw_free_driver_interface_info_i(struct sw_driver_interface_info *info)
+{
+    if (info) {
+        sw_kfree(info);
+    }
+}
+
+void sw_free_ops_i(const struct sw_hw_ops **ops)
+{
+    if (ops) {
+        sw_kfree(ops);
+    }
+}
+
+/**
+ * sw_copy_driver_interface_info_i - Allocate and copy the passed-in "info".
+ *
+ * @info: Information about the metric and collection properties
+ *
+ * Returns: a pointer to the newly allocated sw_driver_interface_info,
+ *          which is a copy of the version passed in via the info pointer.
+ */
+struct sw_driver_interface_info *sw_copy_driver_interface_info_i(
+                           const struct sw_driver_interface_info *info)
+{
+    size_t size;
+    struct sw_driver_interface_info *node = NULL;
+
+    if (!info) {
+        pw_pr_error("ERROR: NULL sw_driver_interface_info in alloc!\n");
+        return node;
+    }
+
+    size = SW_DRIVER_INTERFACE_INFO_HEADER_SIZE() +
+        (info->num_io_descriptors * sizeof(struct sw_driver_io_descriptor));
+    node = (struct sw_driver_interface_info *)sw_kmalloc(size, GFP_KERNEL);
+    if (!node) {
+        pw_pr_error("ERROR allocating driver interface info!\n");
+        return node;
+    }
+    memcpy((char *)node, (const char *)info, size);
+
+    /*
+     * Do debug dump.
+     */
+    pw_pr_debug("DRIVER info has plugin_ID = %d, metric_ID = %d, "
+                "msg_ID = %d\n", node->plugin_id, node->metric_id,
+                node->msg_id);
+
+    return node;
+}
+int sw_init_driver_interface_info_i(struct sw_driver_interface_info *info)
+{
+    /*
+     * Do any initialization here.
+     * For now, only IPC/MMIO descriptors need to be initialized.
+     */
+    int i=0;
+    struct sw_driver_io_descriptor *descriptor = NULL;
+    if (!info) {
+        pw_pr_error("ERROR: no info!\n");
+        return -PW_ERROR;
+    }
+    for (i=0, descriptor=(struct sw_driver_io_descriptor *)info->descriptors; i<info->num_io_descriptors; ++i, ++descriptor) {
+        if (sw_init_driver_io_descriptor(descriptor)) {
+            return -PW_ERROR;
+        }
+    }
+    return PW_SUCCESS;
+}
+
+int sw_reset_driver_interface_info_i(struct sw_driver_interface_info *info)
+{
+    /*
+     * Do any finalization here.
+     * For now, only IPC/MMIO descriptors need to be finalized.
+     */
+    int i=0;
+    struct sw_driver_io_descriptor *descriptor = NULL;
+    if (!info) {
+        pw_pr_error("ERROR: no info!\n");
+        return -PW_ERROR;
+    }
+    for (i=0, descriptor=(struct sw_driver_io_descriptor *)info->descriptors; i<info->num_io_descriptors; ++i, ++descriptor) {
+        if (sw_reset_driver_io_descriptor(descriptor)) {
+            return -PW_ERROR;
+        }
+    }
+    return PW_SUCCESS;
+}
+int sw_init_ops_i(const struct sw_hw_ops **ops, const struct sw_driver_interface_info *info)
+{
+    int i=0;
+    struct sw_driver_io_descriptor *descriptor = NULL;
+    if (!ops || !info) {
+        return -PW_ERROR;
+    }
+    for (i=0, descriptor=(struct sw_driver_io_descriptor *)info->descriptors; i<info->num_io_descriptors; ++i, ++descriptor) {
+        ops[i] = sw_get_hw_ops_for(descriptor->collection_type);
+        if (ops[i] == NULL) {
+            return -PW_ERROR;
+        }
+    }
+    return PW_SUCCESS;
+}
+
+// If this descriptor's collector has an init function, call it passing in
+// this descriptor.  That allows the collector to perform any initialization
+// or registration specific to this metric.
+int sw_init_driver_io_descriptor(struct sw_driver_io_descriptor *descriptor)
+{
+    sw_io_desc_init_func_t init_func = NULL;
+    const struct sw_hw_ops *ops = sw_get_hw_ops_for(descriptor->collection_type);
+    if (ops == NULL) {
+        pw_pr_error("NULL ops found in init_driver_io_desc: type %d\n", descriptor->collection_type);
+        return -PW_ERROR;
+    }
+    init_func = ops->init;
+
+    if (init_func) {
+        int retval = (*init_func)(descriptor);
+        if (retval) {
+            pw_pr_error("(*init) return value for type %d: %d\n",
+                        descriptor->collection_type, retval);
+        }
+        return retval;
+    }
+    return PW_SUCCESS;
+}
+
+/*
+ * If this descriptor's collector has a finalize function, call it passing in this
+ * descriptor. This allows the collector to perform any finalization specific to
+ * this metric.
+ */
+int sw_reset_driver_io_descriptor(struct sw_driver_io_descriptor *descriptor)
+{
+    sw_io_desc_reset_func_t reset_func = NULL;
+    const struct sw_hw_ops *ops = sw_get_hw_ops_for(descriptor->collection_type);
+    if (ops == NULL) {
+        pw_pr_error("NULL ops found in reset_driver_io_desc: type %d\n", descriptor->collection_type);
+        return -PW_ERROR;
+    }
+    pw_pr_debug("calling reset on descriptor of type %d\n", descriptor->collection_type);
+    reset_func = ops->reset;
+
+    if (reset_func) {
+        int retval = (*reset_func)(descriptor);
+        if (retval) {
+            pw_pr_error("(*reset) return value for type %d: %d\n",
+                        descriptor->collection_type, retval);
+        }
+        return retval;
+    }
+    return PW_SUCCESS;
+}
+
+int sw_handle_driver_io_descriptor(char *dst_vals, int cpu,
+                                   const struct sw_driver_io_descriptor *descriptor,
+                                   const struct sw_hw_ops *hw_ops)
+{
+    typedef void (*sw_hardware_io_func_t)(char *, int, const struct sw_driver_io_descriptor *, u16);
+    sw_hardware_io_func_t hardware_io_func = NULL;
+    if (descriptor->collection_command < SW_IO_CMD_READ || descriptor->collection_command > SW_IO_CMD_WRITE) {
+        return -PW_ERROR;
+    }
+    switch (descriptor->collection_command) {
+        case SW_IO_CMD_READ:
+            hardware_io_func = hw_ops->read;
+            break;
+        case SW_IO_CMD_WRITE:
+            hardware_io_func = hw_ops->write;
+            break;
+        default:
+            break;
+    }
+    if (hardware_io_func) {
+        (*hardware_io_func)(dst_vals, cpu, descriptor, descriptor->counter_size_in_bytes);
+    } else {
+        pw_pr_debug("NO ops to satisfy %u operation for collection type %u!\n", descriptor->collection_command, descriptor->collection_type);
+    }
+    return PW_SUCCESS;
+}
+
+sw_driver_msg_t *sw_alloc_collector_msg_i(const struct sw_driver_interface_info *info, size_t per_msg_payload_size)
+{
+    size_t per_msg_size = 0, total_size = 0;
+    sw_driver_msg_t *msg = NULL;
+    if (!info) {
+        return NULL;
+    }
+    per_msg_size = sizeof(struct sw_driver_msg) + per_msg_payload_size;
+    total_size = per_msg_size * num_possible_cpus();
+    msg = (sw_driver_msg_t *)sw_kmalloc(total_size, GFP_KERNEL);
+    if (msg) {
+        int cpu = -1;
+        memset(msg, 0, total_size);
+        for_each_possible_cpu(cpu) {
+            sw_driver_msg_t *__msg = GET_MSG_SLOT_FOR_CPU(msg, cpu, per_msg_payload_size);
+            char *__payload = (char *)__msg + sizeof(struct sw_driver_msg);
+            __msg->cpuidx = (pw_u16_t)cpu;
+            __msg->plugin_id = (pw_u8_t)info->plugin_id;
+            __msg->metric_id = (pw_u8_t)info->metric_id;
+            __msg->msg_id = (pw_u8_t)info->msg_id;
+            __msg->payload_len = per_msg_payload_size;
+            __msg->p_payload = __payload;
+            pw_pr_debug("[%d]: per_msg_payload_size = %zx, msg = %p, payload = %p\n", cpu, per_msg_payload_size, __msg, __payload);
+        }
+    }
+    return msg;
+}
+
+void sw_free_collector_msg_i(sw_driver_msg_t *msg)
+{
+    if (msg) {
+        sw_kfree(msg);
+    }
+}
+
+size_t sw_get_payload_size_i(const struct sw_driver_interface_info *info)
+{
+    size_t size = 0;
+    int i = 0;
+
+    if (info) {
+        for (i = 0; i < info->num_io_descriptors; size += ((struct sw_driver_io_descriptor *)info->descriptors)[i].counter_size_in_bytes, ++i);
+    }
+    return size;
+}
+
+void sw_handle_per_cpu_msg_i(void *info, enum sw_wakeup_action action)
+{
+    /*
+     * Basic algo:
+     * For each descriptor in 'node->info->descriptors'; do:
+     * 1. Perform H/W read; use 'descriptor->collection_type' to determine type of read; use 'descriptor->counter_size_in_bytes'
+     * for read size. Use msg->p_payload[dst_idx] as dst address
+     * 2. Increment dst idx by 'descriptor->counter_size_in_bytes'
+     */
+    struct sw_collector_data *node = (struct sw_collector_data *)info;
+    int cpu = RAW_CPU();
+    u16 num_descriptors = node->info->num_io_descriptors, i=0;
+    struct sw_driver_io_descriptor *descriptors = (struct sw_driver_io_descriptor *)node->info->descriptors;
+    sw_driver_msg_t *msg = GET_MSG_SLOT_FOR_CPU(node->msg, cpu, node->per_msg_payload_size);
+    char *dst_vals = msg->p_payload;
+    const struct sw_hw_ops **ops = node->ops;
+    bool wasAnyWrite = false;
+
+    // msg TSC assigned when msg is written to buffer
+    msg->cpuidx = cpu;
+
+    for (i=0; i<num_descriptors; ++i, dst_vals += descriptors->counter_size_in_bytes, ++descriptors) {
+        if (unlikely(ops[i] == NULL)) {
+            pw_pr_debug("NULL OPS!\n");
+            continue;
+        }
+        if (descriptors->collection_command == SW_IO_CMD_WRITE) {
+            wasAnyWrite = true;
+        }
+        if (sw_handle_driver_io_descriptor(dst_vals, cpu, descriptors, ops[i])) {
+            pw_pr_error("ERROR reading descriptor with type %d\n", descriptors->collection_type);
+        }
+    }
+
+    /*
+     * We produce messages only on READs. Note that SWA prohibits
+     * messages that contain both READ and WRITE descriptors, so it
+     * is enough to check if there was ANY WRITE descriptor in this
+     * message.
+     */
+    if (likely(wasAnyWrite == false)) {
+        if (sw_produce_generic_msg(msg, action)) {
+            pw_pr_warn("WARNING: could NOT produce message!\n");
+        }
+    }
+
+    return;
+}
+
+
+/*
+ * Collector list and node functions.
+ */
+struct sw_collector_data *sw_alloc_collector_node(void)
+{
+    struct sw_collector_data *node = (struct sw_collector_data *)sw_kmalloc(sizeof(struct sw_collector_data), GFP_KERNEL);
+    if (node) {
+        node->per_msg_payload_size = 0x0;
+        node->last_update_jiffies = 0x0;
+        node->info = NULL;
+        node->ops = NULL;
+        node->msg = NULL;
+        SW_LIST_ENTRY_INIT(node, list);
+    }
+    return node;
+}
+
+void sw_free_collector_node(struct sw_collector_data *node)
+{
+    if (!node) {
+        return;
+    }
+    if (node->info) {
+        sw_reset_driver_interface_info_i(node->info);
+        sw_free_driver_interface_info_i(node->info);
+        node->info = NULL;
+    }
+    if (node->ops) {
+        sw_free_ops_i(node->ops);
+        node->ops = NULL;
+    }
+    if (node->msg) {
+        sw_free_collector_msg_i(node->msg);
+        node->msg = NULL;
+    }
+    sw_kfree(node);
+    return;
+}
+
+int sw_handle_collector_node(struct sw_collector_data *node)
+{
+    if (!node || !node->info || !node->ops || !node->msg) {
+        return -PW_ERROR;
+    }
+    pw_pr_debug("Calling SMP_CALL_FUNCTION_MANY!\n");
+    sw_schedule_work(&node->cpumask, &sw_handle_per_cpu_msg, node);
+    return PW_SUCCESS;
+}
+
+int sw_handle_collector_node_on_cpu(struct sw_collector_data *node, int cpu)
+{
+    if (!node || !node->info || !node->ops || !node->msg) {
+        return -PW_ERROR;
+    }
+    /*
+     * Check if this node indicates it should be scheduled
+     * on the given cpu. If so, clear all other CPUs from the
+     * mask and schedule the node.
+     */
+    if (cpumask_test_cpu(cpu, &node->cpumask)) {
+        struct cpumask tmp_mask;
+        cpumask_clear(&tmp_mask);
+        cpumask_set_cpu(cpu, &tmp_mask);
+        pw_pr_debug("Calling SMP_CALL_FUNCTION_MANY!\n");
+        sw_schedule_work(&tmp_mask, &sw_handle_per_cpu_msg, node);
+    }
+    return PW_SUCCESS;
+}
+
+void sw_init_collector_list(void *list_head)
+{
+    SW_LIST_HEAD_VAR(sw_collector_data) *head = list_head;
+    SW_LIST_HEAD_INIT(head);
+}
+
+void sw_destroy_collector_list(void *list_head)
+{
+    SW_LIST_HEAD_VAR(sw_collector_data) *head = list_head;
+    while (!SW_LIST_EMPTY(head)) {
+        struct sw_collector_data *curr = SW_LIST_GET_HEAD_ENTRY(head, sw_collector_data, list);
+        BUG_ON(!curr->info);
+        SW_LIST_UNLINK(curr, list);
+        sw_free_collector_node(curr);
+    }
+}
+
+/**
+ * sw_handle_collector_list - Iterate through the collector list, calling
+ *                            func() upon each element.
+ * @list_head:  The collector list head.
+ * @func:  The function to call for each collector.
+ *
+ * This function is called when one of the "when types" fires, since the
+ * passed-in collector node list is the list of collections to do at that time.
+ *
+ * Returns: PW_SUCCESS on success, -PW_ERROR on error.
+ */
+int sw_handle_collector_list(void *list_head,
+                             int (*func)(struct sw_collector_data *data))
+{
+    SW_LIST_HEAD_VAR(sw_collector_data) *head = list_head;
+    int retVal = PW_SUCCESS;
+    struct sw_collector_data *curr = NULL;
+    if (!head || !func) {
+        return -PW_ERROR;
+    }
+    SW_LIST_FOR_EACH_ENTRY(curr, head, list) {
+        pw_pr_debug("HANDLING\n");
+        if ((*func)(curr)) {
+            retVal = -PW_ERROR;
+        }
+    }
+    return retVal;
+}
+
+int sw_handle_collector_list_on_cpu(void *list_head,
+                                    int (*func)(struct sw_collector_data *data, int cpu),
+                                    int cpu)
+{
+    SW_LIST_HEAD_VAR(sw_collector_data) *head = list_head;
+    int retVal = PW_SUCCESS;
+    struct sw_collector_data *curr = NULL;
+    if (!head || !func) {
+        return -PW_ERROR;
+    }
+    SW_LIST_FOR_EACH_ENTRY(curr, head, list) {
+        pw_pr_debug("HANDLING\n");
+        if ((*func)(curr, cpu)) {
+            retVal = -PW_ERROR;
+        }
+    }
+    return retVal;
+}
+
+void sw_handle_per_cpu_msg(void *info)
+{
+    sw_handle_per_cpu_msg_i(info, SW_WAKEUP_ACTION_DIRECT);
+}
+
+void sw_handle_per_cpu_msg_no_sched(void *info)
+{
+    sw_handle_per_cpu_msg_i(info, SW_WAKEUP_ACTION_TIMER);
+}
+
+void sw_handle_per_cpu_msg_on_cpu(int cpu, void *info)
+{
+    if (unlikely(cpu == RAW_CPU())) {
+        sw_handle_per_cpu_msg_no_sched(info);
+    } else {
+        pw_pr_debug("[%d] is handling for %d\n", RAW_CPU(), cpu);
+        /*
+         * No need to disable preemption -- 'smp_call_function_single' does that for us.
+         */
+        smp_call_function_single(cpu, &sw_handle_per_cpu_msg_no_sched, info, false /* false ==> do NOT wait for function completion */);
+    }
+}
+
+void sw_set_collector_ops(const struct sw_hw_ops *hw_ops)
+{
+    s_hw_ops = hw_ops;
+}

--- a/perftools-external/socwatch_driver/src/sw_driver.c
+++ b/perftools-external/socwatch_driver/src/sw_driver.c
@@ -1,0 +1,1266 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#define MOD_AUTHOR "Gautam Upadhyaya <gautam.upadhyaya@intel.com>"
+#define MOD_DESC "SoC Watch kernel module"
+
+#include "sw_internal.h"
+#include "sw_structs.h"
+#include "sw_defines.h"
+#include "sw_types.h"
+#include "sw_mem.h"
+#include "sw_ioctl.h"
+#include "sw_output_buffer.h"
+#include "sw_hardware_io.h"
+#include "sw_overhead_measurements.h"
+#include "sw_tracepoint_handlers.h"
+#include "sw_collector.h"
+#include "sw_file_ops.h"
+
+/* -------------------------------------------------
+ * Compile time constants.
+ * -------------------------------------------------
+ */
+/*
+ * Number of entries in the 'sw_collector_lists' array
+ */
+#define NUM_COLLECTOR_MODES (SW_WHEN_TYPE_END - SW_WHEN_TYPE_BEGIN + 1)
+#define PW_OUTPUT_BUFFER_SIZE 256 /* Number of output messages in each per-cpu buffer */
+/*
+ * Check if tracepoint/notifier ID is in (user-supplied) mask
+ */
+#define IS_TRACE_NOTIFIER_ID_IN_MASK(id, mask) ( (id) >= 0 && ( ( (mask) >> (id) ) & 0x1 ) )
+
+
+/* -------------------------------------------------
+ *  Local function declarations.
+ * -------------------------------------------------
+ */
+int sw_load_driver_i(void);
+void sw_unload_driver_i(void);
+int sw_init_collector_lists_i(void);
+void sw_destroy_collector_lists_i(void);
+int sw_init_data_structures_i(void);
+void sw_destroy_data_structures_i(void);
+int sw_get_arch_details_i(void);
+void sw_iterate_driver_info_lists_i(void);
+void sw_handle_immediate_request_i(void *request);
+int sw_print_collector_node_i(struct sw_collector_data *data);
+int sw_collection_start_i(void);
+int sw_collection_stop_i(void);
+int sw_collection_poll_i(void);
+size_t sw_get_payload_size_i(const struct sw_driver_interface_info *info);
+sw_driver_msg_t *sw_alloc_collector_msg_i(const struct sw_driver_interface_info *info, size_t per_msg_payload_size);
+static long sw_unlocked_handle_ioctl_i(unsigned int ioctl_num,
+                                       void *p_local_args);
+static long sw_set_driver_infos_i(struct sw_driver_interface_msg __user *remote_msg, int local_len);
+static long sw_handle_cmd_i(sw_driver_collection_cmd_t cmd, u64 __user* remote_out_args);
+static void sw_do_extract_scu_fw_version(void);
+static long sw_get_available_name_id_mappings_i(enum sw_name_id_type type, struct sw_name_info_msg __user* remote_info, size_t local_len);
+static enum sw_driver_collection_cmd sw_get_collection_cmd_i(void);
+static bool sw_should_flush_buffer_i(void);
+
+/* -------------------------------------------------
+ * Data structures.
+ * -------------------------------------------------
+ */
+/*
+ * Structure to hold current CMD state
+ * of the device driver. Constantly evolving, but
+ * that's OK -- this is internal to the driver
+ * and is NOT exported.
+ */
+struct swa_internal_state {
+    sw_driver_collection_cmd_t cmd; // indicates which command was specified last e.g. START, STOP etc.
+    /*
+     * Should we write to our per-cpu output buffers?
+     * YES if we're actively collecting.
+     * NO if we're not.
+     */
+    bool write_to_buffers;
+    /*
+     * Should we "drain/flush" the per-cpu output buffers?
+     * (See "device_read" for an explanation)
+     */
+    bool drain_buffers;
+    // Others...
+};
+
+
+/* -------------------------------------------------
+ * Variables.
+ * -------------------------------------------------
+ */
+static bool do_force_module_scope_for_cpu_frequencies = false;
+module_param(do_force_module_scope_for_cpu_frequencies, bool, S_IRUSR);
+MODULE_PARM_DESC(do_force_module_scope_for_cpu_frequencies, "Toggle module scope for cpu frequencies. Sets \"affected_cpus\" and \"related_cpus\" of cpufreq_policy.");
+
+static unsigned short sw_buffer_num_pages = 16;
+module_param(sw_buffer_num_pages, ushort, S_IRUSR);
+MODULE_PARM_DESC(sw_buffer_num_pages, "Specify number of 4kB pages to use for each per-cpu buffer. MUST be a power of 2! Default value = 16 (64 kB)");
+
+/* TODO: convert from 'list_head' to 'hlist_head' */
+/*
+ * sw_collector_lists is an array of linked lists of "collector nodes"
+ * (sw_collector_data structs).  It is indexed by the sw_when_type_t's.
+ * Each list holds the collectors to "execute" at a specific time,
+ * e.g. the begining of the run, at a poll interval, tracepoint, etc.
+ */
+static SW_DEFINE_LIST_HEAD(sw_collector_lists, sw_collector_data)[NUM_COLLECTOR_MODES];
+static __read_mostly u16 sw_scu_fw_major_minor = 0x0;
+
+static struct swa_internal_state s_internal_state;
+static struct sw_file_ops s_ops = {
+    .ioctl_handler =    &sw_unlocked_handle_ioctl_i,
+    .stop_handler =     &sw_collection_stop_i,
+    .get_current_cmd =  &sw_get_collection_cmd_i,
+    .should_flush =     &sw_should_flush_buffer_i,
+};
+
+/*
+ * For each function that you want to profile,
+ * do the following (e.g. function 'foo'):
+ * **************************************************
+ * DECLARE_OVERHEAD_VARS(foo);
+ * **************************************************
+ * This will declare the two variables required
+ * to keep track of overheads incurred in
+ * calling/servicing 'foo'. Note that the name
+ * that you declare here *MUST* match the function name!
+ */
+
+DECLARE_OVERHEAD_VARS(sw_collection_poll_i); // for POLL
+DECLARE_OVERHEAD_VARS(sw_any_seg_full);
+
+/*
+ * String representation of the various 'SW_WHEN_TYPE_XYZ' enum values.
+ * Debugging ONLY!
+ */
+#if DO_DEBUG_OUTPUT
+static const char *s_when_type_names[] = {
+    "BEGIN",
+    "POLL",
+    "NOTIFIER",
+    "TRACEPOINT",
+    "END"
+};
+#endif // DO_DEBUG_OUTPUT
+
+/* -------------------------------------------------
+ * Function definitions.
+ * -------------------------------------------------
+ */
+/*
+ * External functions.
+ */
+int sw_process_snapshot(enum sw_when_type when)
+{
+    if (when > SW_WHEN_TYPE_END) {
+        pw_pr_error("invalid snapshot time %d specified!\n", when);
+        return -EINVAL;
+    }
+    if (sw_handle_collector_list(&sw_collector_lists[when], &sw_handle_collector_node)) {
+        pw_pr_error("ERROR: could NOT handle snapshot for time %d!\n", when);
+        return -EIO;
+    }
+    return 0;
+}
+
+int sw_process_snapshot_on_cpu(enum sw_when_type when, int cpu)
+{
+    if (when > SW_WHEN_TYPE_END) {
+        pw_pr_error("invalid snapshot time %d specified!\n", when);
+        return -EINVAL;
+    }
+    if (sw_handle_collector_list_on_cpu(&sw_collector_lists[when], &sw_handle_collector_node_on_cpu, cpu)) {
+        pw_pr_error("ERROR: could NOT handle snapshot for time %d!\n", when);
+        return -EIO;
+    }
+    return 0;
+}
+
+/*
+ * Driver interface info and collector list functions.
+ */
+int sw_print_collector_node_i(struct sw_collector_data *curr)
+{
+    pw_u16_t num_descriptors = 0;
+    sw_io_desc_print_func_t print_func = NULL;
+    struct sw_driver_io_descriptor *descriptor = NULL;
+    struct sw_driver_interface_info *info = NULL;
+    if (!curr) {
+        return -PW_ERROR;
+    }
+    info = curr->info;
+    descriptor = (struct sw_driver_io_descriptor *)info->descriptors;
+    pw_pr_debug("cpu-mask = %d, Plugin-ID = %d, Metric-ID = %d, MSG-ID = %d\n",
+                info->cpu_mask, info->plugin_id, info->metric_id, info->msg_id);
+    for (num_descriptors = info->num_io_descriptors; num_descriptors > 0; --num_descriptors, ++descriptor) {
+        const struct sw_hw_ops *ops = sw_get_hw_ops_for(descriptor->collection_type);
+        if (ops == NULL) {
+            return -PW_ERROR;
+        }
+        print_func = ops->print;
+        if (print_func && (*print_func)(descriptor)) {
+            return -PW_ERROR;
+        }
+    }
+    return PW_SUCCESS;
+}
+
+/*
+ * Driver interface info and collector list functions.
+ */
+
+/**
+ * sw_reset_collector_node_i - Call the reset op on all of the descriptors
+ *                             in coll that have one.
+ * @coll: The data structure containing an array of collector descriptors.
+ *
+ * Return: PW_SUCCESS if all of the resets succeeded, -PW_ERROR if any failed.
+ */
+int sw_reset_collector_node_i(struct sw_collector_data *coll)
+{
+    struct sw_driver_io_descriptor *descriptor = NULL;
+    struct sw_driver_interface_info *info = NULL;
+    int num_descriptors;
+    int retcode = PW_SUCCESS;
+
+    if (!coll) {
+        return -PW_ERROR;
+    }
+    info = coll->info;
+
+    descriptor = (struct sw_driver_io_descriptor *)info->descriptors;
+    pw_pr_debug("cpu-mask = %d, Plugin-ID = %d, Metric-ID = %d, MSG-ID = %d\n",
+                info->cpu_mask, info->plugin_id, info->metric_id, info->msg_id);
+    for (num_descriptors = info->num_io_descriptors; num_descriptors > 0; --num_descriptors, ++descriptor) {
+        const struct sw_hw_ops *ops = sw_get_hw_ops_for(descriptor->collection_type);
+        if (ops && ops->reset && (*ops->reset)(descriptor)) {
+            retcode = -PW_ERROR;
+        }
+    }
+    return retcode;
+}
+
+int sw_iterate_trace_notifier_list_i(struct sw_trace_notifier_data *node, void *dummy)
+{
+    return sw_handle_collector_list(&node->list, &sw_print_collector_node_i);
+}
+
+void sw_iterate_driver_info_lists_i(void)
+{
+    sw_when_type_t which;
+    for (which = SW_WHEN_TYPE_BEGIN; which <= SW_WHEN_TYPE_END; ++which) {
+        pw_pr_debug("ITERATING list %s\n", s_when_type_names[which]);
+        if (sw_handle_collector_list(&sw_collector_lists[which], &sw_print_collector_node_i)) { // Should NEVER happen!
+            pw_pr_error("WARNING: error occured while printing values!\n");
+        }
+    }
+
+    if (sw_for_each_tracepoint_node(&sw_iterate_trace_notifier_list_i, NULL, false /*return-on-error*/)) {
+        pw_pr_error("WARNING: error occured while printing tracepoint values!\n");
+    }
+    if (sw_for_each_notifier_node(&sw_iterate_trace_notifier_list_i, NULL, false /*return-on-error*/)) {
+        pw_pr_error("WARNING: error occured while printing notifier values!\n");
+    }
+}
+
+void sw_reset_collectors_i(void)
+{
+    sw_when_type_t which;
+    for (which = SW_WHEN_TYPE_BEGIN; which <= SW_WHEN_TYPE_END; ++which) {
+        pw_pr_debug("ITERATING list %s\n", s_when_type_names[which]);
+        if (sw_handle_collector_list(&sw_collector_lists[which], &sw_reset_collector_node_i)) {
+            pw_pr_error("WARNING: error occured while resetting a collector!\n");
+        }
+    }
+}
+
+int sw_init_data_structures_i(void)
+{
+    /*
+     * Find the # CPUs in this system.
+     * Update: use 'num_possible' instead of 'num_present' in case
+     * the cpus aren't numbered contiguously
+     */
+    sw_max_num_cpus = num_possible_cpus();
+
+    /*
+     * Initialize our trace subsys: MUST be called
+     * BEFORE 'sw_init_collector_lists_i()!
+     */
+    if (sw_add_trace_notify()) {
+        sw_destroy_data_structures_i();
+        return -PW_ERROR;
+    }
+    if (sw_init_collector_lists_i()) {
+        sw_destroy_data_structures_i();
+        return -PW_ERROR;
+    }
+    if (sw_init_per_cpu_buffers()) {
+        sw_destroy_data_structures_i();
+        return -PW_ERROR;
+    }
+    if (sw_register_hw_ops()) {
+        sw_destroy_data_structures_i();
+        return -PW_ERROR;
+    }
+    return PW_SUCCESS;
+}
+
+void sw_destroy_data_structures_i(void)
+{
+    sw_free_hw_ops();
+    sw_destroy_per_cpu_buffers();
+    sw_destroy_collector_lists_i();
+    sw_remove_trace_notify();
+}
+
+int sw_get_arch_details_i(void)
+{
+    /*
+     * SCU F/W version (if applicable)
+     */
+    sw_do_extract_scu_fw_version();
+    return PW_SUCCESS;
+}
+
+#define INIT_FLAG ((void *)0)
+#define DESTROY_FLAG ((void *)1)
+
+static int sw_init_destroy_trace_notifier_lists_i(struct sw_trace_notifier_data *node, void *is_init)
+{
+    if (is_init == INIT_FLAG) {
+        sw_init_collector_list(&node->list);
+    } else {
+        sw_destroy_collector_list(&node->list);
+    }
+    node->was_registered = false;
+
+    return PW_SUCCESS;
+}
+
+int sw_init_collector_lists_i(void)
+{
+    int i=0;
+    for (i=0; i<NUM_COLLECTOR_MODES; ++i) {
+        sw_init_collector_list(&sw_collector_lists[i]);
+    }
+    sw_for_each_tracepoint_node(&sw_init_destroy_trace_notifier_lists_i, INIT_FLAG, false /*return-on-error*/);
+    sw_for_each_notifier_node(&sw_init_destroy_trace_notifier_lists_i, INIT_FLAG, false /*return-on-error*/);
+
+    return PW_SUCCESS;
+}
+
+void sw_destroy_collector_lists_i(void)
+{
+    int i=0;
+    for (i=0; i<NUM_COLLECTOR_MODES; ++i) {
+        sw_destroy_collector_list(&sw_collector_lists[i]);
+    }
+    sw_for_each_tracepoint_node(&sw_init_destroy_trace_notifier_lists_i, DESTROY_FLAG, false /*return-on-error*/);
+    sw_for_each_notifier_node(&sw_init_destroy_trace_notifier_lists_i, DESTROY_FLAG, false /*return-on-error*/);
+}
+
+/*
+ * Used for {READ,WRITE}_IMMEDIATE requests.
+ */
+typedef struct sw_immediate_request_info sw_immediate_request_info_t;
+struct sw_immediate_request_info {
+    struct sw_driver_io_descriptor *local_descriptor;
+    char *dst_vals;
+    int *retVal;
+};
+void sw_handle_immediate_request_i(void *request)
+{
+    struct sw_immediate_request_info *info = (struct sw_immediate_request_info *)request;
+    struct sw_driver_io_descriptor *descriptor = info->local_descriptor;
+    char *dst_vals = info->dst_vals;
+    const struct sw_hw_ops *ops = sw_get_hw_ops_for(descriptor->collection_type);
+    if (likely(ops != NULL)) {
+        *(info->retVal) = sw_handle_driver_io_descriptor(dst_vals, RAW_CPU(), descriptor, ops);
+    } else {
+        pw_pr_error("No operations found to satisfy collection type %u!\n", descriptor->collection_type);
+    }
+    return;
+}
+
+static int num_times_polled=0;
+
+int sw_collection_start_i(void)
+{
+    /*
+     * Reset the poll tick counter.
+     */
+    num_times_polled = 0;
+    /*
+     * Update the output buffers.
+     */
+    sw_reset_per_cpu_buffers();
+    /*
+     * Ensure clients don't think we're in 'flush' mode.
+     */
+    s_internal_state.drain_buffers = false;
+    /*
+     * Set the 'command'
+     */
+    s_internal_state.cmd = SW_DRIVER_START_COLLECTION;
+    /*
+     * Clear out the topology list
+     */
+    sw_clear_topology_list();
+    /*
+     * Handle 'START' snapshots, if any.
+     */
+    {
+        if (sw_handle_collector_list(&sw_collector_lists[SW_WHEN_TYPE_BEGIN], &sw_handle_collector_node)) {
+            pw_pr_error("ERROR: could NOT handle START collector list!\n");
+            return -PW_ERROR;
+        }
+    }
+    /*
+     * Register any required tracepoints and notifiers.
+     */
+    {
+        if (sw_register_trace_notifiers()) {
+            pw_pr_error("ERROR registering trace_notifiers!\n");
+            sw_unregister_trace_notifiers();
+            return -PW_ERROR;
+        }
+    }
+    pw_pr_debug("OK, STARTED collection!\n");
+    return PW_SUCCESS;
+}
+
+int sw_collection_stop_i(void)
+{
+    /*
+     * Unregister any registered tracepoints and notifiers.
+     */
+    if (sw_unregister_trace_notifiers()) {
+        pw_pr_warn("Warning: some trace_notifier probe functions could NOT be unregistered!\n");
+    }
+    /*
+     * Handle 'STOP' snapshots, if any.
+     */
+    if (sw_handle_collector_list(&sw_collector_lists[SW_WHEN_TYPE_END], &sw_handle_collector_node)) {
+        pw_pr_error("ERROR: could NOT handle STOP collector list!\n");
+        return -PW_ERROR;
+    }
+    /*
+     * Set the 'command'
+     */
+    s_internal_state.cmd = SW_DRIVER_STOP_COLLECTION;
+    /*
+     * Tell consumers to 'flush' all buffers. We need to
+     * defer this as long as possible because it needs to be
+     * close to the 'wake_up_interruptible', below.
+     */
+    s_internal_state.drain_buffers = true;
+    smp_mb();
+    /*
+     * Wakeup any sleeping readers, and cleanup any
+     * timers in the reader subsys.
+     */
+    sw_cancel_reader();
+    /*
+     * Collect stats on samples produced and dropped.
+     * TODO: call from 'device_read()' instead?
+     */
+    sw_count_samples_produced_dropped();
+#if DO_OVERHEAD_MEASUREMENTS
+    pw_pr_force("DEBUG: there were %llu samples produced and %llu samples dropped in buffer v5!\n", sw_num_samples_produced, sw_num_samples_dropped);
+#endif // DO_OVERHEAD_MEASUREMENTS
+    /*
+     * DEBUG: iterate over collection lists.
+     */
+    sw_iterate_driver_info_lists_i();
+    /*
+     * Shut down any collectors that need shutting down.
+     */
+    sw_reset_collectors_i();
+    /*
+     * Clear out the collector lists.
+     */
+    sw_destroy_collector_lists_i();
+    pw_pr_debug("OK, STOPPED collection!\n");
+#if DO_OVERHEAD_MEASUREMENTS
+    pw_pr_force("There were %d poll ticks!\n", num_times_polled);
+#endif // DO_OVERHEAD_MEASUREMENTS
+    return PW_SUCCESS;
+}
+
+int sw_collection_poll_i(void)
+{
+    /*
+     * Handle 'POLL' timer expirations.
+     */
+    if (SW_LIST_EMPTY(&sw_collector_lists[SW_WHEN_TYPE_POLL])) {
+        pw_pr_debug("DEBUG: EMPTY POLL LIST\n");
+    }
+    ++num_times_polled;
+    return sw_handle_collector_list(&sw_collector_lists[SW_WHEN_TYPE_POLL], &sw_handle_collector_node);
+}
+
+/*
+ * Private data for the 'sw_add_trace_notifier_driver_info_i' function.
+ */
+struct tn_data {
+    struct sw_driver_interface_info *info;
+    u64 mask;
+};
+
+static int sw_add_trace_notifier_driver_info_i(struct sw_trace_notifier_data *node, void *priv)
+{
+    struct tn_data *data = (struct tn_data *)priv;
+    struct sw_driver_interface_info *local_info = data->info;
+    u64 mask = data->mask;
+    int id = sw_get_trace_notifier_id(node);
+    if (IS_TRACE_NOTIFIER_ID_IN_MASK(id, mask)) {
+        pw_pr_debug("TRACEPOINT ID = %d is IN mask 0x%llx\n", id, mask);
+        if (sw_add_driver_info(&node->list, local_info)) {
+            pw_pr_error("WARNING: could NOT add driver info to list!\n");
+            return -PW_ERROR;
+        }
+    }
+    return PW_SUCCESS;
+}
+
+static int sw_post_config_i(const struct sw_hw_ops *op, void *priv)
+{
+    if (!op->available || !(*op->available)()) {
+        /* op not available */
+        return 0;
+    }
+    if (!op->post_config || (*op->post_config)()) {
+        return 0;
+    }
+    return -EIO;
+}
+
+/**
+ * sw_set_driver_infos_i - Process the collection config data passed down
+ *                         from the client.
+ * @remote_msg: The user space address of our ioctl data.
+ * @local_len:  The number of bytes of remote_msg we should copy.
+ *
+ * This function copies the ioctl data from user space to kernel
+ * space.  That data is an array of sw_driver_interface_info structs,
+ * which hold information about tracepoints, notifiers, and collector
+ * configuration info for this collection run..  For each driver_info
+ * struct, it calls the appropriate "add info" (registration/
+ * configuration) function for each of the "when types" (begin, poll,
+ * notifier, tracepoint, end) which should trigger a collection
+ * operation for that collector.
+ *
+ * When this function is done, the data structures corresponding to
+ * collection should be configured and initialized.
+ *
+ *
+ * Returns: PW_SUCCESS on success, or a non-zero on an error.
+ */
+static long sw_set_driver_infos_i(struct sw_driver_interface_msg __user *remote_msg, int local_len)
+{
+    struct sw_driver_interface_info *local_info = NULL;
+    struct sw_driver_interface_msg *local_msg = vmalloc(local_len);
+    pw_u8_t read_triggers = 0x0;
+    pw_u16_t num_infos = 0;
+    sw_when_type_t i = SW_WHEN_TYPE_BEGIN;
+    char *__data = (char *)local_msg->infos;
+    size_t dst_idx = 0;
+
+    if (!local_msg) {
+        pw_pr_error("ERROR allocating space for local message!\n");
+        return -EFAULT;
+    }
+    if (copy_from_user(local_msg, remote_msg, local_len)) {
+        pw_pr_error("ERROR copying message from user space!\n");
+        vfree(local_msg);
+        return -EFAULT;
+    }
+    /*
+     * We aren't allowed to config the driver multiple times between
+     * collections. Clear out any previous config values.
+     */
+    sw_destroy_collector_lists_i();
+
+    /*
+     * Did the user specify a min polling interval?
+     */
+    sw_min_polling_interval_msecs = local_msg->min_polling_interval_msecs;
+    pw_pr_debug("min_polling_interval_msecs = %u\n", sw_min_polling_interval_msecs);
+
+    num_infos = local_msg->num_infos;
+    pw_pr_debug("LOCAL NUM INFOS = %u\n", num_infos);
+    for (; num_infos > 0; --num_infos) {
+        local_info = (struct sw_driver_interface_info *)&__data[dst_idx];
+        dst_idx += (SW_DRIVER_INTERFACE_INFO_HEADER_SIZE() + local_info->num_io_descriptors * sizeof(struct sw_driver_io_descriptor));
+        read_triggers = local_info->trigger_bits;
+        pw_pr_debug("read_triggers = %u, # msrs = %u, new dst_idx = %u\n",
+            (unsigned)read_triggers, (unsigned)local_info->num_io_descriptors, (unsigned)dst_idx);
+        for (i=SW_WHEN_TYPE_BEGIN; i<= SW_WHEN_TYPE_END; ++i, read_triggers >>= 1) {
+            if (read_triggers & 0x1) { // Bit 'i' is set
+                pw_pr_debug("BIT %d is SET!\n", i);
+                if (i == SW_WHEN_TYPE_TRACEPOINT) {
+                    struct tn_data tn_data = {local_info, local_info->tracepoint_id_mask};
+                    pw_pr_debug("TRACEPOINT, MASK = 0x%llx\n", local_info->tracepoint_id_mask);
+                    sw_for_each_tracepoint_node(&sw_add_trace_notifier_driver_info_i, &tn_data, false /*return-on-error*/);
+                } else if (i == SW_WHEN_TYPE_NOTIFIER) {
+                    struct tn_data tn_data = {local_info, local_info->notifier_id_mask};
+                    pw_pr_debug("NOTIFIER, MASK = 0x%llx\n", local_info->notifier_id_mask);
+                    sw_for_each_notifier_node(&sw_add_trace_notifier_driver_info_i, &tn_data, false /*return-on-error*/);
+                } else {
+                    if (sw_add_driver_info(&sw_collector_lists[i], local_info)) {
+                        pw_pr_error("WARNING: could NOT add driver info to list for 'when type' %d!\n", i);
+                    }
+                }
+            }
+        }
+    }
+    if (sw_for_each_hw_op(&sw_post_config_i, NULL, false /*return-on-error*/)) {
+        pw_pr_error("POST-CONFIG error!\n");
+    }
+    vfree(local_msg);
+    memset(&s_internal_state, 0, sizeof(s_internal_state));
+    /*
+     * DEBUG: iterate over collection lists.
+     */
+    sw_iterate_driver_info_lists_i();
+    return PW_SUCCESS;
+}
+
+static long sw_handle_cmd_i(sw_driver_collection_cmd_t cmd, u64 __user* remote_out_args)
+{
+    /*
+     * First, handle the command.
+     */
+    if (cmd < SW_DRIVER_START_COLLECTION || cmd > SW_DRIVER_CANCEL_COLLECTION) {
+        pw_pr_error("ERROR: invalid cmd = %d\n", cmd);
+        return -PW_ERROR;
+    }
+    switch (cmd) {
+        case SW_DRIVER_START_COLLECTION:
+            if (sw_collection_start_i()) {
+                return -PW_ERROR;
+            }
+            break;
+        case SW_DRIVER_STOP_COLLECTION:
+            if (sw_collection_stop_i()) {
+                return -PW_ERROR;
+            }
+            break;
+        default:
+            pw_pr_error("WARNING: unsupported command %d\n", cmd);
+            break;
+    }
+    /*
+     * Then retrieve sample stats.
+     */
+#if DO_COUNT_DROPPED_SAMPLES
+    if (cmd == SW_DRIVER_STOP_COLLECTION) {
+        u64 local_args[2] = {sw_num_samples_produced, sw_num_samples_dropped};
+        if (copy_to_user(remote_out_args, local_args, sizeof(local_args))) {
+            pw_pr_error("couldn't copy collection stats to user space!\n");
+            return -PW_ERROR;
+        }
+    }
+#endif // DO_COUNT_DROPPED_SAMPLES
+    return PW_SUCCESS;
+}
+
+#ifdef SFI_SIG_OEMB
+static int sw_do_parse_sfi_oemb_table(struct sfi_table_header *header)
+{
+#ifdef CONFIG_X86_WANT_INTEL_MID
+    struct sfi_table_oemb *oemb = (struct sfi_table_oemb *)header; // 'struct sfi_table_oemb' defined in 'intel-mid.h'
+    if (!oemb) {
+        pw_pr_error("ERROR: NULL sfi table header!\n");
+        return -PW_ERROR;
+    }
+    sw_scu_fw_major_minor = (oemb->scu_runtime_major_version << 8) | (oemb->scu_runtime_minor_version);
+    pw_pr_debug("DEBUG: major = %u, minor = %u\n", oemb->scu_runtime_major_version, oemb->scu_runtime_minor_version);
+#endif // CONFIG_X86_WANT_INTEL_MID
+    return PW_SUCCESS;
+}
+#endif // SFI_SIG_OEMB
+
+static void sw_do_extract_scu_fw_version(void)
+{
+    sw_scu_fw_major_minor = 0x0;
+#ifdef SFI_SIG_OEMB
+    if (sfi_table_parse(SFI_SIG_OEMB, NULL, NULL, &sw_do_parse_sfi_oemb_table)) {
+        pw_pr_force("WARNING: NO SFI information!\n");
+    }
+#endif // SFI_SIG_OEMB
+}
+
+static int sw_gather_trace_notifier_i(struct sw_trace_notifier_data *node, struct sw_name_info_msg *msg, enum sw_name_id_type type)
+{
+    pw_u16_t *idx = &msg->payload_len;
+    char *buffer = (char *)&msg->pairs[*idx];
+    struct sw_name_id_pair *pair = (struct sw_name_id_pair *)buffer;
+    int id = sw_get_trace_notifier_id(node);
+    struct sw_string_type *str = &pair->name;
+    const char *abstract_name = sw_get_trace_notifier_abstract_name(node);
+
+    if (likely(abstract_name && id >= 0)) {
+        ++msg->num_name_id_pairs;
+        pair->type = type;
+        pair->id = (u16)id;
+        str->len = strlen(abstract_name) + 1; // "+1" for trailing '\0'
+        memcpy(&str->data[0], abstract_name, str->len);
+
+        pw_pr_debug("TP[%d] = %s (%u)\n", sw_get_trace_notifier_id(node), abstract_name, (unsigned)strlen(abstract_name));
+
+        *idx += SW_NAME_ID_HEADER_SIZE() + SW_STRING_TYPE_HEADER_SIZE() + str->len;
+    }
+
+    return PW_SUCCESS;
+}
+
+static int sw_gather_tracepoint_i(struct sw_trace_notifier_data *node, void *priv)
+{
+    return sw_gather_trace_notifier_i(node, (struct sw_name_info_msg *)priv, SW_NAME_TYPE_TRACEPOINT);
+}
+
+static int sw_gather_notifier_i(struct sw_trace_notifier_data *node, void *priv)
+{
+    return sw_gather_trace_notifier_i(node, (struct sw_name_info_msg *)priv, SW_NAME_TYPE_NOTIFIER);
+}
+
+static long sw_get_available_trace_notifiers_i(enum sw_name_id_type type, struct sw_name_info_msg *local_info)
+{
+    long retVal = PW_SUCCESS;
+    if (type == SW_NAME_TYPE_TRACEPOINT) {
+        retVal = sw_for_each_tracepoint_node(&sw_gather_tracepoint_i, local_info, false /*return-on-error*/);
+    } else {
+        retVal = sw_for_each_notifier_node(&sw_gather_notifier_i, local_info, false /*return-on-error*/);
+    }
+    pw_pr_debug("There are %u extracted traces/notifiers for a total of %u bytes!\n", local_info->num_name_id_pairs, local_info->payload_len);
+    return retVal;
+}
+
+static int sw_gather_hw_op_i(const struct sw_hw_ops *op, void *priv)
+{
+    struct sw_name_info_msg *msg = (struct sw_name_info_msg *)priv;
+    pw_u16_t *idx = &msg->payload_len;
+    char *buffer = (char *)&msg->pairs[*idx];
+    struct sw_name_id_pair *pair = (struct sw_name_id_pair *)buffer;
+    struct sw_string_type *str = &pair->name;
+    const char *abstract_name = sw_get_hw_op_abstract_name(op);
+    int id = sw_get_hw_op_id(op);
+
+    pw_pr_debug("Gather Collector[%d] = %s\n", id, abstract_name);
+    if (likely(abstract_name && id >= 0)) {
+        /*
+         * Final check: is this operation available on the target platform?
+         * If 'available' function doesn't exist then YES. Else call 'available'
+         * function to decide.
+         */
+        pw_pr_debug("%s has available = %p\n", abstract_name, op->available);
+        if (!op->available || (*op->available)()) {
+            ++msg->num_name_id_pairs;
+            pair->type = SW_NAME_TYPE_COLLECTOR;
+            pair->id = (u16)id;
+            str->len = strlen(abstract_name) + 1; // "+1" for trailing '\0'
+            memcpy(&str->data[0], abstract_name, str->len);
+
+            *idx += SW_NAME_ID_HEADER_SIZE() + SW_STRING_TYPE_HEADER_SIZE() + str->len;
+        }
+    }
+
+    return PW_SUCCESS;
+}
+
+static long sw_get_available_collectors_i(struct sw_name_info_msg *local_info)
+{
+    return sw_for_each_hw_op(&sw_gather_hw_op_i, local_info, false /*return-on-error*/);
+}
+
+static long sw_get_available_name_id_mappings_i(enum sw_name_id_type type, struct sw_name_info_msg __user* remote_info, size_t local_len)
+{
+    char *buffer = vmalloc(local_len);
+    struct sw_name_info_msg *local_info = NULL;
+    long retVal = PW_SUCCESS;
+    if (!buffer) {
+        pw_pr_error("ERROR: couldn't alloc temp buffer!\n");
+        return -PW_ERROR;
+    }
+    memset(buffer, 0, local_len);
+    local_info = (struct sw_name_info_msg *)buffer;
+
+    if (type == SW_NAME_TYPE_COLLECTOR) {
+        retVal = sw_get_available_collectors_i(local_info);
+    } else {
+        retVal = sw_get_available_trace_notifiers_i(type, local_info);
+    }
+    if (retVal == PW_SUCCESS) {
+        retVal = copy_to_user(remote_info, local_info, local_len);
+        if (retVal) {
+            pw_pr_error("ERROR: couldn't copy tracepoint info to user space!\n");
+        }
+    }
+    vfree(buffer);
+    return retVal;
+}
+
+static long sw_get_topology_changes_i(struct sw_driver_topology_msg __user* remote_msg, size_t local_len)
+{
+    char *buffer = NULL;
+    struct sw_driver_topology_msg *local_msg = NULL;
+    size_t buffer_len = sizeof(struct sw_driver_topology_msg) + sw_num_topology_entries * sizeof(struct sw_driver_topology_change);
+    long retVal = PW_SUCCESS;
+    struct sw_driver_topology_change *dst = NULL;
+    size_t dst_idx = 0;
+    SW_LIST_HEAD_VAR(sw_topology_node) *head = (void *)&sw_topology_list;
+    struct sw_topology_node *tnode = NULL;
+
+    if (local_len < buffer_len) {
+        pw_pr_error("ERROR: insufficient buffer space to encode topology changes! Requires %zu, output space = %zu\n", buffer_len, local_len);
+        return -EIO;
+    }
+
+    buffer = vmalloc(buffer_len);
+    if (!buffer) {
+        pw_pr_error("ERROR: couldn't allocate buffer for topology transfer!\n");
+        return -EIO;
+    }
+    memset(buffer, 0, buffer_len);
+
+    local_msg = (struct sw_driver_topology_msg *)buffer;
+    local_msg->num_entries = sw_num_topology_entries;
+    dst = (struct sw_driver_topology_change *)&local_msg->topology_entries[0];
+    SW_LIST_FOR_EACH_ENTRY(tnode, head, list) {
+        struct sw_driver_topology_change *change = &tnode->change;
+        memcpy(&dst[dst_idx++], change, sizeof(*change));
+    }
+    retVal = copy_to_user(remote_msg, local_msg, buffer_len);
+    if (retVal) {
+        pw_pr_error("ERROR: couldn't copy topology changes to user space!\n");
+    }
+    vfree(buffer);
+    return retVal;
+}
+
+
+#if defined(CONFIG_COMPAT) && defined(CONFIG_X86_64)
+    #define MATCH_IOCTL(num, pred) ( (num) == (pred) || (num) == (pred##32) )
+#else
+    #define MATCH_IOCTL(num, pred) ( (num) == (pred) )
+#endif
+
+static long sw_unlocked_handle_ioctl_i(unsigned int ioctl_num,
+                                       void *p_local_args)
+{
+    struct sw_driver_ioctl_arg local_args;
+    int local_in_len, local_out_len;
+
+    if (!p_local_args) {
+        pw_pr_error("ERROR: NULL p_local_args value?!\n");
+        return -PW_ERROR;
+    }
+
+    /*
+     * (1) Sanity check:
+     * Before doing anything, double check to
+     * make sure this IOCTL was really intended
+     * for us!
+     */
+    if(_IOC_TYPE(ioctl_num) != APWR_IOCTL_MAGIC_NUM){
+        pw_pr_error("ERROR: requested IOCTL TYPE (%d) != APWR_IOCTL_MAGIC_NUM (%d)\n", _IOC_TYPE(ioctl_num), APWR_IOCTL_MAGIC_NUM);
+        return -PW_ERROR;
+    }
+    /*
+     * (2) Extract arg lengths.
+     */
+    local_args = *((struct sw_driver_ioctl_arg *)p_local_args);
+
+    local_in_len = local_args.in_len;
+    local_out_len = local_args.out_len;
+    pw_pr_debug("GU: local_in_len = %d, local_out_len = %d\n", local_in_len, local_out_len);
+    /*
+     * (3) Service individual IOCTL requests.
+     */
+    if (MATCH_IOCTL(ioctl_num, PW_IOCTL_CONFIG)) {
+        pw_pr_debug("PW_IOCTL_CONFIG\n");
+        return sw_set_driver_infos_i((struct sw_driver_interface_msg __user*)local_args.in_arg, local_in_len);
+    }
+    else if (MATCH_IOCTL(ioctl_num, PW_IOCTL_CMD)) {
+        sw_driver_collection_cmd_t local_cmd;
+        pw_pr_debug("PW_IOCTL_CMD\n");
+        if (get_user(local_cmd, (sw_driver_collection_cmd_t __user *)local_args.in_arg)) {
+            pw_pr_error("ERROR: could NOT extract cmd value!\n");
+            return -PW_ERROR;
+        }
+        return sw_handle_cmd_i(local_cmd, (u64 __user*)local_args.out_arg);
+    }
+    else if (MATCH_IOCTL(ioctl_num, PW_IOCTL_POLL)) {
+        pw_pr_debug("PW_IOCTL_POLL\n");
+        return DO_PER_CPU_OVERHEAD_FUNC_RET(int , sw_collection_poll_i);
+    }
+    else if (MATCH_IOCTL(ioctl_num, PW_IOCTL_IMMEDIATE_IO)) {
+        struct sw_driver_interface_info *local_info;
+        struct sw_driver_io_descriptor *local_descriptor = NULL;
+        int retVal = PW_SUCCESS;
+        char *src_vals = NULL;
+        char *dst_vals = NULL;
+
+        pw_pr_debug("PW_IOCTL_IMMEDIATE_IO\n");
+        pw_pr_debug("local_in_len = %u\n", local_in_len);
+
+        src_vals = vmalloc(local_in_len);
+        if (!src_vals) {
+            pw_pr_error("ERROR allocating space for immediate IO\n");
+            return -PW_ERROR;
+        }
+        if (local_out_len) {
+            dst_vals = vmalloc(local_out_len);
+            if (!dst_vals) {
+                vfree(src_vals);
+                pw_pr_error("ERROR allocating space for immediate IO\n");
+                return -PW_ERROR;
+            }
+        }
+        if (copy_from_user(src_vals, (char *)local_args.in_arg, local_in_len)) {
+            pw_pr_error("ERROR copying in immediate IO descriptor\n");
+            retVal = -PW_ERROR;
+            goto ret_immediate_io;
+        }
+        local_info = (struct sw_driver_interface_info *)src_vals;
+        pw_pr_debug("OK, asked to perform immediate IO on cpu(s) %d, # descriptors = %d\n",
+            local_info->cpu_mask, local_info->num_io_descriptors);
+        /*
+         * For now, require only a single descriptor.
+         */
+        if (local_info->num_io_descriptors != 1) {
+            pw_pr_error("ERROR: told to perform immediate IO with %d descriptors -- MAX of 1 descriptor allowed!\n",
+            local_info->num_io_descriptors);
+            retVal = -PW_ERROR;
+            goto ret_immediate_io;
+        }
+        local_descriptor = ((struct sw_driver_io_descriptor *)local_info->descriptors);
+        pw_pr_debug("Collection type after %d\n", local_descriptor->collection_type);
+        /*
+         * Check cpu mask for correctness here. For now, we do NOT allow
+         * reading on ALL cpus.
+         */
+        if ((int)local_info->cpu_mask < -1 || (int)local_info->cpu_mask >= (int)sw_max_num_cpus) {
+            pw_pr_error("ERROR: invalid cpu mask %d specified in immediate IO; valid values are: -1, [0 -- %d]!\n",
+            local_info->cpu_mask, sw_max_num_cpus-1);
+            retVal = -PW_ERROR;
+            goto ret_immediate_io;
+        }
+        /*
+         * Check collection type for correctness here
+         */
+        pw_pr_debug("Asked to perform immediate IO with descriptor with type = %d, on cpu = %d\n", local_descriptor->collection_type,
+            local_info->cpu_mask);
+        if (sw_is_valid_hw_op_id(local_descriptor->collection_type) == false) {
+            pw_pr_error("ERROR: invalid collection type %d specified for immediate IO\n", (int)local_descriptor->collection_type);
+            retVal = -PW_ERROR;
+            goto ret_immediate_io;
+        }
+        /*
+         * Check collection cmd for correctness here
+         */
+        if (local_descriptor->collection_command < SW_IO_CMD_READ || local_descriptor->collection_command > SW_IO_CMD_WRITE) {
+            pw_pr_error("ERROR: invalid collection command %d specified for immediate IO\n", local_descriptor->collection_command);
+            retVal = -PW_ERROR;
+            goto ret_immediate_io;
+        }
+        /*
+         * Initialize the descriptor -- 'MMIO' and 'IPC' reads may need
+         * an "ioremap_nocache"
+         */
+        if (sw_init_driver_io_descriptor(local_descriptor)) {
+            pw_pr_error("ERROR initializing immediate IO descriptor\n");
+            retVal = -PW_ERROR;
+            goto ret_immediate_io;
+        }
+        /*
+         * OK, perform the actual IO.
+         */
+        {
+            struct sw_immediate_request_info request_info = {local_descriptor, dst_vals, &retVal};
+            struct cpumask cpumask;
+            cpumask_clear(&cpumask);
+            switch (local_info->cpu_mask) {
+                case -1: // IO on ANY CPU (assume current CPU)
+                    cpumask_set_cpu(RAW_CPU(), &cpumask);
+                    pw_pr_debug("ANY CPU\n");
+                    break;
+                default: // IO on a particular CPU
+                    cpumask_set_cpu(local_info->cpu_mask, &cpumask);
+                    pw_pr_debug("[%d] setting for %d\n", RAW_CPU(), local_info->cpu_mask);
+                    break;
+            }
+            sw_schedule_work(&cpumask, &sw_handle_immediate_request_i, &request_info);
+        }
+        if (retVal != PW_SUCCESS) {
+            pw_pr_error("ERROR performing immediate IO on one (or more) CPUs!\n");
+            goto ret_immediate_io_reset;
+        }
+        /*
+         * OK, all done.
+         */
+        if (local_descriptor->collection_command == SW_IO_CMD_READ) {
+            if (copy_to_user(local_args.out_arg, dst_vals, local_out_len)) {
+                pw_pr_error("ERROR copying %u bytes of value to userspace!\n", local_out_len);
+                retVal = -PW_ERROR;
+                goto ret_immediate_io_reset;
+            }
+            pw_pr_debug("OK, copied %u bytes of value to userspace addr %p!\n", local_out_len, local_args.out_arg);
+        }
+ret_immediate_io_reset:
+        /*
+         * Reset the descriptor -- 'MMIO' and 'IPC' reads may have
+         * performed an "ioremap_nocache" which now needs to be unmapped.
+         */
+        if (sw_reset_driver_io_descriptor(local_descriptor)) {
+            pw_pr_error("ERROR resetting immediate IO descriptor\n");
+            retVal = -PW_ERROR;
+            goto ret_immediate_io;
+        }
+ret_immediate_io:
+        vfree(src_vals);
+        if (dst_vals) {
+            vfree(dst_vals);
+        }
+        return retVal;
+    }
+    else if (MATCH_IOCTL(ioctl_num, PW_IOCTL_GET_SCU_FW_VERSION)) {
+        u32 local_data = (u32)sw_scu_fw_major_minor;
+        if (put_user(local_data, (u32 __user *)local_args.out_arg)) {
+            pw_pr_error("ERROR copying scu fw version to userspace!\n");
+            return -PW_ERROR;
+        }
+        return PW_SUCCESS;
+    }
+    else if (MATCH_IOCTL(ioctl_num, PW_IOCTL_GET_DRIVER_VERSION)) {
+        pw_u64_t local_version = (pw_u64_t)SW_DRIVER_VERSION_MAJOR << 32 | \
+                                 (pw_u64_t)SW_DRIVER_VERSION_MINOR << 16 |
+                                 (pw_u64_t)SW_DRIVER_VERSION_OTHER;
+        if (put_user(local_version, (u64 __user *)local_args.out_arg)) {
+            pw_pr_error("ERROR copying driver version to userspace!\n");
+            return -PW_ERROR;
+        }
+        return PW_SUCCESS;
+    }
+    else if (MATCH_IOCTL(ioctl_num, PW_IOCTL_GET_AVAILABLE_TRACEPOINTS)) {
+        pw_pr_debug("DEBUG: AVAIL tracepoints! local_out_len = %u\n", local_out_len);
+        return sw_get_available_name_id_mappings_i(SW_NAME_TYPE_TRACEPOINT, (struct sw_name_info_msg __user*)local_args.out_arg, local_out_len);
+    }
+    else if (MATCH_IOCTL(ioctl_num, PW_IOCTL_GET_AVAILABLE_NOTIFIERS)) {
+        pw_pr_debug("DEBUG: AVAIL tracepoints! local_out_len = %u\n", local_out_len);
+        return sw_get_available_name_id_mappings_i(SW_NAME_TYPE_NOTIFIER, (struct sw_name_info_msg __user*)local_args.out_arg, local_out_len);
+    }
+    else if (MATCH_IOCTL(ioctl_num, PW_IOCTL_GET_AVAILABLE_COLLECTORS)) {
+        pw_pr_debug("DEBUG: AVAIL tracepoints! local_out_len = %u\n", local_out_len);
+        return sw_get_available_name_id_mappings_i(SW_NAME_TYPE_COLLECTOR, (struct sw_name_info_msg __user*)local_args.out_arg, local_out_len);
+    }
+    else if (MATCH_IOCTL(ioctl_num, PW_IOCTL_GET_TOPOLOGY_CHANGES)) {
+        pw_pr_debug("DEBUG: TOPOLOGY changes! local_out_len = %u\n", local_out_len);
+        return sw_get_topology_changes_i((struct sw_driver_topology_msg __user*)local_args.out_arg, local_out_len);
+    }
+    else {
+        pw_pr_error("ERROR: invalid ioctl num: %u\n", _IOC_NR(ioctl_num));
+    }
+    return -PW_ERROR;
+}
+
+enum sw_driver_collection_cmd sw_get_collection_cmd_i(void)
+{
+    return s_internal_state.cmd;
+};
+
+bool sw_should_flush_buffer_i(void)
+{
+    return s_internal_state.drain_buffers;
+};
+
+
+int sw_load_driver_i(void)
+{
+    /*
+     * Set per-cpu buffer size.
+     * First, Perform sanity checking of per-cpu buffer size.
+     */
+    /*
+     * 1. Num pages MUST be pow-of-2.
+     */
+    {
+        if (sw_buffer_num_pages & (sw_buffer_num_pages - 1)) {
+            pw_pr_error("Invalid value (%u) for number of pages in each per-cpu buffer; MUST be a power of 2!\n", sw_buffer_num_pages);
+            return -PW_ERROR;
+        }
+    }
+    /*
+     * 2. Num pages MUST be <= 16 (i.e. per-cpu buffer size
+     * MUST be <= 64 kB)
+     */
+    {
+        if (sw_buffer_num_pages > 16) {
+            pw_pr_error("Invalid value (%u) for number of pages in each per-cpu buffer; MUST be <= 16!\n", sw_buffer_num_pages);
+            return -PW_ERROR;
+        }
+    }
+    sw_buffer_alloc_size = sw_buffer_num_pages * PAGE_SIZE;
+    /*
+     * Retrieve any arch details here.
+     */
+    if (sw_get_arch_details_i()) {
+        pw_pr_error("ERROR retrieving arch details!\n");
+        return -PW_ERROR;
+    }
+    /*
+     * Check to see if the user wants us to force
+     * software coordination of CPU frequencies.
+     */
+    if (do_force_module_scope_for_cpu_frequencies) {
+        pw_pr_force("DEBUG: FORCING MODULE SCOPE FOR CPU FREQUENCIES!\n");
+        if (sw_set_module_scope_for_cpus()) {
+            pw_pr_force("ERROR setting affected cpus\n");
+            return -PW_ERROR;
+        } else {
+            pw_pr_debug("OK, setting worked\n");
+        }
+    }
+    if (sw_init_data_structures_i()) {
+        pw_pr_error("ERROR initializing data structures!\n");
+        goto err_ret_init_data;
+    }
+    if (sw_register_dev(&s_ops)) {
+        goto err_ret_register_dev;
+    }
+    /*
+     * Retrieve a list of tracepoint structs to use when
+     * registering probe functions.
+     */
+    {
+        if (sw_extract_tracepoints()) {
+            pw_pr_error("ERROR: could NOT retrieve a complete list of valid tracepoint structs!\n");
+            goto err_ret_tracepoint;
+        }
+    }
+    pw_pr_force("-----------------------------------------\n");
+    pw_pr_force("OK: LOADED SoC Watch Driver\n");
+#ifdef CONFIG_X86_WANT_INTEL_MID
+    pw_pr_force("SOC Identifier = %u, Stepping = %u\n", intel_mid_identify_cpu(), intel_mid_soc_stepping());
+#endif // CONFIG_X86_WANT_INTEL_MID
+    pw_pr_force("-----------------------------------------\n");
+    return PW_SUCCESS;
+
+err_ret_tracepoint:
+    sw_unregister_dev();
+err_ret_register_dev:
+    sw_destroy_data_structures_i();
+err_ret_init_data:
+    if (do_force_module_scope_for_cpu_frequencies) {
+        if (sw_reset_module_scope_for_cpus()) {
+            pw_pr_force("ERROR resetting affected cpus\n");
+        } else {
+            pw_pr_debug("OK, resetting worked\n");
+        }
+    }
+    return -PW_ERROR;
+}
+
+void sw_unload_driver_i(void)
+{
+    sw_iterate_driver_info_lists_i();
+
+    sw_unregister_dev();
+
+    sw_destroy_data_structures_i();
+
+    if (do_force_module_scope_for_cpu_frequencies) {
+        if (sw_reset_module_scope_for_cpus()) {
+            pw_pr_force("ERROR resetting affected cpus\n");
+        } else {
+            pw_pr_debug("OK, resetting worked\n");
+        }
+    }
+
+    pw_pr_force("-----------------------------------------\n");
+    pw_pr_force("OK: UNLOADED SoC Watch Driver\n");
+
+    sw_print_trace_notifier_overheads();
+    sw_print_output_buffer_overheads();
+    PRINT_CUMULATIVE_OVERHEAD_PARAMS(sw_collection_poll_i, "POLL");
+    PRINT_CUMULATIVE_OVERHEAD_PARAMS(sw_any_seg_full, "ANY_SEG_FULL");
+#if DO_TRACK_MEMORY_USAGE
+    {
+        /*
+         * Dump memory stats.
+         */
+        pw_pr_force("TOTAL # BYTES ALLOCED = %llu, CURR # BYTES ALLOCED = %llu, MAX # BYTES ALLOCED = %llu\n",
+           sw_get_total_bytes_alloced(), sw_get_curr_bytes_alloced(), sw_get_max_bytes_alloced());
+        if (unlikely(sw_get_curr_bytes_alloced())) {
+            pw_pr_force("***********************************************************************\n");
+            pw_pr_force("WARNING: possible memory leak: there are %llu bytes still allocated!\n", sw_get_curr_bytes_alloced());
+            pw_pr_force("***********************************************************************\n");
+        }
+    }
+#endif // DO_TRACK_MEMORY_USAGE
+    pw_pr_force("-----------------------------------------\n");
+}
+
+module_init(sw_load_driver_i);
+module_exit(sw_unload_driver_i);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR(MOD_AUTHOR);
+MODULE_DESCRIPTION(MOD_DESC);

--- a/perftools-external/socwatch_driver/src/sw_file_ops.c
+++ b/perftools-external/socwatch_driver/src/sw_file_ops.c
@@ -1,0 +1,332 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#include <linux/module.h>  // try_module_get
+#include <linux/fs.h>      // inode
+#include <linux/device.h>  // class_create
+#include <linux/cdev.h>    // cdev_alloc
+#include <linux/version.h> // LINUX_VERSION_CODE
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,12,0)
+    #include <asm/uaccess.h>   // copy_to_user
+#else
+    #include <linux/uaccess.h>   // copy_to_user
+#endif // LINUX_VERSION_CODE
+#include <linux/wait.h>    // wait_event_interruptible
+#include <linux/sched.h>   // TASK_INTERRUPTIBLE
+
+#include "sw_types.h"
+#include "sw_structs.h"
+#include "sw_file_ops.h"
+#include "sw_ioctl.h"
+#include "sw_output_buffer.h"
+
+/* -------------------------------------------------
+ * Compile time constants.
+ * -------------------------------------------------
+ */
+/*
+ * Get current command.
+ */
+#define GET_CMD() ( (*s_file_ops->get_current_cmd)() )
+/*
+ * Check if we're currently collecting data.
+ */
+#define IS_COLLECTING() ({sw_driver_collection_cmd_t __cmd = GET_CMD(); bool __val = (__cmd == SW_DRIVER_START_COLLECTION || __cmd == SW_DRIVER_RESUME_COLLECTION); __val;})
+/*
+ * Check if we're currently paused.
+ */
+#define IS_SLEEPING() ({sw_driver_collection_cmd_t __cmd = GET_CMD(); bool __val = __cmd == SW_DRIVER_PAUSE_COLLECTION; __val;})
+/* -------------------------------------------------
+ * Typedefs
+ * -------------------------------------------------
+ */
+typedef unsigned long sw_bits_t;
+
+
+/* -------------------------------------------------
+ *  Local function declarations.
+ * -------------------------------------------------
+ */
+static int sw_device_open_i(struct inode *inode, struct file *file);
+static int sw_device_release_i(struct inode *inode, struct file *file);
+static ssize_t sw_device_read_i(struct file *file, char __user * buffer, size_t length, loff_t * offset);
+static long sw_device_unlocked_ioctl_i(struct file *filp, unsigned int ioctl_num, unsigned long ioctl_param);
+#if defined(CONFIG_COMPAT) && defined(CONFIG_X86_64)
+    static long sw_device_compat_ioctl_i(struct file *file, unsigned int ioctl_num, unsigned long ioctl_param);
+#endif
+
+/*
+ * File operations exported by the driver.
+ */
+static struct file_operations s_fops = {
+    .open = &sw_device_open_i,
+    .read = &sw_device_read_i,
+    .unlocked_ioctl = &sw_device_unlocked_ioctl_i,
+#if defined(CONFIG_COMPAT) && defined(CONFIG_X86_64)
+    .compat_ioctl = &sw_device_compat_ioctl_i,
+#endif // COMPAT && x64
+    .release = &sw_device_release_i,
+};
+/*
+ * Character device file MAJOR
+ * number -- we're now obtaining
+ * this dynamically.
+ */
+static int apwr_dev_major_num = -1;
+/*
+ * Variables to create the character device file
+ */
+static dev_t apwr_dev;
+static struct cdev *apwr_cdev;
+static struct class *apwr_class = NULL;
+/*
+ * Operations exported by the main driver.
+ */
+static struct sw_file_ops *s_file_ops = NULL;
+/*
+ * Is the device open right now? Used to prevent
+ * concurent access into the same device.
+ */
+#define DEV_IS_OPEN 0 // see if device is in use
+static volatile sw_bits_t dev_status;
+
+/*
+ * File operations.
+ */
+/*
+ * Service an "open(...)" call from user-space.
+ */
+static int sw_device_open_i(struct inode *inode, struct file *file)
+{
+    /*
+     * We don't want to talk to two processes at the same time
+     */
+    if(test_and_set_bit(DEV_IS_OPEN, &dev_status)){
+        // Device is busy
+        return -EBUSY;
+    }
+
+    try_module_get(THIS_MODULE);
+    pw_pr_debug("OK, allowed client open!\n");
+    return PW_SUCCESS;
+}
+
+/*
+ * Service a "close(...)" call from user-space.
+ */
+static int sw_device_release_i(struct inode *inode, struct file *file)
+{
+    /*
+     * Did the client just try to zombie us?
+     */
+    int retVal = PW_SUCCESS;
+    if (IS_COLLECTING()) {
+        pw_pr_error("ERROR: Detected ongoing collection on a device release!\n");
+        retVal = (*s_file_ops->stop_handler)();
+    }
+    module_put(THIS_MODULE);
+    /*
+     * We're now ready for our next caller
+     */
+    clear_bit(DEV_IS_OPEN, &dev_status);
+    return retVal;
+}
+
+static ssize_t sw_device_read_i(struct file *file, char __user * user_buffer, size_t length, loff_t * offset)
+{
+    size_t bytes_read = 0;
+    u32 val = 0;
+
+    if (!user_buffer) {
+        pw_pr_error("ERROR: \"read\" called with an empty user_buffer?!\n");
+        return -PW_ERROR;
+    }
+    do {
+        val = SW_ALL_WRITES_DONE_MASK;
+        if (wait_event_interruptible(sw_reader_queue,
+                                     (sw_any_seg_full(&val, (*s_file_ops->should_flush)())
+                                     || (!IS_COLLECTING() && !IS_SLEEPING())))) {
+            pw_pr_error("wait_event_interruptible error\n");
+            return -ERESTARTSYS;
+        }
+        pw_pr_debug(KERN_INFO "After wait: val = %u\n", val);
+    } while (val == SW_NO_DATA_AVAIL_MASK);
+    /*
+     * Are we done producing/consuming?
+     */
+    if (val == SW_ALL_WRITES_DONE_MASK) {
+        return 0; // "0" ==> EOF
+    }
+    /*
+     * Copy the buffer contents into userspace.
+     */
+    bytes_read = sw_consume_data(val, user_buffer, length); // 'read' returns # of bytes actually read
+    if (unlikely(bytes_read == 0)) {
+        /* Cannot be EOF since that has already been checked above */
+        return -EIO;
+    }
+    return bytes_read;
+}
+
+/*
+ * (1) Handle 32b IOCTLs in 32b kernel-space.
+ * (2) Handle 64b IOCTLs in 64b kernel-space.
+ */
+static long sw_device_unlocked_ioctl_i(struct file *filp, unsigned int ioctl_num, unsigned long ioctl_param)
+{
+    struct sw_driver_ioctl_arg __user *remote_args = (struct sw_driver_ioctl_arg __user*)ioctl_param;
+    struct sw_driver_ioctl_arg local_args;
+    if (copy_from_user(&local_args, remote_args, sizeof(local_args))) {
+        pw_pr_error("ERROR copying ioctl args from userspace\n");
+        return -PW_ERROR;
+    }
+    return (*s_file_ops->ioctl_handler)(ioctl_num, &local_args);
+};
+
+#if defined(CONFIG_COMPAT) && defined(CONFIG_X86_64)
+#include <linux/compat.h>
+/*
+ * Helper struct for use in translating
+ * IOCTLs from 32b user programs in 64b
+ * kernels.
+ */
+#pragma pack(push, 1)
+struct sw_driver_ioctl_arg32 {
+    pw_s32_t in_len;
+    pw_s32_t out_len;
+    compat_caddr_t in_arg;
+    compat_caddr_t out_arg;
+};
+#pragma pack(pop)
+
+/*
+ * Handle 32b IOCTLs in 64b kernel-space.
+ */
+static long sw_device_compat_ioctl_i(struct file *file, unsigned int ioctl_num, unsigned long ioctl_param)
+{
+    struct sw_driver_ioctl_arg32 __user *remote_args32 = compat_ptr(ioctl_param);
+    struct sw_driver_ioctl_arg local_args;
+    u32 data;
+
+    if (get_user(local_args.in_len, &remote_args32->in_len)) {
+        return -PW_ERROR;
+    }
+    if (get_user(local_args.out_len, &remote_args32->out_len)) {
+        return -PW_ERROR;
+    }
+    if (get_user(data, &remote_args32->in_arg)) {
+        return -PW_ERROR;
+    }
+    local_args.in_arg = (char *)(unsigned long)data;
+    if (get_user(data, &remote_args32->out_arg)) {
+        return -PW_ERROR;
+    }
+    local_args.out_arg = (char *)(unsigned long)data;
+    return (*s_file_ops->ioctl_handler)(ioctl_num, &local_args);
+}
+#endif
+
+/*
+ * Device creation, deletion operations.
+ */
+int sw_register_dev(struct sw_file_ops *ops)
+{
+    int ret;
+    /*
+     * Ensure we have valid handlers!
+     */
+    if (!ops) {
+        pw_pr_error("NULL file ops?!\n");
+        return -PW_ERROR;
+    }
+
+    /*
+     * Create the character device
+     */
+    ret = alloc_chrdev_region(&apwr_dev, 0, 1, PW_DEVICE_NAME);
+    apwr_dev_major_num = MAJOR(apwr_dev);
+    apwr_class = class_create(THIS_MODULE, "apwr");
+    if (IS_ERR(apwr_class)) {
+        printk(KERN_ERR "Error registering apwr class\n");
+    }
+
+    device_create(apwr_class, NULL, apwr_dev, NULL, PW_DEVICE_NAME);
+    apwr_cdev = cdev_alloc();
+    if (apwr_cdev == NULL) {
+        printk("Error allocating character device\n");
+        return ret;
+    }
+    apwr_cdev->owner = THIS_MODULE;
+    apwr_cdev->ops = &s_fops;
+    if (cdev_add(apwr_cdev, apwr_dev, 1) < 0 )  {
+        printk("Error registering device driver\n");
+        return ret;
+    }
+    s_file_ops = ops;
+
+    return ret;
+}
+
+void sw_unregister_dev(void)
+{
+    /*
+     * Remove the device
+     */
+    unregister_chrdev(apwr_dev_major_num, PW_DEVICE_NAME);
+    device_destroy(apwr_class, apwr_dev);
+    class_destroy(apwr_class);
+    unregister_chrdev_region(apwr_dev, 1);
+    cdev_del(apwr_cdev);
+}

--- a/perftools-external/socwatch_driver/src/sw_hardware_io.c
+++ b/perftools-external/socwatch_driver/src/sw_hardware_io.c
@@ -1,0 +1,176 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "sw_types.h"
+#include "sw_defines.h"
+#include "sw_ops_provider.h"
+#include "sw_mem.h"
+#include "sw_internal.h"
+#include "sw_hardware_io.h"
+
+
+struct sw_ops_node {
+    const struct sw_hw_ops *op;
+    int id;
+    SW_LIST_ENTRY(list, sw_ops_node);
+};
+
+static SW_DEFINE_LIST_HEAD(s_ops, sw_ops_node) = SW_LIST_HEAD_INITIALIZER(s_ops);
+
+static int s_op_idx = -1;
+
+/*
+ * Function definitions.
+ */
+int sw_get_hw_op_id(const struct sw_hw_ops *ops)
+{
+    if (ops && ops->name) {
+        struct sw_ops_node *node = NULL;
+        SW_LIST_FOR_EACH_ENTRY(node, &s_ops, list) {
+            if (node->op->name && !strcmp(node->op->name, ops->name)) {
+                return node->id;
+            }
+        }
+    }
+    return -1;
+}
+
+const struct sw_hw_ops *sw_get_hw_ops_for(int id)
+{
+    struct sw_ops_node *node = NULL;
+    SW_LIST_FOR_EACH_ENTRY(node, &s_ops, list) {
+        if (node->id == id) {
+            return node->op;
+        }
+    }
+    return NULL;
+}
+
+bool sw_is_valid_hw_op_id(int id)
+{
+    struct sw_ops_node *node = NULL;
+    SW_LIST_FOR_EACH_ENTRY(node, &s_ops, list) {
+        if (node->id == id) {
+            return true;
+        }
+    }
+    return false;
+}
+
+const char *sw_get_hw_op_abstract_name(const struct sw_hw_ops *op)
+{
+    if (op) {
+        return op->name;
+    }
+    return NULL;
+}
+
+int sw_for_each_hw_op(int (*func)(const struct sw_hw_ops *op, void *priv), void *priv, bool return_on_error)
+{
+    int retval = PW_SUCCESS;
+    struct sw_ops_node *node = NULL;
+    if (func) {
+        SW_LIST_FOR_EACH_ENTRY(node, &s_ops, list) {
+            if ((*func)(node->op, priv)) {
+                retval = -EIO;
+                if (return_on_error) {
+                    break;
+                }
+            }
+        }
+    }
+    return retval;
+}
+
+int sw_register_hw_op(const struct sw_hw_ops *op)
+{
+    struct sw_ops_node *node = NULL;
+    if (!op) {
+        pw_pr_error("NULL input node in \"sw_register_hw_op\"");
+        return -EIO;
+    }
+    node = sw_kmalloc(sizeof(struct sw_ops_node), GFP_KERNEL);
+    if (!node) {
+        pw_pr_error("sw_kmalloc error in \"sw_register_hw_op\"");
+        return -ENOMEM;
+    }
+    node->op = op;
+    node->id = ++s_op_idx;
+    SW_LIST_ENTRY_INIT(node, list);
+    SW_LIST_ADD(&s_ops, node, list);
+    return PW_SUCCESS;
+}
+
+int sw_register_hw_ops(void)
+{
+    return sw_register_ops_providers();
+}
+
+void sw_free_hw_ops(void)
+{
+    /*
+     * Free all nodes.
+     */
+    while (!SW_LIST_EMPTY(&s_ops)) {
+        struct sw_ops_node *node = SW_LIST_GET_HEAD_ENTRY(&s_ops, sw_ops_node, list);
+        SW_LIST_UNLINK(node, list);
+        sw_kfree(node);
+    }
+    /*
+     * Call our providers to deallocate resources.
+     */
+    sw_free_ops_providers();
+}

--- a/perftools-external/socwatch_driver/src/sw_internal.c
+++ b/perftools-external/socwatch_driver/src/sw_internal.c
@@ -1,0 +1,225 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#include "sw_hardware_io.h"
+#include "sw_mem.h"
+#include "sw_internal.h"
+
+bool sw_check_output_buffer_params(void *buffer, size_t bytes_to_read, size_t buff_size)
+{
+    if (!buffer) {
+        pw_pr_error("ERROR: NULL ptr in sw_consume_data!\n");
+        return false;
+    }
+    if (bytes_to_read != buff_size) {
+        pw_pr_error("Error: bytes_to_read = %zu, required to be %zu\n", bytes_to_read, buff_size);
+        return false;
+    }
+    return true;
+}
+
+unsigned long sw_copy_to_user(void *dst, char *src, size_t bytes_to_copy)
+{
+    return copy_to_user((char __user *)dst, src, bytes_to_copy);
+}
+
+void sw_schedule_work(const struct cpumask *mask, void (*work)(void *), void *data)
+{
+    /*
+     * Did the user ask us to run on 'ANY' CPU?
+     */
+    if (cpumask_empty(mask)) {
+        (*work)(data); // Call on current CPU
+    } else {
+        preempt_disable();
+        {
+            /*
+             * Did the user ask to run on this CPU?
+             */
+            if (cpumask_test_cpu(RAW_CPU(), mask)) {
+                (*work)(data); // Call on current CPU
+            }
+            /*
+             * OK, now check other CPUs.
+             */
+            smp_call_function_many(mask, work, data, true/* Wait for all funcs to complete */);
+        }
+        preempt_enable();
+    }
+}
+
+int sw_get_cpu(unsigned long *flags)
+{
+    local_irq_save(*flags);
+    return get_cpu();
+}
+
+void sw_put_cpu(unsigned long flags)
+{
+    put_cpu();
+    local_irq_restore(flags);
+}
+
+#ifndef CONFIG_NR_CPUS_PER_MODULE
+    #define CONFIG_NR_CPUS_PER_MODULE 2
+#endif // CONFIG_NR_CPUS_PER_MODULE
+
+static void sw_get_cpu_sibling_mask(int cpu, struct cpumask *sibling_mask)
+{
+    unsigned int base = (cpu/CONFIG_NR_CPUS_PER_MODULE) * CONFIG_NR_CPUS_PER_MODULE;
+    unsigned int i;
+
+    cpumask_clear(sibling_mask);
+    for (i=base; i<(base+CONFIG_NR_CPUS_PER_MODULE); ++i) {
+        cpumask_set_cpu(i, sibling_mask);
+    }
+}
+
+struct pw_cpufreq_node {
+    int cpu;
+    struct cpumask cpus, related_cpus;
+    unsigned int shared_type;
+    struct list_head list;
+};
+static struct list_head pw_cpufreq_policy_lists;
+
+int sw_set_module_scope_for_cpus(void)
+{
+    /*
+     * Warning: no support for cpu hotplugging!
+     */
+    int cpu=0;
+    INIT_LIST_HEAD(&pw_cpufreq_policy_lists);
+    for_each_online_cpu(cpu) {
+        struct cpumask sibling_mask;
+        struct pw_cpufreq_node *node = NULL;
+        struct cpufreq_policy *policy = cpufreq_cpu_get(cpu);
+
+        if (!policy) {
+            continue;
+        }
+        /*
+         * Get siblings for this cpu.
+         */
+        sw_get_cpu_sibling_mask(cpu, &sibling_mask);
+        /*
+         * Check if affected_cpus already contains sibling_mask
+         */
+        if (cpumask_subset(&sibling_mask, policy->cpus)) {
+            /*
+             * 'sibling_mask' is already a subset of affected_cpus -- nothing
+             * to do on this CPU.
+             */
+            cpufreq_cpu_put(policy);
+            continue;
+        }
+
+        node = sw_kmalloc(sizeof(*node), GFP_ATOMIC);
+        if (node) {
+            cpumask_clear(&node->cpus); cpumask_clear(&node->related_cpus);
+
+            node->cpu = cpu;
+            cpumask_copy(&node->cpus, policy->cpus);
+            cpumask_copy(&node->related_cpus, policy->related_cpus);
+            node->shared_type = policy->shared_type;
+        }
+
+        policy->shared_type = CPUFREQ_SHARED_TYPE_ALL;
+        /*
+         * Set siblings. Don't worry about online/offline, that's
+         * handled below.
+         */
+        cpumask_copy(policy->cpus, &sibling_mask);
+        /*
+         * Ensure 'related_cpus' is a superset of 'cpus'
+         */
+        cpumask_or(policy->related_cpus, policy->related_cpus, policy->cpus);
+        /*
+         * Ensure 'cpus' only contains online cpus.
+         */
+        cpumask_and(policy->cpus, policy->cpus, cpu_online_mask);
+
+        cpufreq_cpu_put(policy);
+
+        if (node) {
+            INIT_LIST_HEAD(&node->list);
+            list_add_tail(&node->list, &pw_cpufreq_policy_lists);
+        }
+    }
+    return PW_SUCCESS;
+}
+
+int sw_reset_module_scope_for_cpus(void)
+{
+    struct list_head *head = &pw_cpufreq_policy_lists;
+    while (!list_empty(head)) {
+        struct pw_cpufreq_node *node = list_first_entry(head, struct pw_cpufreq_node, list);
+        int cpu = node->cpu;
+        struct cpufreq_policy *policy = cpufreq_cpu_get(cpu);
+        if (!policy) {
+            continue;
+        }
+        policy->shared_type = node->shared_type;
+        cpumask_copy(policy->related_cpus, &node->related_cpus);
+        cpumask_copy(policy->cpus, &node->cpus);
+
+        cpufreq_cpu_put(policy);
+
+        pw_pr_debug("OK, reset cpufreq_policy for cpu %d\n", cpu);
+        list_del(&node->list);
+        sw_kfree(node);
+    }
+    return PW_SUCCESS;
+}

--- a/perftools-external/socwatch_driver/src/sw_mem.c
+++ b/perftools-external/socwatch_driver/src/sw_mem.c
@@ -1,0 +1,299 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#include <linux/slab.h>
+
+#include "sw_defines.h"
+#include "sw_lock_defs.h"
+#include "sw_mem.h"
+
+/*
+ * How do we behave if we ever
+ * get an allocation error?
+ * (a) Setting to '1' REFUSES ANY FURTHER
+ * allocation requests.
+ * (b) Setting to '0' treats each
+ * allocation request as separate, and
+ * handles them on an on-demand basis
+ */
+#define DO_MEM_PANIC_ON_ALLOC_ERROR 0
+
+#if DO_MEM_PANIC_ON_ALLOC_ERROR
+/*
+ * If we ever run into memory allocation errors then
+ * stop (and drop) everything.
+ */
+static atomic_t pw_mem_should_panic = ATOMIC_INIT(0);
+/*
+ * Macro to check if PANIC is on.
+ */
+#define MEM_PANIC() do{ atomic_set(&pw_mem_should_panic, 1); smp_mb(); }while(0)
+#define SHOULD_TRACE() ({bool __tmp = false; smp_mb(); __tmp = (atomic_read(&pw_mem_should_panic) == 0); __tmp;})
+
+#else // if !DO_MEM_PANIC_ON_ALLOC_ERROR
+
+#define MEM_PANIC()
+#define SHOULD_TRACE() (true)
+
+#endif
+
+/*
+ * Variables to track memory usage.
+ */
+/*
+ * TOTAL num bytes allocated.
+ */
+static u64 total_num_bytes_alloced = 0;
+/*
+ * Num of allocated bytes that have
+ * not yet been freed.
+ */
+static u64 curr_num_bytes_alloced = 0;
+/*
+ * Max # of allocated bytes that
+ * have not been freed at any point
+ * in time.
+ */
+static u64 max_num_bytes_alloced = 0;
+
+u64 sw_get_total_bytes_alloced(void)
+{
+    return total_num_bytes_alloced;
+};
+
+u64 sw_get_max_bytes_alloced(void)
+{
+    return max_num_bytes_alloced;
+};
+
+u64 sw_get_curr_bytes_alloced(void)
+{
+    return curr_num_bytes_alloced;
+};
+
+/*
+ * Allocate free pages.
+ * TODO: add memory tracker?
+ */
+unsigned long sw_allocate_pages(unsigned int flags, unsigned int alloc_size_in_bytes)
+{
+    return __get_free_pages((gfp_t)flags, get_order(alloc_size_in_bytes));
+}
+/*
+ * Free up previously allocated pages.
+ * TODO: add memory tracker?
+ */
+void sw_release_pages(unsigned long addr, unsigned int alloc_size_in_bytes)
+{
+    free_pages(addr, get_order(alloc_size_in_bytes));
+}
+
+#if DO_TRACK_MEMORY_USAGE
+
+/*
+ * Lock to guard access to memory
+ * debugging stats.
+ */
+static SW_DEFINE_SPINLOCK(sw_kmalloc_lock);
+
+/*
+ * Helper macros to print out
+ * mem debugging stats.
+ */
+#define TOTAL_NUM_BYTES_ALLOCED() total_num_bytes_alloced
+#define CURR_NUM_BYTES_ALLOCED() curr_num_bytes_alloced
+#define MAX_NUM_BYTES_ALLOCED() max_num_bytes_alloced
+
+/*
+ * MAGIC number based memory tracker. Relies on
+ * storing (a) a MAGIC marker and (b) the requested
+ * size WITHIN the allocated block of memory. Standard
+ * malloc-tracking stuff, really.
+ *
+ * Overview:
+ * (1) ALLOCATION:
+ * When asked to allocate a block of 'X' bytes, allocate
+ * 'X' + 8 bytes. Then, in the FIRST 4 bytes, write the
+ * requested size. In the NEXT 4 bytes, write a special
+ * (i.e. MAGIC) number to let our deallocator know that
+ * this block of memory was allocated using this technique.
+ * Also, keep track of the number of bytes allocated.
+ *
+ * (2) DEALLOCATION:
+ * When given an object to deallocate, we first check
+ * the MAGIC number by decrementing the pointer by
+ * 4 bytes and reading the (integer) stored there.
+ * After ensuring the pointer was, in fact, allocated
+ * by us, we then read the size of the allocated
+ * block (again, by decrementing the pointer by 4
+ * bytes and reading the integer size). We
+ * use this size argument to decrement # of bytes
+ * allocated.
+ */
+#define PW_MEM_MAGIC 0xdeadbeef
+
+#define PW_ADD_MAGIC(x) ({char *__tmp1 = (char *)(x); *((int *)__tmp1) = PW_MEM_MAGIC; __tmp1 += sizeof(int); __tmp1;})
+#define PW_ADD_SIZE(x,s) ({char *__tmp1 = (char *)(x); *((int *)__tmp1) = (s); __tmp1 += sizeof(int); __tmp1;})
+#define PW_ADD_STAMP(x,s) PW_ADD_MAGIC(PW_ADD_SIZE((x), (s)))
+
+#define PW_IS_MAGIC(x) ({int *__tmp1 = (int *)((char *)(x) - sizeof(int)); *__tmp1 == PW_MEM_MAGIC;})
+#define PW_REMOVE_STAMP(x) ({char *__tmp1 = (char *)(x); __tmp1 -= sizeof(int) * 2; __tmp1;})
+#define PW_GET_SIZE(x) (*((int *)(x)))
+
+void *sw_kmalloc(size_t size, unsigned flags)
+{
+    size_t act_size = 0;
+    void *retVal = NULL;
+    /*
+     * No point in allocating if
+     * we were unable to allocate
+     * previously!
+     */
+    {
+        if (!SHOULD_TRACE()) {
+            return NULL;
+        }
+    }
+    /*
+     * (1) Allocate requested block.
+     */
+    act_size = size + sizeof(int) * 2;
+    retVal = kmalloc(act_size, (gfp_t)flags);
+    if (!retVal) {
+        /*
+         * Panic if we couldn't allocate
+         * requested memory.
+         */
+        printk(KERN_INFO "ERROR: could NOT allocate memory!\n");
+        MEM_PANIC();
+        return NULL;
+    }
+    /*
+     * (2) Update memory usage stats.
+     */
+    LOCK(sw_kmalloc_lock);
+    {
+        total_num_bytes_alloced += size;
+        curr_num_bytes_alloced += size;
+        if (curr_num_bytes_alloced > max_num_bytes_alloced)
+            max_num_bytes_alloced = curr_num_bytes_alloced;
+    }
+    UNLOCK(sw_kmalloc_lock);
+    /*
+     * (3) And finally, add the 'size'
+     * and 'magic' stamps.
+     */
+    return PW_ADD_STAMP(retVal, size);
+};
+
+void sw_kfree(const void *obj)
+{
+    void *tmp = NULL;
+    size_t size = 0;
+
+    /*
+     * (1) Check if this block was allocated
+     * by us.
+     */
+    if (!PW_IS_MAGIC(obj)) {
+        printk(KERN_INFO "ERROR: %p is NOT a PW_MAGIC ptr!\n", obj);
+        return;
+    }
+    /*
+     * (2) Strip the magic num...
+     */
+    tmp = PW_REMOVE_STAMP(obj);
+    /*
+     * ...and retrieve size of block.
+     */
+    size = PW_GET_SIZE(tmp);
+    /*
+     * (3) Update memory usage stats.
+     */
+    LOCK(sw_kmalloc_lock);
+    {
+        curr_num_bytes_alloced -= size;
+    }
+    UNLOCK(sw_kmalloc_lock);
+    /*
+     * And finally, free the block.
+     */
+    kfree(tmp);
+};
+
+#else // !DO_TRACK_MEMORY_USAGE
+
+void *sw_kmalloc(size_t size, unsigned flags)
+{
+    void *ret = NULL;
+
+    if (SHOULD_TRACE()) {
+        if (!(ret = kmalloc(size, (gfp_t)flags))) {
+            /*
+             * Panic if we couldn't allocate
+             * requested memory.
+             */
+            MEM_PANIC();
+        }
+    }
+    return ret;
+};
+
+void sw_kfree(const void *mem)
+{
+    kfree(mem);
+};
+
+#endif // DO_TRACK_MEMORY_USAGE

--- a/perftools-external/socwatch_driver/src/sw_ops_provider.c
+++ b/perftools-external/socwatch_driver/src/sw_ops_provider.c
@@ -1,0 +1,886 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#include <linux/kernel.h>
+#include <linux/errno.h>
+#include <linux/pci.h> // "pci_get_domain_bus_and_slot"
+#include <linux/delay.h> // "udelay"
+#include <asm/msr.h>
+#ifdef CONFIG_RPMSG_IPC
+    #include <asm/intel_mid_rpmsg.h>
+#endif // CONFIG_RPMSG_IPC
+
+#include "sw_types.h"
+#include "sw_defines.h"
+#include "sw_hardware_io.h"
+#include "sw_telem.h"
+#include "sw_ops_provider.h"
+
+/*
+ * Compile time constants.
+ */
+/*
+ * Should we be doing 'direct' PCI reads and writes?
+ * '1' ==> YES, call "pci_{read,write}_config_dword()" directly
+ * '0' ==> NO, Use the "intel_mid_msgbus_{read32,write32}_raw()" API (defined in 'intel_mid_pcihelpers.c')
+ */
+#define DO_DIRECT_PCI_READ_WRITE 0
+#if !DO_ANDROID || !defined(CONFIG_X86_WANT_INTEL_MID)
+    /*
+     * 'intel_mid_pcihelpers.h' is probably not present -- force
+     * direct PCI calls in this case.
+     */
+    #undef DO_DIRECT_PCI_READ_WRITE
+    #define DO_DIRECT_PCI_READ_WRITE  1
+#endif
+#if !DO_DIRECT_PCI_READ_WRITE
+    #include <asm/intel_mid_pcihelpers.h>
+#endif
+
+#define SW_PCI_MSG_CTRL_REG 0x000000D0
+#define SW_PCI_MSG_DATA_REG 0x000000D4
+
+/*
+ *  NUM_RETRY & USEC_DELAY are used in PCH Mailbox (sw_read_pch_mailbox_info_i).
+ *  Tested on KBL + SPT-LP. May need to revisit.
+ */
+#define NUM_RETRY  100
+#define USEC_DELAY 100
+
+#define EXTCNF_CTRL 0xF00 // offset for hw semaphore.
+#define FWSM_CTRL 0x5B54 // offset for fw semaphore
+#define GBE_CTRL_OFFSET 0x34 // GBE LPM offset
+
+#define IS_HW_SEMAPHORE_SET(data) (data & (pw_u64_t)(0x1 << 6))
+#define IS_FW_SEMAPHORE_SET(data) (data & (pw_u64_t)0x1)
+
+/*
+ * Local data structures.
+ */
+/*
+ * TODO: separate into H/W and S/W IO?
+ */
+typedef enum sw_io_type {
+    SW_IO_MSR        = 0,
+    SW_IO_IPC        = 1,
+    SW_IO_MMIO       = 2,
+    SW_IO_PCI        = 3,
+    SW_IO_CONFIGDB   = 4,
+    SW_IO_TRACE_ARGS = 5,
+    SW_IO_WAKEUP     = 6,
+    SW_IO_SOCPERF    = 7,
+    SW_IO_PROC_NAME  = 8,
+    SW_IO_IRQ_NAME   = 9,
+    SW_IO_WAKELOCK   =10,
+    SW_IO_TELEM      =11,
+    SW_IO_PCH_MAILBOX=12,
+    SW_IO_MAILBOX    =13,
+    SW_IO_MAX        =14,
+} sw_io_type_t;
+
+/*
+ * "io_remapped" values for HW and FW semaphores
+ */
+static struct {
+    volatile void *hw_semaphore;
+    volatile void *fw_semaphore;
+} s_gbe_semaphore = {0,0};
+
+/*
+ * Function declarations.
+ */
+/*
+ * Exported by the SOCPERF driver.
+ */
+extern void SOCPERF_Read_Data2(void *data_buffer);
+
+/*
+ * Init functions.
+ */
+int sw_ipc_mmio_descriptor_init_func_i(struct sw_driver_io_descriptor *descriptor);
+int sw_pch_mailbox_descriptor_init_func_i(struct sw_driver_io_descriptor *descriptor);
+int sw_mailbox_descriptor_init_func_i(struct sw_driver_io_descriptor *descriptor);
+
+/*
+ * Read functions.
+ */
+void sw_read_msr_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes);
+void sw_read_ipc_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes);
+void sw_read_mmio_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes);
+void sw_read_pch_mailbox_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes);
+void sw_read_mailbox_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes);
+void sw_read_pci_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes);
+void sw_read_configdb_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes);
+void sw_read_socperf_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes);
+
+/*
+ * Write functions.
+ */
+void sw_write_msr_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes);
+void sw_write_ipc_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes);
+void sw_write_mmio_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes);
+void sw_write_mailbox_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes);
+void sw_write_pci_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes);
+void sw_write_configdb_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes);
+void sw_write_trace_args_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes);
+void sw_write_wakeup_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes);
+void sw_write_socperf_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes);
+
+/*
+ * Print functions.
+ */
+int sw_print_msr_io_descriptor(const struct sw_driver_io_descriptor *descriptor);
+
+/*
+ * Reset functions -- equal but opposite of init.
+ */
+int sw_ipc_mmio_descriptor_reset_func_i(const struct sw_driver_io_descriptor *descriptor);
+int sw_pch_mailbox_descriptor_reset_func_i(const struct sw_driver_io_descriptor *descriptor);
+int sw_mailbox_descriptor_reset_func_i(const struct sw_driver_io_descriptor *descriptor);
+
+/*
+ * Available functions.
+ */
+bool sw_socperf_available_i(void);
+
+/*
+ * Helper functions.
+ */
+u32 sw_platform_configdb_read32(u32 address);
+u32 sw_platform_pci_read32(u32 bus, u32 device, u32 function, u32 ctrl_offset, u32 ctrl_value, u32 data_offset);
+u64 sw_platform_pci_read64(u32 bus, u32 device, u32 function, u32 ctrl_offset, u32 ctrl_value, u32 data_offset);
+bool sw_platform_pci_write32(u32 bus, u32 device, u32 function, u32 write_offset, u32 data_value);
+
+/*
+ * Table of collector operations.
+ */
+static const struct sw_hw_ops s_hw_ops[] = {
+    [SW_IO_MSR] = {
+        .name = "MSR",
+        .init = NULL,
+        .read = &sw_read_msr_info_i,
+        .write = &sw_write_msr_info_i,
+        .print = &sw_print_msr_io_descriptor,
+        .reset = NULL,
+        .available = NULL
+    },
+    [SW_IO_IPC] = {
+        .name = "IPC",
+        .init = &sw_ipc_mmio_descriptor_init_func_i,
+        .read = &sw_read_ipc_info_i,
+        .reset = &sw_ipc_mmio_descriptor_reset_func_i,
+        /* Other fields are don't care (will be set to NULL) */
+    },
+    [SW_IO_MMIO] = {
+        .name = "MMIO",
+        .init = &sw_ipc_mmio_descriptor_init_func_i,
+        .read = &sw_read_mmio_info_i,
+        .write = &sw_write_mmio_info_i,
+        .reset = &sw_ipc_mmio_descriptor_reset_func_i,
+        /* Other fields are don't care (will be set to NULL) */
+    },
+    [SW_IO_PCI] = {
+        .name = "PCI",
+        .read = &sw_read_pci_info_i,
+        .write = &sw_write_pci_info_i,
+        /* Other fields are don't care (will be set to NULL) */
+    },
+    [SW_IO_CONFIGDB] = {
+        .name = "CONFIGDB",
+        .read = &sw_read_configdb_info_i,
+        /* Other fields are don't care (will be set to NULL) */
+    },
+    [SW_IO_WAKEUP] = {
+        .name = "WAKEUP",
+        /* Other fields are don't care (will be set to NULL) */
+    },
+    [SW_IO_SOCPERF] = {
+        .name = "SOCPERF",
+        .read = &sw_read_socperf_info_i,
+        .available = &sw_socperf_available_i,
+        /* Other fields are don't care (will be set to NULL) */
+    },
+    [SW_IO_PROC_NAME] = {
+        .name = "PROC-NAME",
+        /* Other fields are don't care (will be set to NULL) */
+    },
+    [SW_IO_IRQ_NAME] = {
+        .name = "IRQ-NAME",
+        /* Other fields are don't care (will be set to NULL) */
+    },
+    [SW_IO_WAKELOCK] = {
+        .name = "WAKELOCK",
+        /* Other fields are don't care (will be set to NULL) */
+    },
+    [SW_IO_TELEM] = {
+        .name = "TELEM",
+        .init = &sw_telem_init_func,
+        .read = &sw_read_telem_info,
+        .reset = &sw_reset_telem,
+        .available = &sw_telem_available,
+        .post_config = &sw_telem_post_config,
+        /* Other fields are don't care (will be set to NULL) */
+    },
+    [SW_IO_PCH_MAILBOX] = {
+        .name = "PCH-MAILBOX",
+        .init = &sw_pch_mailbox_descriptor_init_func_i,
+        .read = &sw_read_pch_mailbox_info_i,
+        .reset = &sw_pch_mailbox_descriptor_reset_func_i,
+        /* Other fields are don't care (will be set to NULL) */
+    },
+    [SW_IO_MAILBOX] = {
+        .name = "MAILBOX",
+        .init = &sw_mailbox_descriptor_init_func_i,
+        .read = &sw_read_mailbox_info_i,
+        .write = &sw_write_mailbox_info_i,
+        .reset = &sw_mailbox_descriptor_reset_func_i,
+        /* Other fields are don't care (will be set to NULL) */
+    },
+    [SW_IO_MAX] = {
+        .name = NULL,
+        /* Other fields are don't care (will be set to NULL) */
+    }
+};
+
+/*
+ * Function definitions.
+ */
+int sw_ipc_mmio_descriptor_init_func_i(struct sw_driver_io_descriptor *descriptor)
+{
+    // Perform any required 'io_remap' calls here
+    struct sw_driver_ipc_mmio_io_descriptor *__ipc_mmio = NULL;
+    u64 data_address = 0;
+    if (!descriptor) { // Should NEVER happen
+        return -PW_ERROR;
+    }
+    if (descriptor->collection_type == SW_IO_IPC) {
+        __ipc_mmio = &descriptor->ipc_descriptor;
+    } else {
+        __ipc_mmio = &descriptor->mmio_descriptor;
+    }
+    pw_pr_debug("cmd = %u, sub-cmd = %u, data_addr = 0x%llx\n", __ipc_mmio->command, __ipc_mmio->sub_command, __ipc_mmio->data_address);
+    data_address = __ipc_mmio->data_address;
+    /*
+    if (__ipc_mmio->command || __ipc_mmio->sub_command) {
+        __ipc_mmio->ipc_command = ((pw_u32_t)__ipc_mmio->sub_command << 12) | (pw_u32_t)__ipc_mmio->command;
+    }
+    */
+    if (data_address) {
+        __ipc_mmio->data_remapped_address = (pw_u64_t)(unsigned long)ioremap_nocache((unsigned long)data_address, descriptor->counter_size_in_bytes);
+        if ((void *)(unsigned long)__ipc_mmio->data_remapped_address == NULL) {
+            return -EIO;
+        }
+        pw_pr_debug("mapped addr 0x%llx\n", __ipc_mmio->data_remapped_address);
+        if (__ipc_mmio->is_gbe) {
+            if (!s_gbe_semaphore.hw_semaphore || !s_gbe_semaphore.fw_semaphore) {
+                pw_pr_debug("Initializing GBE semaphore\n");
+                if (data_address >= GBE_CTRL_OFFSET) {
+                    u64 hw_addr = (data_address - GBE_CTRL_OFFSET) + EXTCNF_CTRL;
+                    u64 fw_addr = (data_address - GBE_CTRL_OFFSET) + FWSM_CTRL;
+                    s_gbe_semaphore.hw_semaphore = (volatile void *)ioremap_nocache((unsigned long)hw_addr, descriptor->counter_size_in_bytes);
+                    s_gbe_semaphore.fw_semaphore = (volatile void *)ioremap_nocache((unsigned long)fw_addr, descriptor->counter_size_in_bytes);
+                    if (s_gbe_semaphore.hw_semaphore == NULL || s_gbe_semaphore.fw_semaphore == NULL) {
+                        pw_pr_error("couldn't mmap hw/fw semaphores for GBE MMIO op!\n");
+                        return -EIO;
+                    }
+                    pw_pr_debug("GBE has hw_sem = 0x%llx, fw_sem = 0x%llx, size = %u\n",
+                            s_gbe_semaphore.hw_semaphore, s_gbe_semaphore.fw_semaphore, descriptor->counter_size_in_bytes);
+                }
+            }
+        }
+    }
+    return PW_SUCCESS;
+}
+
+int sw_pch_mailbox_descriptor_init_func_i(struct sw_driver_io_descriptor *descriptor)
+{
+    // Perform any required 'io_remap' calls here
+    struct sw_driver_pch_mailbox_io_descriptor *__pch_mailbox = NULL;
+    if (!descriptor) { // Should NEVER happen
+        return -PW_ERROR;
+    }
+    __pch_mailbox = &descriptor->pch_mailbox_descriptor;
+    pw_pr_debug("cmd = %u, sub-cmd = %u, data_addr = 0x%llx\n", __pch_mailbox->command, __pch_mailbox->sub_command, __pch_mailbox->data_address);
+    if (__pch_mailbox->mtpmc_address) {
+        __pch_mailbox->mtpmc_remapped_address = (pw_u64_t)(unsigned long)ioremap_nocache((unsigned long)__pch_mailbox->mtpmc_address, descriptor->counter_size_in_bytes);
+        if ((void *)(unsigned long)__pch_mailbox->mtpmc_remapped_address == NULL) {
+            return -PW_ERROR;
+        }
+        pw_pr_debug("mtpmc_mapped addr 0x%llx\n", __pch_mailbox->mtpmc_remapped_address);
+    }
+    if (__pch_mailbox->msg_full_sts_address) {
+        __pch_mailbox->msg_full_sts_remapped_address = (pw_u64_t)(unsigned long)ioremap_nocache((unsigned long)__pch_mailbox->msg_full_sts_address, descriptor->counter_size_in_bytes);
+        if ((void *)(unsigned long)__pch_mailbox->msg_full_sts_remapped_address == NULL) {
+            return -PW_ERROR;
+        }
+        pw_pr_debug("msg_full_sts_mapped addr 0x%llx\n", __pch_mailbox->msg_full_sts_address);
+    }
+    if (__pch_mailbox->mfpmc_address) {
+        __pch_mailbox->mfpmc_remapped_address = (pw_u64_t)(unsigned long)ioremap_nocache((unsigned long)__pch_mailbox->mfpmc_address, descriptor->counter_size_in_bytes);
+        if ((void *)(unsigned long)__pch_mailbox->mfpmc_remapped_address == NULL) {
+            return -PW_ERROR;
+        }
+        pw_pr_debug("mfpmc_mapped addr 0x%llx\n", __pch_mailbox->mfpmc_remapped_address);
+    }
+    return PW_SUCCESS;
+}
+
+int sw_mailbox_descriptor_init_func_i(struct sw_driver_io_descriptor *descriptor)
+{
+    // Perform any required 'io_remap' calls here
+    struct sw_driver_mailbox_io_descriptor *__mailbox = NULL;
+    if (!descriptor) { // Should NEVER happen
+        return -PW_ERROR;
+    }
+    __mailbox = &descriptor->mailbox_descriptor;
+
+    pw_pr_debug("type = %u, interface_address = 0x%llx, data_address = 0x%llx\n", __mailbox->is_msr_type, __mailbox->interface_address, __mailbox->data_address);
+
+    if (!__mailbox->is_msr_type) {
+        if (__mailbox->interface_address) {
+            __mailbox->interface_remapped_address = (pw_u64_t)(unsigned long)ioremap_nocache((unsigned long)__mailbox->interface_address, descriptor->counter_size_in_bytes);
+            if ((void *)(unsigned long)__mailbox->interface_remapped_address == NULL) {
+                pw_pr_error("Couldn't iomap interface_address = 0x%llx\n", __mailbox->interface_address);
+                return -PW_ERROR;
+            }
+        }
+        if (__mailbox->data_address) {
+            __mailbox->data_remapped_address = (pw_u64_t)(unsigned long)ioremap_nocache((unsigned long)__mailbox->data_address, descriptor->counter_size_in_bytes);
+            if ((void *)(unsigned long)__mailbox->data_remapped_address == NULL) {
+                pw_pr_error("Couldn't iomap data_address = 0x%llx\n", __mailbox->data_address);
+                return -PW_ERROR;
+            }
+        }
+        pw_pr_debug("OK, mapped addr 0x%llx, 0x%llx\n", __mailbox->interface_remapped_address, __mailbox->data_remapped_address);
+    }
+    return PW_SUCCESS;
+}
+
+void sw_read_msr_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptors, u16 counter_size_in_bytes)
+{
+    u64 address = descriptors->msr_descriptor.address;
+    u32 l=0, h=0;
+
+    if (likely(cpu == RAW_CPU())) {
+        rdmsr_safe((unsigned long)address, &l, &h);
+    } else {
+        rdmsr_safe_on_cpu(cpu, (unsigned long)address, &l, &h);
+    }
+    switch (counter_size_in_bytes) {
+    case 4:
+        *((u32 *)dst_vals) = l;
+        break;
+    case 8:
+        *((u64 *)dst_vals) = ((u64)h << 32) | l;
+        break;
+    default:
+        break;
+    }
+    return;
+}
+
+#ifdef CONFIG_RPMSG_IPC
+#    define SW_DO_IPC(cmd, sub_cmd) rpmsg_send_generic_simple_command(cmd, sub_cmd)
+#else
+#    define SW_DO_IPC(cmd, sub_cmd) (-ENODEV)
+#endif // CONFIG_RPMSG_IPC
+
+void sw_read_ipc_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptors, u16 counter_size_in_bytes)
+{
+    u16 cmd = descriptors->ipc_descriptor.command, sub_cmd = descriptors->ipc_descriptor.sub_command;
+    unsigned long remapped_address = (unsigned long)descriptors->ipc_descriptor.data_remapped_address;
+
+    if (cmd || sub_cmd) {
+        pw_pr_debug("EXECUTING IPC Cmd = %u, %u\n", cmd, sub_cmd);
+        if (SW_DO_IPC(cmd, sub_cmd)) {
+            pw_pr_error("ERROR running IPC command(s)\n");
+            return;
+        }
+    }
+
+    if (remapped_address) {
+        // memcpy(&value, (void *)remapped_address, counter_size_in_bytes);
+        pw_pr_debug("COPYING MMIO size %u\n", counter_size_in_bytes);
+        memcpy(dst_vals, (void *)remapped_address, counter_size_in_bytes);
+    }
+    pw_pr_debug("Value = %llu\n", *((u64 *)dst_vals));
+}
+
+static void sw_read_gbe_mmio_info_i(char *dst_vals, const struct sw_driver_io_descriptor *descriptors, u16 counter_size_in_bytes)
+{
+    u32 hw_val=0, fw_val=0;
+    unsigned long remapped_address = (unsigned long)descriptors->mmio_descriptor.data_remapped_address;
+    u64 write_value = descriptors->write_value;
+
+    memset(dst_vals, 0, counter_size_in_bytes);
+
+    pw_pr_debug("hw_sem = 0x%llx, fw_sem = 0x%llx, addr = 0x%lx, dst_vals = 0x%lx, size = %u\n",
+            s_gbe_semaphore.hw_semaphore, s_gbe_semaphore.fw_semaphore, remapped_address, (unsigned long)dst_vals, counter_size_in_bytes);
+    if (!s_gbe_semaphore.hw_semaphore || !s_gbe_semaphore.fw_semaphore || !remapped_address) {
+        return;
+    }
+
+    memcpy_fromio(&hw_val, s_gbe_semaphore.hw_semaphore, sizeof(hw_val));
+    memcpy_fromio(&fw_val, s_gbe_semaphore.fw_semaphore, sizeof(fw_val));
+    pw_pr_debug("HW_VAL = 0x%lx, FW_VAL = 0x%lx\n", (unsigned long)hw_val, (unsigned long)fw_val);
+    if (!IS_HW_SEMAPHORE_SET(hw_val) && !IS_FW_SEMAPHORE_SET(fw_val)) {
+        memcpy_toio((void *)remapped_address, &write_value, 4 /* counter_size_in_bytes*/);
+        memcpy_fromio(dst_vals, (void *)remapped_address, counter_size_in_bytes);
+    }
+}
+void sw_read_mmio_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptors, u16 counter_size_in_bytes)
+{
+    unsigned long remapped_address = (unsigned long)descriptors->mmio_descriptor.data_remapped_address;
+    if (descriptors->mmio_descriptor.is_gbe) {
+        /* MMIO for GBE requires a mailbox-like operation */
+        sw_read_gbe_mmio_info_i(dst_vals, descriptors, counter_size_in_bytes);
+    } else {
+        if (remapped_address) {
+            memcpy_fromio(dst_vals, (void *)remapped_address, counter_size_in_bytes);
+        }
+    }
+    pw_pr_debug("Value = %llu\n", *((u64 *)dst_vals));
+}
+
+void sw_read_pch_mailbox_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes)
+{
+    /*
+     * TODO: spinlock?
+     */
+    const struct sw_driver_pch_mailbox_io_descriptor *pch_mailbox = &descriptor->pch_mailbox_descriptor;
+    u32 address = pch_mailbox->data_address;
+    u64 mtpmc_remapped_address = pch_mailbox->mtpmc_remapped_address;
+    u64 msg_full_sts_remapped_address = pch_mailbox->msg_full_sts_remapped_address;
+    u64 mfpmc_remapped_address = pch_mailbox->mfpmc_remapped_address;
+
+    /*
+     * write address of desired device counter to request from PMC (shift and add 2 to format device offset)
+     */
+    if (mtpmc_remapped_address) {
+        int iter = 0;
+        u32 written_val = 0;
+        u32 write_value = (address << 16) + 2; /* shift and add 2 to format device offset */
+        memcpy_toio((volatile void *)(unsigned long)mtpmc_remapped_address, &write_value, 4 /*counter_size_in_bytes*/);
+        /*
+         * Check if address has been written using a while loop in order to wait for the PMC to consume that address
+         * and to introduce sufficient delay so that the message full status bit has time to flip. This should ensure
+         * all is ready when begin the wait loop for it to turn 0, which indicates the value is available to be read.
+         * (This fixes problem where values being read were huge.)
+         */
+        do {
+            memcpy_fromio(&written_val, (volatile void *)(unsigned long)mtpmc_remapped_address, 4 /*counter_size_in_bytes*/);
+            pw_pr_debug("DEBUG: written_val = 0x%x, address = 0x%x\n", written_val, address);
+            udelay(USEC_DELAY);
+        } while ((written_val >> 16) != address && ++iter < NUM_RETRY);
+    }
+
+
+    /*
+     * wait for PMC to set status indicating that device counter is available for read.
+     */
+    if (msg_full_sts_remapped_address) {
+        u32 status_wait = 0;
+        int iter = 0;
+        do {
+            memcpy_fromio(&status_wait, (volatile void *)(unsigned long)msg_full_sts_remapped_address, 4 /*counter_size_in_bytes*/);
+            pw_pr_debug("DEBUG: status_wait = 0x%x\n", status_wait);
+            udelay(USEC_DELAY);
+        } while ((status_wait & 0x01000000) >> 24 && ++iter < NUM_RETRY);
+    }
+
+    /*
+     * read device counter
+     */
+    if (mfpmc_remapped_address) {
+        memcpy_fromio(dst_vals, (volatile void *)(unsigned long)mfpmc_remapped_address, 4 /*counter_size_in_bytes*/);
+        pw_pr_debug("DEBUG: read value = 0x%x\n", *((pw_u32_t *)dst_vals));
+    }
+}
+
+void sw_read_mailbox_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes)
+{
+    /*
+     * TODO: spinlock?
+     */
+    const struct sw_driver_mailbox_io_descriptor *mailbox = &descriptor->mailbox_descriptor;
+    unsigned long interface_address = mailbox->interface_address;
+    unsigned long interface_remapped_address = mailbox->interface_remapped_address;
+    unsigned long data_address = mailbox->data_address;
+    size_t iter = 0;
+
+    if (mailbox->is_msr_type) {
+        u64 command = 0;
+        rdmsrl_safe(interface_address, &command);
+        command &= mailbox->command_mask;
+        command |= mailbox->command | (u64)0x1 << mailbox->run_busy_bit;
+        wrmsrl_safe(interface_address, command);
+        do {
+            rdmsrl_safe(interface_address, &command);
+        } while ((command & ((u64)0x1 << mailbox->run_busy_bit)) && ++iter < 100);
+        rdmsrl_safe(data_address, &command);
+        *((u64 *)dst_vals) = command;
+    } else {
+        u32 command = 0;
+        memcpy_fromio(&command, (volatile void *)(unsigned long)interface_remapped_address, sizeof(command));
+        command &= mailbox->command_mask;
+        command |= (u32)mailbox->command | (u32)0x1 << mailbox->run_busy_bit;
+        memcpy_toio((volatile void *)(unsigned long)interface_remapped_address, &command, sizeof(command));
+        do {
+            memcpy_fromio(&command, (volatile void *)(unsigned long)interface_remapped_address, sizeof(command));
+        } while ((command & ((u32)0x1 << mailbox->run_busy_bit)) && ++iter < 100);
+        memcpy_toio((volatile void *)(unsigned long)mailbox->data_remapped_address, &command, 4 /* counter size in bytes */);
+        *((u32 *)dst_vals) = command;
+    }
+}
+
+void sw_read_pci_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptors, u16 counter_size_in_bytes)
+{
+    u32 bus = descriptors->pci_descriptor.bus, device = descriptors->pci_descriptor.device;
+    u32 function = descriptors->pci_descriptor.function, offset = descriptors->pci_descriptor.offset;
+    u32 data32 = 0;
+    u64 data64 = 0;
+    switch (counter_size_in_bytes) {
+        case 4:
+            data32 = sw_platform_pci_read32(bus, device, function, 0 /* CTRL-OFFSET */, 0 /* CTRL-DATA, don't care */, offset /* DATA-OFFSET */);
+            *((u32 *)dst_vals) = data32;
+            break;
+        case 8:
+            data64 = sw_platform_pci_read64(bus, device, function, 0 /* CTRL-OFFSET */, 0 /* CTRL-DATA, don't care */, offset /* DATA-OFFSET */);
+            *((u64 *)dst_vals) = data64;
+            break;
+        default:
+            pw_pr_error("ERROR: invalid read size = %u\n", counter_size_in_bytes);
+            return;
+        }
+    return;
+}
+void sw_read_configdb_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptors, u16 counter_size_in_bytes)
+{
+    {
+        pw_u32_t address = descriptors->configdb_descriptor.address;
+        u32 data = sw_platform_configdb_read32(address);
+        pw_pr_debug( "ADDRESS = 0x%x, CPU = %d, dst_vals = %p, counter size = %u, data = %u\n", address, cpu, dst_vals, counter_size_in_bytes, data);
+        /*
+         * 'counter_size_in_bytes' is ignored, for now.
+         */
+        *((u32 *)dst_vals) = data;
+    }
+    return;
+}
+void sw_read_socperf_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptors, u16 counter_size_in_bytes)
+{
+#if DO_SOCPERF
+    u64 *socperf_buffer = (u64 *)dst_vals;
+
+    memset(socperf_buffer, 0, counter_size_in_bytes);
+    SOCPERF_Read_Data2(socperf_buffer);
+#endif // DO_SOCPERF
+    return;
+}
+
+/**
+ * Decide if the socperf interface is available for use
+ * @returns     true if available
+ */
+bool sw_socperf_available_i(void)
+{
+    bool retVal = false;
+#if DO_SOCPERF
+    retVal = true;
+#endif
+    return retVal;
+}
+
+
+/**
+ * sw_platform_configdb_read32 - for reading PCI space through config registers
+ *                               of the platform.
+ * @address: An address in the PCI space
+ *
+ * Returns: the value read from address.
+ */
+u32 sw_platform_configdb_read32(u32 address)
+{
+    u32 read_value = 0;
+#if DO_DIRECT_PCI_READ_WRITE
+    return sw_platform_pci_read32(0/*bus*/, 0/*device*/, 0/*function*/, SW_PCI_MSG_CTRL_REG/*ctrl-offset*/, address/*ctrl-value*/, SW_PCI_MSG_DATA_REG/*data-offset*/);
+#else // !DO_DIRECT_PCI_READ_WRITE
+    read_value = intel_mid_msgbus_read32_raw(address);
+    pw_pr_debug("address = %u, value = %u\n", address, read_value);
+#endif // if DO_DIRECT_PCI_READ_WRITE
+    return read_value;
+}
+
+u32 sw_platform_pci_read32(u32 bus, u32 device, u32 function, u32 write_offset, u32 write_value, u32 read_offset)
+{
+    u32 read_value = 0;
+    struct pci_dev *pci_root = pci_get_domain_bus_and_slot(0, bus, PCI_DEVFN(device, function)); // 0, PCI_DEVFN(0, 0));
+    if (!pci_root) {
+        return 0; /* Application will verify the data */
+    }
+    if (write_offset) {
+        pci_write_config_dword(pci_root, write_offset, write_value); // SW_PCI_MSG_CTRL_REG, address);
+    }
+    pci_read_config_dword(pci_root, read_offset, &read_value); // SW_PCI_MSG_DATA_REG, &read_value);
+    return read_value;
+}
+
+u64 sw_platform_pci_read64(u32 bus, u32 device, u32 function, u32 write_offset, u32 write_value, u32 read_offset)
+{
+    u32 lo = sw_platform_pci_read32(bus, device, function, 0 /* CTRL-OFFSET */, 0 /* CTRL-DATA, don't care */, read_offset /* DATA-OFFSET */);
+    u32 hi = sw_platform_pci_read32(bus, device, function, 0 /* CTRL-OFFSET */, 0 /* CTRL-DATA, don't care */, read_offset + 4 /* DATA-OFFSET */);
+    return ((u64)hi << 32) | lo;
+}
+
+void sw_write_msr_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes)
+{
+    u64 write_value = descriptor->write_value;
+    u64 address = descriptor->msr_descriptor.address;
+    pw_pr_debug("ADDRESS = 0x%llx, CPU = %d, counter size = %u, value = %llu\n", address, cpu, counter_size_in_bytes, write_value);
+    if (likely(cpu == RAW_CPU())) {
+        wrmsrl_safe((unsigned long)address, write_value);
+    } else {
+        u32 l = write_value & 0xffffffff, h = (write_value >> 32) & 0xffffffff;
+        wrmsr_safe_on_cpu(cpu, (u32)address, l, h);
+    }
+    return;
+};
+
+void sw_write_mmio_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes)
+{
+    unsigned long remapped_address = (unsigned long)descriptor->mmio_descriptor.data_remapped_address;
+    u64 write_value = descriptor->write_value;
+
+    if (remapped_address) {
+        memcpy_toio((void *)remapped_address, &write_value, counter_size_in_bytes);
+    }
+    pw_pr_debug("Value = %llu\n", *((u64 *)dst_vals));
+};
+
+void sw_write_mailbox_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes)
+{
+    /*
+     * TODO: spinlock?
+     */
+    const struct sw_driver_mailbox_io_descriptor *mailbox = &descriptor->mailbox_descriptor;
+    unsigned long interface_address = mailbox->interface_address;
+    unsigned long interface_remapped_address = mailbox->interface_remapped_address;
+    unsigned long data_address = mailbox->data_address;
+    u64 data = descriptor->write_value;
+    size_t iter = 0;
+
+    if (mailbox->is_msr_type) {
+        u64 command = 0;
+        rdmsrl_safe(interface_address, &command);
+        command &= mailbox->command_mask;
+        command |= mailbox->command | (u64)0x1 << mailbox->run_busy_bit;
+        wrmsrl_safe(data_address, data);
+        wrmsrl_safe(interface_address, command);
+        do {
+            rdmsrl_safe(interface_address, &command);
+        } while ((command & ((u64)0x1 << mailbox->run_busy_bit)) && ++iter < 100);
+    } else {
+        u32 command = 0;
+        memcpy_fromio(&command, (volatile void *)(unsigned long)interface_remapped_address, sizeof(command));
+        command &= mailbox->command_mask;
+        command |= (u32)mailbox->command | (u32)0x1 << mailbox->run_busy_bit;
+        memcpy_toio((volatile void *)(unsigned long)mailbox->data_remapped_address, &data, sizeof(data));
+        memcpy_toio((volatile void *)(unsigned long)interface_remapped_address, &command, sizeof(command));
+        do {
+            memcpy_fromio(&command, (volatile void *)(unsigned long)interface_remapped_address, sizeof(command));
+        } while ((command & ((u32)0x1 << mailbox->run_busy_bit)) && ++iter < 100);
+    }
+}
+
+void sw_write_pci_info_i(char *dst_vals, int cpu, const struct sw_driver_io_descriptor *descriptor, u16 counter_size_in_bytes)
+{
+    u32 bus = descriptor->pci_descriptor.bus, device = descriptor->pci_descriptor.device;
+    u32 function = descriptor->pci_descriptor.function, offset = descriptor->pci_descriptor.offset;
+    u32 write_value = (u32)descriptor->write_value;
+    /*
+     * 'counter_size_in_bytes' is ignored for now.
+     */
+    if (!sw_platform_pci_write32(bus, device, function, offset, write_value)) {
+        pw_pr_error("ERROR writing to PCI B/D/F/O %u/%u/%u/%u\n", bus, device, function, offset);
+    } else {
+        pw_pr_debug("OK, successfully wrote to PCI B/D/F/O %u/%u/%u/%u\n", bus, device, function, offset);
+    }
+    return;
+};
+
+/*
+ * Write to PCI space via config registers.
+ */
+bool sw_platform_pci_write32(u32 bus, u32 device, u32 function, u32 write_offset, u32 data_value)
+{
+    struct pci_dev *pci_root = pci_get_domain_bus_and_slot(0, bus, PCI_DEVFN(device, function)); // 0, PCI_DEVFN(0, 0));
+    if (!pci_root) {
+        return false;
+    }
+
+    pci_write_config_dword(pci_root, write_offset, data_value);
+
+    return true;
+};
+
+int sw_print_msr_io_descriptor(const struct sw_driver_io_descriptor *descriptor)
+{
+    if (!descriptor) {
+        return -PW_ERROR;
+    }
+    pw_pr_debug("MSR address = 0x%llx\n", descriptor->msr_descriptor.address);
+    return PW_SUCCESS;
+}
+
+int sw_ipc_mmio_descriptor_reset_func_i(const struct sw_driver_io_descriptor *descriptor)
+{
+    /* Unmap previously mapped memory here */
+    struct sw_driver_ipc_mmio_io_descriptor *__ipc_mmio = NULL;
+    if (!descriptor) { // Should NEVER happen
+        return -PW_ERROR;
+    }
+    if (descriptor->collection_type == SW_IO_IPC) {
+        __ipc_mmio = (struct sw_driver_ipc_mmio_io_descriptor *)&descriptor->ipc_descriptor;
+    } else {
+        __ipc_mmio = (struct sw_driver_ipc_mmio_io_descriptor *)&descriptor->mmio_descriptor;
+    }
+    if (__ipc_mmio->data_remapped_address) {
+        pw_pr_debug("unmapping addr 0x%llx\n", __ipc_mmio->data_remapped_address);
+        iounmap((volatile void *)(unsigned long)__ipc_mmio->data_remapped_address);
+        __ipc_mmio->data_remapped_address = 0;
+    }
+    /* Uninitialize the GBE, if it wasn't already done */
+    if (s_gbe_semaphore.hw_semaphore || s_gbe_semaphore.fw_semaphore) {
+        pw_pr_debug("Uninitializing gbe!\n");
+        if (s_gbe_semaphore.hw_semaphore) {
+            iounmap(s_gbe_semaphore.hw_semaphore);
+        }
+        if (s_gbe_semaphore.fw_semaphore) {
+            iounmap(s_gbe_semaphore.fw_semaphore);
+        }
+        memset(&s_gbe_semaphore, 0, sizeof(s_gbe_semaphore));
+    }
+    return PW_SUCCESS;
+}
+
+int sw_pch_mailbox_descriptor_reset_func_i(const struct sw_driver_io_descriptor *descriptor)
+{
+    /* Unmap previously mapped memory here */
+    struct sw_driver_pch_mailbox_io_descriptor *__pch_mailbox = NULL;
+    if (!descriptor) { // Should NEVER happen
+        return -PW_ERROR;
+    }
+    __pch_mailbox = (struct sw_driver_pch_mailbox_io_descriptor *)&descriptor->pch_mailbox_descriptor;
+    if (__pch_mailbox->mtpmc_remapped_address) {
+        pw_pr_debug("unmapping addr 0x%llx\n", __pch_mailbox->mtpmc_remapped_address);
+        iounmap((volatile void *)(unsigned long)__pch_mailbox->mtpmc_remapped_address);
+        __pch_mailbox->mtpmc_remapped_address = 0;
+    }
+    if (__pch_mailbox->msg_full_sts_remapped_address) {
+        pw_pr_debug("unmapping addr 0x%llx\n", __pch_mailbox->msg_full_sts_remapped_address);
+        iounmap((volatile void *)(unsigned long)__pch_mailbox->msg_full_sts_remapped_address);
+        __pch_mailbox->msg_full_sts_remapped_address = 0;
+    }
+    if (__pch_mailbox->mfpmc_remapped_address) {
+        pw_pr_debug("unmapping addr 0x%llx\n", __pch_mailbox->mfpmc_remapped_address);
+        iounmap((volatile void *)(unsigned long)__pch_mailbox->mfpmc_remapped_address);
+        __pch_mailbox->mfpmc_remapped_address = 0;
+    }
+    return PW_SUCCESS;
+}
+
+int sw_mailbox_descriptor_reset_func_i(const struct sw_driver_io_descriptor *descriptor)
+{
+    /* Unmap previously mapped memory here */
+    struct sw_driver_mailbox_io_descriptor *__mailbox = NULL;
+    if (!descriptor) { // Should NEVER happen
+        return -PW_ERROR;
+    }
+    __mailbox = (struct sw_driver_mailbox_io_descriptor *)&descriptor->mailbox_descriptor;
+    if (!__mailbox->is_msr_type) {
+        if (__mailbox->interface_remapped_address) {
+            pw_pr_debug("unmapping addr 0x%llx\n", __mailbox->interface_remapped_address);
+            iounmap((volatile void *)(unsigned long)__mailbox->interface_remapped_address);
+            __mailbox->interface_remapped_address = 0;
+        }
+        if (__mailbox->data_remapped_address) {
+            pw_pr_debug("unmapping addr 0x%llx\n", __mailbox->data_remapped_address);
+            iounmap((volatile void *)(unsigned long)__mailbox->data_remapped_address);
+            __mailbox->data_remapped_address = 0;
+        }
+    }
+    return PW_SUCCESS;
+}
+
+#define NUM_HW_OPS SW_ARRAY_SIZE(s_hw_ops)
+#define FOR_EACH_HW_OP(idx, op) for (idx=0; idx<NUM_HW_OPS && (op=&s_hw_ops[idx]); ++idx)
+
+int sw_register_ops_providers(void)
+{
+    size_t idx=0;
+    const struct sw_hw_ops *op = NULL;
+    FOR_EACH_HW_OP(idx, op) {
+        if (op->name && sw_register_hw_op(op)) {
+            pw_pr_error("ERROR registering provider %s\n", op->name);
+            return -EIO;
+        }
+    }
+    return PW_SUCCESS;
+}
+
+void sw_free_ops_providers(void)
+{
+    // NOP
+}

--- a/perftools-external/socwatch_driver/src/sw_output_buffer.c
+++ b/perftools-external/socwatch_driver/src/sw_output_buffer.c
@@ -1,0 +1,533 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "sw_internal.h"
+#include "sw_output_buffer.h"
+#include "sw_defines.h"
+#include "sw_mem.h"
+#include "sw_lock_defs.h"
+#include "sw_overhead_measurements.h"
+
+/* -------------------------------------------------
+ * Compile time constants and macros.
+ * -------------------------------------------------
+ */
+#define NUM_SEGS_PER_BUFFER 2 /* MUST be pow 2! */
+#define NUM_SEGS_PER_BUFFER_MASK (NUM_SEGS_PER_BUFFER - 1)
+/*
+ * The size of the 'buffer' data array in each segment.
+ */
+#define SW_SEG_DATA_SIZE (sw_buffer_alloc_size)
+/*
+ * Min size of per-cpu output buffers.
+ */
+#define SW_MIN_SEG_SIZE_BYTES (1 << 10) /* 1kB */
+#define SW_MIN_OUTPUT_BUFFER_SIZE (SW_MIN_SEG_SIZE_BYTES * NUM_SEGS_PER_BUFFER)
+/*
+ * A symbolic constant for an empty buffer index.
+ */
+#define EMPTY_SEG (-1)
+/*
+ * How much space is available in a given segment?
+ */
+#define EMPTY_TSC ((u64)-1)
+#define SEG_IS_FULL(seg) ({bool __full = false; \
+        smp_mb(); \
+        __full = ((seg)->is_full != EMPTY_TSC); \
+        __full;})
+#define SEG_SET_FULL(seg, tsc) do { \
+    (seg)->is_full = (tsc); \
+    smp_mb(); \
+} while(0)
+#define SEG_SET_EMPTY(seg) do { \
+    barrier(); \
+    (seg)->bytes_written = 0; \
+    SEG_SET_FULL(seg, EMPTY_TSC); \
+    /*smp_mb(); */ \
+} while(0)
+#define SPACE_AVAIL(seg) (SW_SEG_DATA_SIZE - (seg)->bytes_written )
+#define SEG_IS_EMPTY(seg) (SPACE_AVAIL(seg) == SW_SEG_DATA_SIZE)
+
+#define GET_OUTPUT_BUFFER(cpu) &per_cpu_output_buffers[(cpu)]
+/*
+ * Convenience macro: iterate over each segment in a per-cpu output buffer.
+ */
+#define for_each_segment(i) for (i=0; i<NUM_SEGS_PER_BUFFER; ++i)
+#define for_each_seg(buffer, seg) for (int i=0; i<NUM_SEGS_PER_BUFFER && (seg=(buffer)->segments[i]); ++i)
+/*
+ * How many buffers are we using?
+ */
+#define GET_NUM_OUTPUT_BUFFERS() (sw_max_num_cpus + 1)
+/*
+ * Convenience macro: iterate over each per-cpu output buffer.
+ */
+#define for_each_output_buffer(i) for (i=0; i<GET_NUM_OUTPUT_BUFFERS(); ++i)
+
+/* -------------------------------------------------
+ * Local data structures.
+ * -------------------------------------------------
+ */
+typedef struct sw_data_buffer sw_data_buffer_t;
+typedef struct sw_output_buffer sw_output_buffer_t;
+struct sw_data_buffer {
+    u64 is_full;
+    u32 bytes_written;
+    char *buffer;
+} __attribute__((packed));
+#define SW_SEG_HEADER_SIZE() (sizeof(struct sw_data_buffer) - sizeof(char *))
+
+struct sw_output_buffer {
+    sw_data_buffer_t buffers[NUM_SEGS_PER_BUFFER];
+    int buff_index;
+    u32 produced_samples;
+    u32 dropped_samples;
+    int last_seg_read;
+    unsigned int mem_alloc_size;
+    unsigned long free_pages;
+} ____cacheline_aligned_in_smp;
+
+/* -------------------------------------------------
+ * Function declarations.
+ * -------------------------------------------------
+ */
+extern u64 sw_timestamp(void);
+
+/* -------------------------------------------------
+ * Variable definitions.
+ * -------------------------------------------------
+ */
+u64 sw_num_samples_produced = 0, sw_num_samples_dropped = 0;
+int sw_max_num_cpus = -1;
+
+DECLARE_OVERHEAD_VARS(sw_produce_generic_msg_i);
+/*
+ * Per-cpu output buffers.
+ */
+sw_output_buffer_t *per_cpu_output_buffers = NULL;
+/*
+ * Variables for book keeping.
+ */
+volatile int sw_last_cpu_read = -1;
+volatile s32 sw_last_mask = -1;
+/*
+ * Lock for the polled buffer.
+ */
+SW_DECLARE_SPINLOCK(sw_polled_lock);
+/*
+ * Buffer allocation size.
+ */
+unsigned long sw_buffer_alloc_size = (1 << 16); // 64 KB
+
+/* -------------------------------------------------
+ * Function definitions.
+ * -------------------------------------------------
+ */
+
+static char *reserve_seg_space_i(size_t size, int cpu, bool *should_wakeup, u64 *reservation_tsc)
+{
+    sw_output_buffer_t *buffer = GET_OUTPUT_BUFFER(cpu);
+    int i=0;
+    int buff_index = buffer->buff_index;
+    char *dst = NULL;
+
+    if (buff_index < 0 || buff_index >= NUM_SEGS_PER_BUFFER) {
+        goto prod_seg_done;
+    }
+    for_each_segment(i) {
+        sw_data_buffer_t *seg = &buffer->buffers[buff_index];
+        if (SEG_IS_FULL(seg) == false) {
+            if (SPACE_AVAIL(seg) >= size) {
+                *reservation_tsc = sw_timestamp();
+                dst = &seg->buffer[seg->bytes_written];
+                seg->bytes_written += size;
+                smp_mb();
+                buffer->buff_index = buff_index;
+                buffer->produced_samples++;
+                goto prod_seg_done;
+            }
+            SEG_SET_FULL(seg, sw_timestamp());
+        }
+        buff_index = CIRCULAR_INC(buff_index, NUM_SEGS_PER_BUFFER_MASK);
+        *should_wakeup = true;
+    }
+prod_seg_done:
+    if (!dst) {
+        buffer->dropped_samples++;
+    }
+    return dst;
+};
+
+int produce_polled_msg(struct sw_driver_msg *msg, enum sw_wakeup_action action)
+{
+    int cpu = GET_POLLED_CPU();
+    bool should_wakeup = false;
+    int retVal = PW_SUCCESS;
+
+    if (!msg) {
+        return -PW_ERROR;
+    }
+    pw_pr_debug("POLLED! cpu = %d\n", cpu);
+    LOCK(sw_polled_lock);
+    {
+        size_t size = SW_DRIVER_MSG_HEADER_SIZE() + msg->payload_len;
+        char *dst = reserve_seg_space_i(size, cpu, &should_wakeup, &msg->tsc);
+        if (dst) {
+            /*
+             * Assign a special CPU number to this CPU.
+             * This is OK, because messages enqueued in this buffer
+             * are always CPU agnostic (otherwise they would
+             * be invoked from within a preempt_disable()d context
+             * in 'sw_handle_collector_node_i()', which ensures they
+             * will be enqueued within the 'sw_produce_generic_msg_on_cpu()'
+             * function).
+             */
+            msg->cpuidx = cpu;
+            memcpy(dst, msg, SW_DRIVER_MSG_HEADER_SIZE()); dst += SW_DRIVER_MSG_HEADER_SIZE();
+            memcpy(dst, msg->p_payload, msg->payload_len);
+        } else {
+            pw_pr_debug("NO space in polled msg!\n");
+            retVal = -PW_ERROR;
+        }
+    }
+    UNLOCK(sw_polled_lock);
+    if (unlikely(should_wakeup)) {
+        sw_wakeup_reader(action);
+    }
+    return retVal;
+};
+
+static int sw_produce_generic_msg_i(struct sw_driver_msg *msg, enum sw_wakeup_action action)
+{
+    int retval = PW_SUCCESS;
+    bool should_wakeup = false;
+    int cpu = -1;
+    unsigned long flags = 0;
+
+    if (!msg) {
+        pw_pr_error("ERROR: CANNOT produce a NULL msg!\n");
+        return -PW_ERROR;
+    }
+
+#ifdef CONFIG_PREEMPT_COUNT
+    if (!in_atomic()) {
+        return produce_polled_msg(msg, action);
+    }
+#endif
+
+    cpu = sw_get_cpu(&flags);
+    {
+
+        size_t size = msg->payload_len + SW_DRIVER_MSG_HEADER_SIZE();
+        char *dst = reserve_seg_space_i(size, cpu, &should_wakeup, &msg->tsc);
+        if (likely(dst)) {
+            memcpy(dst, msg, SW_DRIVER_MSG_HEADER_SIZE()); dst += SW_DRIVER_MSG_HEADER_SIZE();
+            memcpy(dst, msg->p_payload, msg->payload_len);
+        } else {
+            retval = -PW_ERROR;
+        }
+    }
+    sw_put_cpu(flags);
+
+    if (unlikely(should_wakeup)) {
+        sw_wakeup_reader(action);
+    }
+
+    return retval;
+};
+
+int sw_produce_generic_msg(struct sw_driver_msg *msg, enum sw_wakeup_action action)
+{
+    return DO_PER_CPU_OVERHEAD_FUNC_RET(int, sw_produce_generic_msg_i, msg, action);
+};
+
+int sw_init_per_cpu_buffers_i(unsigned long per_cpu_mem_size)
+{
+    int cpu = -1;
+    per_cpu_output_buffers = (sw_output_buffer_t *)sw_kmalloc(sizeof(sw_output_buffer_t) * GET_NUM_OUTPUT_BUFFERS(), GFP_KERNEL | __GFP_ZERO);
+    if (per_cpu_output_buffers == NULL) {
+        pw_pr_error("ERROR allocating space for per-cpu output buffers!\n");
+        sw_destroy_per_cpu_buffers();
+        return -PW_ERROR;
+    }
+    for_each_output_buffer(cpu) {
+        sw_output_buffer_t *buffer = &per_cpu_output_buffers[cpu];
+        char *buff = NULL;
+        int i=0;
+        buffer->mem_alloc_size = per_cpu_mem_size;
+        buffer->free_pages = sw_allocate_pages(GFP_KERNEL | __GFP_ZERO, (unsigned int)per_cpu_mem_size);
+        if (buffer->free_pages == 0) {
+            pw_pr_error("ERROR allocating pages for buffer [%d]!\n", cpu);
+            sw_destroy_per_cpu_buffers();
+            return -PW_ERROR;
+        }
+        buff = (char *)buffer->free_pages;
+        for_each_segment(i) {
+            buffer->buffers[i].buffer = (char *)buff;
+            buff += SW_SEG_DATA_SIZE;
+        }
+    }
+    pw_pr_debug("PER_CPU_MEM_SIZE = %lu, order = %u\n", per_cpu_mem_size, get_order(per_cpu_mem_size));
+    return PW_SUCCESS;
+};
+
+int sw_init_per_cpu_buffers(void)
+{
+    unsigned int per_cpu_mem_size = sw_get_output_buffer_size();
+
+    pw_pr_debug("Buffer alloc size = %ld\n", sw_buffer_alloc_size);
+
+    if (GET_NUM_OUTPUT_BUFFERS() <= 0) {
+        pw_pr_error("ERROR: max # output buffers= %d\n", GET_NUM_OUTPUT_BUFFERS());
+        return -PW_ERROR;
+    }
+
+    pw_pr_debug("DEBUG: sw_max_num_cpus = %d, num output buffers = %d\n", sw_max_num_cpus, GET_NUM_OUTPUT_BUFFERS());
+
+    /*
+     * Try to allocate per-cpu buffers. If allocation fails, decrease buffer size and retry.
+     * Stop trying if size drops below 2KB (which means 1KB for each buffer).
+     */
+    while (per_cpu_mem_size >= SW_MIN_OUTPUT_BUFFER_SIZE && sw_init_per_cpu_buffers_i(per_cpu_mem_size)) {
+        pw_pr_debug("WARNING: couldn't allocate per-cpu buffers with size %u -- trying smaller size!\n", per_cpu_mem_size);
+        sw_buffer_alloc_size >>= 1;
+        per_cpu_mem_size = sw_get_output_buffer_size();
+    }
+
+    if (unlikely(per_cpu_output_buffers == NULL)) {
+        pw_pr_error("ERROR: couldn't allocate space for per-cpu output buffers!\n");
+        return -PW_ERROR;
+    }
+    /*
+     * Initialize our locks.
+     */
+    SW_INIT_SPINLOCK(sw_polled_lock);
+
+    pw_pr_debug("OK, allocated per-cpu buffers with size = %lu\n", per_cpu_mem_size);
+
+    if (sw_init_reader_queue()) {
+        pw_pr_error("ERROR initializing reader subsys\n");
+        return -PW_ERROR;
+    }
+
+    return PW_SUCCESS;
+};
+
+void sw_destroy_per_cpu_buffers(void)
+{
+    int cpu = -1;
+
+    /*
+     * Perform lock finalization.
+     */
+    SW_DESTROY_SPINLOCK(sw_polled_lock);
+
+    if (per_cpu_output_buffers != NULL) {
+        for_each_output_buffer(cpu) {
+            sw_output_buffer_t *buffer = &per_cpu_output_buffers[cpu];
+            if (buffer->free_pages != 0) {
+                sw_release_pages(buffer->free_pages, buffer->mem_alloc_size);
+                buffer->free_pages = 0;
+            }
+        }
+        sw_kfree(per_cpu_output_buffers);
+        per_cpu_output_buffers = NULL;
+    }
+};
+
+void sw_reset_per_cpu_buffers(void)
+{
+    int cpu = 0, i=0;
+    for_each_output_buffer(cpu) {
+        sw_output_buffer_t *buffer = GET_OUTPUT_BUFFER(cpu);
+        buffer->buff_index = buffer->dropped_samples = buffer->produced_samples = 0;
+        buffer->last_seg_read = -1;
+
+        for_each_segment(i) {
+            sw_data_buffer_t *seg = &buffer->buffers[i];
+            memset(seg->buffer, 0, SW_SEG_DATA_SIZE);
+            SEG_SET_EMPTY(seg);
+        }
+    }
+    sw_last_cpu_read = -1;
+    sw_last_mask = -1;
+    pw_pr_debug("OK, reset per-cpu output buffers!\n");
+};
+
+bool sw_any_seg_full(u32 *val, bool is_flush_mode)
+{
+    int num_visited = 0, i = 0;
+
+    if (!val) {
+        pw_pr_error("ERROR: NULL ptrs in sw_any_seg_full!\n");
+        return false;
+    }
+
+    *val = SW_NO_DATA_AVAIL_MASK;
+    pw_pr_debug(KERN_INFO "Checking for full seg: val = %u, flush = %s\n", *val, GET_BOOL_STRING(is_flush_mode));
+    for_each_output_buffer(num_visited) {
+        int min_seg = EMPTY_SEG, non_empty_seg = EMPTY_SEG;
+        u64 min_tsc = EMPTY_TSC;
+        sw_output_buffer_t *buffer = NULL;
+        if (++sw_last_cpu_read >= GET_NUM_OUTPUT_BUFFERS()) {
+            sw_last_cpu_read = 0;
+        }
+        buffer = GET_OUTPUT_BUFFER(sw_last_cpu_read);
+        for_each_segment(i) {
+            sw_data_buffer_t *seg = &buffer->buffers[i];
+            u64 seg_tsc = seg->is_full;
+            if (SEG_IS_EMPTY(seg)) {
+                continue;
+            }
+            non_empty_seg = i;
+            if (seg_tsc < min_tsc) {
+                /*
+                 * Can only happen if seg was full, provided 'EMPTY_TSC' is set to "(u64)-1"
+                 */
+                min_tsc = seg_tsc;
+                min_seg = i;
+            }
+        }
+        if (min_seg != EMPTY_SEG) {
+            *val = (sw_last_cpu_read & 0xffff) << 16 | (min_seg & 0xffff);
+            return true;
+        } else if (is_flush_mode && non_empty_seg != EMPTY_SEG) {
+            *val = (sw_last_cpu_read & 0xffff) << 16 | (non_empty_seg & 0xffff);
+            return true;
+        }
+    }
+    /*
+     * Reaches here only if there's no data to be read.
+     */
+    if (is_flush_mode) {
+        /*
+         * We've drained all buffers and need to tell the userspace application there
+         * isn't any data. Unfortunately, we can't just return a 'zero' value for the
+         * mask (because that could also indicate that segment # 0 of cpu #0 has data).
+         */
+        *val = SW_ALL_WRITES_DONE_MASK;
+        return true;
+    }
+    return false;
+};
+
+/*
+ * Has semantics of 'copy_to_user()' -- returns # of bytes that could NOT be copied
+ * (On success ==> returns 0).
+ */
+size_t sw_consume_data(u32 mask, void *buffer, size_t bytes_to_read)
+{
+    int which_cpu = -1, which_seg = -1;
+    unsigned long bytes_not_copied = 0;
+    sw_output_buffer_t *buff = NULL;
+    sw_data_buffer_t *seg = NULL;
+    size_t bytes_read = 0;
+
+    if (!sw_check_output_buffer_params(buffer, bytes_to_read, SW_SEG_DATA_SIZE)) {
+        pw_pr_error("ERROR: invalid params to \"sw_consume_data\"!\n");
+        return -PW_ERROR;
+    }
+
+    which_cpu = mask >> 16; which_seg = mask & 0xffff;
+    pw_pr_debug("CONSUME: cpu = %d, seg = %d\n", which_cpu, which_seg);
+    if (which_seg >= NUM_SEGS_PER_BUFFER) {
+        pw_pr_error("Error: which_seg (%d) >= NUM_SEGS_PER_BUFFER (%d)\n", which_seg, NUM_SEGS_PER_BUFFER);
+        return bytes_to_read;
+    }
+    /*
+     * OK to access unlocked; either the segment is FULL, or no collection
+     * is ongoing. In either case, we're GUARANTEED no producer is touching
+     * this segment.
+     */
+    buff = GET_OUTPUT_BUFFER(which_cpu);
+    seg = &buff->buffers[which_seg];
+
+    bytes_not_copied = sw_copy_to_user(buffer, seg->buffer, seg->bytes_written); // dst, src
+
+    // bytes_not_copied = copy_to_user(buffer, seg->buffer, seg->bytes_written); // dst,src
+    if (likely(bytes_not_copied == 0)) {
+      bytes_read = seg->bytes_written;
+    } else {
+        pw_pr_error("Warning: couldn't copy %lu bytes\n", bytes_not_copied);
+        bytes_read = 0;
+    }
+    SEG_SET_EMPTY(seg);
+    return bytes_read;
+}
+
+unsigned int sw_get_output_buffer_size(void)
+{
+    return (sw_buffer_alloc_size * NUM_SEGS_PER_BUFFER);
+};
+
+void sw_count_samples_produced_dropped(void)
+{
+    int cpu = 0;
+    sw_num_samples_produced = sw_num_samples_dropped = 0;
+    if (per_cpu_output_buffers == NULL) {
+        return;
+    }
+    for_each_output_buffer(cpu) {
+        sw_output_buffer_t *buff = GET_OUTPUT_BUFFER(cpu);
+        sw_num_samples_dropped += buff->dropped_samples;
+        sw_num_samples_produced += buff->produced_samples;
+    }
+};
+
+void sw_print_output_buffer_overheads(void)
+{
+    PRINT_CUMULATIVE_OVERHEAD_PARAMS(sw_produce_generic_msg_i, "PRODUCE_GENERIC_MSG");
+    sw_print_reader_stats();
+};

--- a/perftools-external/socwatch_driver/src/sw_reader.c
+++ b/perftools-external/socwatch_driver/src/sw_reader.c
@@ -1,0 +1,159 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2017 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#include "sw_internal.h"
+#include "sw_output_buffer.h"
+#include "sw_defines.h"
+
+#define SW_BUFFER_CLEANUP_TIMER_DELAY_NSEC 1000000 /* delay buffer cleanup by 10^6 nsec i.e. 1 msec */
+
+/*
+ * The alarm queue.
+ */
+wait_queue_head_t sw_reader_queue;
+/*
+ * Reader wakeup timer.
+ */
+static struct hrtimer s_reader_wakeup_timer;
+/*
+ * Variable to track # timer fires.
+ */
+static int s_num_timer_fires = 0;
+
+/*
+ * The alarm callback.
+ */
+static enum hrtimer_restart sw_wakeup_callback_i(struct hrtimer *timer)
+{
+    ++s_num_timer_fires;
+    wake_up_interruptible(&sw_reader_queue);
+    return HRTIMER_NORESTART;
+}
+
+/*
+ * Init reader queue.
+ */
+int sw_init_reader_queue(void)
+{
+    init_waitqueue_head(&sw_reader_queue);
+    /*
+     * Also init wakeup timer (used in low-overhead mode).
+     */
+    hrtimer_init(&s_reader_wakeup_timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+    s_reader_wakeup_timer.function = &sw_wakeup_callback_i;
+
+    return PW_SUCCESS;
+}
+/*
+ * Destroy reader queue.
+ */
+void sw_destroy_reader_queue(void)
+{
+    /* NOP */
+}
+/*
+ * Wakeup client waiting for a full buffer.
+ */
+void sw_wakeup_reader(enum sw_wakeup_action action)
+{
+    if (!waitqueue_active(&sw_reader_queue)) {
+        return;
+    }
+    /*
+     * Direct mode?
+     */
+    switch (action) {
+        case SW_WAKEUP_ACTION_DIRECT:
+            wake_up_interruptible(&sw_reader_queue);
+            break;
+        case SW_WAKEUP_ACTION_TIMER:
+            if (!hrtimer_active(&s_reader_wakeup_timer)) {
+                ktime_t ktime = ns_to_ktime(SW_BUFFER_CLEANUP_TIMER_DELAY_NSEC);
+                // TODO: possible race here -- introduce locks?
+                hrtimer_start(&s_reader_wakeup_timer, ktime, HRTIMER_MODE_REL);
+            }
+            break;
+        default:
+            break;
+    }
+    return;
+}
+/*
+ * Wakeup client waiting for a full buffer, and
+ * cancel any timers initialized by the reader
+ * subsys.
+ */
+void sw_cancel_reader(void)
+{
+    /*
+     * Cancel pending wakeup timer (used in low-overhead mode).
+     */
+    if (hrtimer_active(&s_reader_wakeup_timer)) {
+        hrtimer_cancel(&s_reader_wakeup_timer);
+    }
+    /*
+     * There might be a reader thread blocked on a read: wake
+     * it up to give it a chance to respond to changed
+     * conditions.
+     */
+    sw_wakeup_reader(SW_WAKEUP_ACTION_DIRECT);
+}
+
+void sw_print_reader_stats(void)
+{
+#if DO_OVERHEAD_MEASUREMENTS
+    printk(KERN_INFO "# reader queue timer fires = %d\n", s_num_timer_fires);
+#endif // OVERHEAD
+}

--- a/perftools-external/socwatch_driver/src/sw_telem.c
+++ b/perftools-external/socwatch_driver/src/sw_telem.c
@@ -1,0 +1,488 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2018 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2018 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/compiler.h>     /* Definition of __weak */
+#include <linux/version.h>      /* LINUX_VERSION_CODE */
+#include "sw_defines.h"         /* PW_ERROR, etc. */
+#include "sw_kernel_defines.h"  /* pw_pr_debug */
+#include "sw_mem.h"             /* sw_kmalloc/free */
+#include "sw_lock_defs.h"       /* Various lock-related definitions */
+#include "sw_telem.h"           /* Signatures of fn's exported from here. */
+
+/*
+ * These functions and data structures are exported by the Telemetry
+ * driver.  However, that file may not be available in the kernel for
+ * which this driver is being built, so we re-define many of the same
+ * things here.
+ */
+/**
+ * struct telemetry_evtlog - The "event log" returned by the kernel's
+ *                           full-read telemetry driver.
+ * @telem_evtid:   The 16-bit event ID.
+ * @telem_evtlog:  The actual telemetry data.
+ */
+struct telemetry_evtlog {
+    u32 telem_evtid;    /* Event ID of a data item. */
+    u64 telem_evtlog;   /* Counter data */
+};
+
+struct telemetry_evtconfig {
+    u32 *evtmap;    /* Array of Event-IDs to Enable */
+    u8 num_evts;    /* Number of Events (<29) in evtmap */
+    u8 period;      /* Sampling period */
+};
+
+#define MAX_TELEM_EVENTS 28  /* Max telem events per unit */
+
+/* The enable bit is set when programming events, but is returned
+ * cleared for queried events requests.
+ */
+#define TELEM_EVENT_ENABLE 0x8000 /* Enabled when Event ID HIGH bit */
+
+/*
+ * Sampling Period values.
+ * The sampling period is encoded in an 7-bit value, where
+ *    Period = (Value * 16^Exponent) usec where:
+ *        bits[6:3] -> Value;
+ *        bits [0:2]-> Exponent;
+ * Here are some of the calculated possible values:
+ * | Value  Val+Exp  | Value | Exponent | Period (usec) | Period (msec) |
+ * |-----------------+-------+----------+---------------+---------------|
+ * | 0xA = 000 1+010 |     1 |        2 |           256 |         0.256 |
+ * | 0x12= 001 0+010 |     2 |        2 |           512 |         0.512 |
+ * | 0x22= 010 0+010 |     4 |        2 |          1024 |         1.024 |
+ * | 0xB = 000 1+011 |     1 |        3 |          4096 |         4.096 |
+ * | 0x13= 001 0+011 |     2 |        3 |          8192 |         8.192 |
+ * | 0x1B= 001 1+011 |     3 |        3 |         12288 |        12.288 |
+ * | 0x0C= 000 1+100 |     1 |        4 |         65536 |        65.536 |
+ * | 0x0D= 000 1+101 |     1 |        5 |       1048576 |      1048.576 |
+ */
+#define TELEM_SAMPLING_1MS 0x22  /* Approximately 1 ms */
+#define TELEM_SAMPLING_1S  0x0D  /* Approximately 1 s */
+
+/* These functions make up the main APIs of the telemetry driver.  We
+ * define all of them with weak linkage so that we can still compile
+ * and load into kernels which don't have a telemetry driver.
+ */
+extern int __weak telemetry_raw_read_eventlog(enum telemetry_unit telem_unit,
+                                              struct telemetry_evtlog *evtlog,
+                                              int evcount);
+extern int __weak telemetry_reset(void);
+extern int __weak telemetry_reset_events(void);
+extern int __weak telemetry_get_sampling_period(u8 *punit_min,
+                                                u8 *punit_max,
+                                                u8 *pmc_min,
+                                                u8 *pmc_max);
+extern int __weak telemetry_set_sampling_period(u8 punit_period,
+                                                u8   pmc_period);
+extern int __weak telemetry_get_eventconfig(struct telemetry_evtconfig *punit_config,
+                                            struct telemetry_evtconfig *pmc_config,
+                                            int  punit_len,
+                                            int  pmc_len);
+extern int __weak telemetry_add_events(u8 num_punit_evts, u8 num_pmc_evts,
+                                       u32 *punit_evtmap, u32 *pmc_evtmap);
+
+extern int __weak telemetry_update_events(struct telemetry_evtconfig punit_config,
+                                          struct telemetry_evtconfig pmc_config);
+
+/*
+ * Some telemetry IDs have multiple instances, indexed by cpu ID.  We
+ * implement these by defining two types of IDs: 'regular' and 'scaled'.
+ * For Telemetry IDs with a single instance (the majority of them), the
+ * index into the system's telemetry table is stored in the
+ * sw_driver_io_descriptor.idx.  At read time, the driver gets the telemetry
+ * "slot" from sw_driver_io_descriptor.idx, and reads that data.  This case
+ * is illustrated by telem_desc_A in the illustration below, where idx 2
+ * indicates that telem_data[2] contains the telem data for this descriptor.
+ *
+ *   telem_desc_A                            telem_data
+ *    scale_op: X                              |..|[0]
+ *    idx     : 2 --------------------         |..|[1]
+ *                                    \------->|..|[2]
+ *                     Scaled_IDs              |..|[3]
+ *   telem_desc_B     CPU#0 1 2 3       ------>|..|[4]
+ *    scale_op: /     [0]|.|.|.|.|     /
+ *    idx     : 1---->[1]|4|4|5|5|    /
+ *                        +----------/
+ *
+ * Descriptors with scaled IDs contain a scale operation (scale_op) and
+ * value.  They use a 'scaled_ids' table, which is indexed by descriptor
+ * number and CPU id, and stores the telem_data index.  So in the
+ * illustration above, CPU 0 reading from telem_desc_B would fetch row 1
+ * (from telem_desc_B.idx == 1), and column [0] yielding element 4, so
+ * that's the telemetry ID it looks up in the telemetry data.
+ *
+ * The scaled_ids table is populated at telemetry ID initialization time
+ *
+ */
+static unsigned char *sw_telem_scaled_ids = NULL; /* Allocate on demand */
+static unsigned int   sw_telem_rows_alloced = 0; /* Rows currently allocated */
+static unsigned int   sw_telem_rows_avail   = 0; /* Available rows */
+
+extern int sw_max_num_cpus;     /* SoC Watch's copy of cpu count. */
+
+/* Macro for identifying telemetry IDs with either per-cpu, or per-module
+ * instances.  These IDs need to be 'scaled' as per scale_op and scale_val.
+ */
+#define IS_SCALED_ID(td) ((td)->scale_op != TELEM_OP_NONE)
+/*
+ * Event map that is populated with user-supplied IDs
+ */
+static u32 s_event_map[2][MAX_TELEM_EVENTS];
+/*
+ * Index into event map(s)
+ */
+static size_t s_unit_idx[2] = {0, 0};
+/*
+ * Used to decide if telemetry values need refreshing
+ */
+static size_t s_unit_iters[2] = {0, 0};
+/*
+ * Spinlock to guard updates to the 'iters' values.
+ */
+SW_DEFINE_SPINLOCK(sw_telem_lock);
+/*
+ * Macro to determine if socwatch telemetry system has been configured
+ */
+#define SW_TELEM_CONFIGURED() (s_unit_idx[0] > 0 || s_unit_idx[1] > 0)
+
+/**
+ * telemetry_available - Determine if telemetry driver is present
+ *
+ * Returns: 1 if telemetry driver is present, 0 if not.
+ */
+static int telemetry_available(void)
+{
+    int retval = 0;
+    struct telemetry_evtconfig punit_evtconfig;
+    struct telemetry_evtconfig pmc_evtconfig;
+    u32 punit_event_map[MAX_TELEM_EVENTS];
+    u32 pmc_event_map[MAX_TELEM_EVENTS];
+
+
+    /* The symbol below is weak.  We return 1 if we have a definition
+     * for this telemetry-driver-supplied symbol, or 0 if only the
+     * weak definition exists. This test will suffice to detect if
+     * the telemetry driver is loaded.
+     */
+    if (telemetry_get_eventconfig == 0) {
+            return 0;
+    }
+    /* OK, the telemetry driver is loaded. But it's possible it
+     * hasn't been configured properly. To check that, retrieve
+     * the number of events currently configured. This should never
+     * be zero since the telemetry driver reserves some SSRAM slots
+     * for its own use
+     */
+    memset(&punit_evtconfig, 0, sizeof(punit_evtconfig));
+    memset(&pmc_evtconfig, 0, sizeof(pmc_evtconfig));
+
+    punit_evtconfig.evtmap = (u32*) &punit_event_map;
+    pmc_evtconfig.evtmap = (u32*) &pmc_event_map;
+
+    retval = telemetry_get_eventconfig(&punit_evtconfig, &pmc_evtconfig,
+                                        MAX_TELEM_EVENTS, MAX_TELEM_EVENTS);
+    return retval == 0 && punit_evtconfig.num_evts > 0 && pmc_evtconfig.num_evts > 0;
+}
+
+/**
+ * sw_get_instance_row -- Get the address of a 'row' of instance IDs.
+ * @rownum: The row number of the Instance ID table, whose address to return.
+ * Returns: The address of the appropriate row, or NULL if rownum is bad.
+ */
+static unsigned char *sw_get_instance_row_addr(unsigned int rownum)
+{
+    if (rownum >= (sw_telem_rows_alloced - sw_telem_rows_avail)) {
+        pw_pr_error("ERROR: Cannot retrieve row Instance ID row %d\n",
+                    rownum);
+        return NULL;
+    }
+    return &sw_telem_scaled_ids[rownum * sw_max_num_cpus];
+}
+
+/**
+ * sw_free_telem_scaled_id_table - Free the allocated slots.
+ * Returns: Nothing
+ *
+ * Admittedly, a more symmetrical function name would be nice.
+ */
+static void sw_telem_release_scaled_ids(void)
+{
+    sw_telem_rows_alloced = 0;
+    sw_telem_rows_avail   = 0;
+    if (sw_telem_scaled_ids) {
+        sw_kfree(sw_telem_scaled_ids);
+    }
+    sw_telem_scaled_ids = NULL;
+}
+
+/**
+ * sw_telem_init_func - Set up the telemetry unit to retrieve a data item
+ *                        (e.g. counter).
+ * @descriptor:  The IO descriptor containing the unit and ID
+ *                        of the telemetry info to gather.
+ *
+ * Because we don't (currently) control all of the counters, we
+ * economize by seeing if it's already being collected before allocate
+ * a slot for it.
+ *
+ * Returns: PW_SUCCESS  if the telem collector can collect the requested data.
+ *         -PW_ERROR   if the the addition of that item fails.
+ */
+int sw_telem_init_func(struct sw_driver_io_descriptor *descriptor)
+{
+    struct sw_driver_telem_io_descriptor *td = &(descriptor->telem_descriptor);
+    u8  unit = td->unit;  /* Telemetry unit to use. */
+    u32 id; /* Event ID we want telemetry to track. */
+    size_t idx;  /* Index into telemetry data array of event ID to gather. */
+    const char *unit_str = unit == TELEM_PUNIT? "PUNIT" : "PMC";
+    size_t *unit_idx = &s_unit_idx[unit];
+
+    if (!telemetry_available()) {
+        return -ENXIO;
+    }
+
+    id = (u32)(td->id);
+
+    /* Check if we've already added this ID */
+    for (idx=0; idx<*unit_idx && idx<MAX_TELEM_EVENTS; ++idx) {
+        if (s_event_map[unit][idx] == id) {
+            /* Invariant: idx contains the index of the new data item. */
+            /* Save the index for later fast lookup. */
+            td->idx = (u16)idx;
+            return 0;
+        }
+    }
+
+    if (*unit_idx >= MAX_TELEM_EVENTS) {
+        pw_pr_error("Too many events %s units requested; max of %u available!\n", unit_str, MAX_TELEM_EVENTS);
+        return -E2BIG;
+    }
+    s_event_map[unit][(*unit_idx)++] = id;
+    /* Invariant: idx contains the index of the new data item. */
+    /* Save the index for later fast lookup. */
+    td->idx = (u16)idx;
+    pw_pr_debug("OK, added id = 0x%x to unit %s at entry %zu; retrieved = 0x%x\n", id, unit_str, *unit_idx-1, s_event_map[unit][*unit_idx-1]);
+
+    return 0;
+}
+
+
+/**
+ * sw_read_telem_info - Read a metric's data from the telemetry driver.
+ * @dest:               Destination (storage for the read data)
+ * @cpu:                Which CPU to read from (not used)
+ * @descriptor:         The descriptor containing the data ID to read
+ * @data_size_in_bytes: The # of bytes in the result (always 8)
+ *
+ * Returns: Nothing, but stores SW_TELEM_READ_FAIL_VALUE to dest if the read fails.
+ */
+void sw_read_telem_info(char *dest, int cpu,
+                          const sw_driver_io_descriptor_t *descriptor,
+                          u16 data_size_in_bytes)
+{
+    int  len;
+    u64 *data_dest = (u64 *)dest;
+    int retry_count;
+    const struct sw_driver_telem_io_descriptor *td = &(descriptor->telem_descriptor);
+    unsigned int idx;
+    u8 unit = td->unit;
+    bool needs_refresh = false;
+
+#define TELEM_PKT_SIZE 16  /* sizeof(struct telemetry_evtlog) + padding */
+    static struct telemetry_evtlog events[MAX_TELEM_EVENTS];
+
+    // Get the event index
+    if (IS_SCALED_ID(td)) {
+        unsigned char *scaled_ids;
+        scaled_ids = sw_get_instance_row_addr(td->idx);
+        if (scaled_ids == NULL) {
+            pw_pr_error("Sw_read_telem_info_i: Illegal row index: *%p = %d",
+                        &td->idx, td->idx);
+            *data_dest = SW_TELEM_READ_FAIL_VALUE;
+            return;  /* Don't set the dest/data buffer. */
+        }
+        idx = scaled_ids[RAW_CPU()]; /* Get per-cpu entry */
+    } else {
+        idx = td->idx;
+    }
+
+    /*
+     * Check if we need to refresh the list of values
+     */
+    LOCK(sw_telem_lock);
+    {
+        if (s_unit_iters[unit] == 0) {
+            needs_refresh = true;
+        }
+        if (++s_unit_iters[unit] == s_unit_idx[unit]) {
+            s_unit_iters[unit] = 0;
+        }
+    }
+    UNLOCK(sw_telem_lock);
+
+    /*
+     * Because of the enormous overhead of reading telemetry data from
+     * the current kernel driver, failure to read the data is not
+     * unheard of.  As such, 3 times, should the read fail.  Once we
+     * get a higher-performance read routine, we should be able to
+     * eliminate this retry (or maybe decrease it.)
+     */
+    retry_count = 3;
+    while (needs_refresh && retry_count--) {
+        len = telemetry_raw_read_eventlog(unit,
+                                          events,
+                                          sizeof(events) / TELEM_PKT_SIZE);
+
+        if ((len < 0) || (len < idx)) {
+            pw_pr_error("sw_read_telem_info_i: read failed: len=%d\n", len);
+        } else {
+            break;
+        }
+    }
+
+    if (retry_count) {
+        // TODO: Resolve if we should return something other than
+        //       SW_TELEM_READ_FAIL_VALUE, if the actual data happens to be that.
+        *data_dest = events[idx].telem_evtlog;
+    } else {
+        *data_dest = SW_TELEM_READ_FAIL_VALUE;
+    }
+}
+
+/**
+ * sw_reset_telem - Stop collecting telemetry info.
+ * @descriptor: Unused in this function
+ *
+ * Stop collecting anything extra, and give the driver back to
+ * debugfs.  Because this driver increases the sampling rate, the
+ * kernel's telemetry driver can't succesfully reset the driver unless
+ * we first drop the rate back down to a much slower rate.  This is a
+ * temporary measure, since the reset operation will then reset the
+ * sampling interval to whatever the GMIN driver wants.
+ *
+ * Return: PW_SUCCESS.
+ */
+int sw_reset_telem(const struct sw_driver_io_descriptor *descriptor)
+{
+    if (telemetry_available() && SW_TELEM_CONFIGURED()) {
+        telemetry_set_sampling_period(TELEM_SAMPLING_1S,
+                                      TELEM_SAMPLING_1S);
+        telemetry_reset_events();
+        sw_telem_release_scaled_ids();
+        memset(s_unit_idx, 0, sizeof(s_unit_idx));
+        memset(s_unit_iters, 0, sizeof(s_unit_iters));
+    }
+    return PW_SUCCESS;
+}
+
+/**
+ * sw_available_telem -- Decide if the telemetry subsystem is available for use
+ */
+bool sw_telem_available(void)
+{
+    return telemetry_available();
+};
+
+bool sw_telem_post_config(void)
+{
+    bool retval = true;
+    size_t i=0;
+    struct telemetry_evtconfig punit_evtconfig;
+    struct telemetry_evtconfig pmc_evtconfig;
+
+    if (!SW_TELEM_CONFIGURED()) {
+        return true;
+    }
+
+    memset(&punit_evtconfig, 0, sizeof(punit_evtconfig));
+    memset(&pmc_evtconfig, 0, sizeof(pmc_evtconfig));
+
+    telemetry_set_sampling_period(TELEM_SAMPLING_1S, TELEM_SAMPLING_1S);
+
+    punit_evtconfig.period = TELEM_SAMPLING_1S;
+    pmc_evtconfig.period = TELEM_SAMPLING_1S;
+
+    /* Punit */
+    punit_evtconfig.evtmap = (u32 *)&s_event_map[TELEM_PUNIT];
+    punit_evtconfig.num_evts = s_unit_idx[TELEM_PUNIT];
+    /* PMC */
+    pmc_evtconfig.evtmap = (u32 *)&s_event_map[TELEM_PMC];
+    pmc_evtconfig.num_evts = s_unit_idx[TELEM_PMC];
+
+    for (i=0; i<punit_evtconfig.num_evts; ++i) {
+        pw_pr_debug("PUNIT[%zu] = 0x%x\n", i, punit_evtconfig.evtmap[i]);
+    }
+    for (i=0; i<pmc_evtconfig.num_evts; ++i) {
+        pw_pr_debug("PMC[%zu] = 0x%x\n", i, pmc_evtconfig.evtmap[i]);
+    }
+
+    /*
+     * OK, everything done. Now update
+     */
+    if (telemetry_update_events(punit_evtconfig, pmc_evtconfig)) {
+        pw_pr_error("telemetry_update_events error");
+        retval = false;
+    } else {
+        pw_pr_debug("OK, telemetry_update_events success\n");
+    }
+
+    telemetry_set_sampling_period(TELEM_SAMPLING_1MS, TELEM_SAMPLING_1MS);
+
+    return retval;
+}

--- a/perftools-external/socwatch_driver/src/sw_trace_notifier_provider.c
+++ b/perftools-external/socwatch_driver/src/sw_trace_notifier_provider.c
@@ -1,0 +1,1876 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2018 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2018 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#include <linux/version.h> // "LINUX_VERSION_CODE"
+#include <linux/hrtimer.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,11,0)
+    #include <asm/cputime.h>
+#else
+    #include <linux/sched/cputime.h>
+#endif
+#include <asm/hardirq.h>
+#include <asm/local.h>
+
+#include <trace/events/power.h>
+#include <trace/events/irq.h>
+#include <trace/events/timer.h>
+#include <trace/events/power.h>
+#include <trace/events/sched.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0)
+    #include <asm/trace/irq_vectors.h> // for the various APIC vector tracepoints (e.g. "thermal_apic", "local_timer" etc.)
+#endif // LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0)
+struct pool_workqueue; // Forward declaration to avoid compiler warnings
+struct cpu_workqueue_struct; // Forward declaration to avoid compiler warnings
+#include <trace/events/workqueue.h>
+#include <linux/suspend.h> // for 'pm_notifier'
+#include <linux/cpufreq.h> // for "cpufreq_notifier"
+#include <linux/cpu.h> // for 'CPU_UP_PREPARE' etc
+
+#include "sw_collector.h"
+#include "sw_overhead_measurements.h"
+#include "sw_tracepoint_handlers.h"
+#include "sw_output_buffer.h"
+#include "sw_mem.h"
+#include "sw_trace_notifier_provider.h"
+
+/* -------------------------------------------------
+ * Compile time constants and useful macros.
+ * -------------------------------------------------
+ */
+#ifndef __get_cpu_var
+    /*
+     * Kernels >= 3.19 don't include a definition
+     * of '__get_cpu_var'. Create one now.
+     */
+    #define __get_cpu_var(var) *this_cpu_ptr(&var)
+#endif // __get_cpu_var
+
+#define BEGIN_LOCAL_IRQ_STATS_READ(p) do{	\
+    p = &__get_cpu_var(irq_stat);
+
+#define END_LOCAL_IRQ_STATS_READ(p)		\
+    }while(0)
+/*
+ * CAS{32,64}
+ */
+#define CAS32(p, o, n) ( cmpxchg((p), (o), (n)) == (o) )
+#define CAS64(p, o, n) ( cmpxchg64((p), (o), (n)) == (o) )
+/*
+ * Timer start pid accessor macros
+ */
+#ifdef CONFIG_TIMER_STATS
+    #define GET_TIMER_THREAD_ID(t) ( (t)->start_pid ) /* 'start_pid' is actually the thread ID of the thread that initialized the timer */
+#else
+    #define GET_TIMER_THREAD_ID(t) ( -1 )
+#endif // CONFIG_TIMER_STATS
+/*
+ * Tracepoint probe register/unregister functions and
+ * helper macros.
+ */
+#ifdef CONFIG_TRACEPOINTS
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,35)
+    #define DO_REGISTER_SW_TRACEPOINT_PROBE(node, name, probe) WARN_ON(register_trace_##name(probe))
+    #define DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, name, probe) unregister_trace_##name(probe)
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(3,15,0)
+    #define DO_REGISTER_SW_TRACEPOINT_PROBE(node, name, probe) WARN_ON(register_trace_##name(probe, NULL))
+    #define DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, name, probe) unregister_trace_##name(probe, NULL)
+#else
+    #define DO_REGISTER_SW_TRACEPOINT_PROBE(node, name, probe) WARN_ON(tracepoint_probe_register(node->tp, probe, NULL))
+    #define DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, name, probe) tracepoint_probe_unregister(node->tp, probe, NULL)
+#endif
+#else // CONFIG_TRACEPOINTS
+    #define DO_REGISTER_SW_TRACEPOINT_PROBE(...) /* NOP */
+    #define DO_UNREGISTER_SW_TRACEPOINT_PROBE(...) /* NOP */
+#endif // CONFIG_TRACEPOINTS
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,35)
+    #define _DEFINE_PROBE_FUNCTION(name, ...) static void name(__VA_ARGS__)
+#else
+    #define _DEFINE_PROBE_FUNCTION(name, ...) static void name(void *ignore, __VA_ARGS__)
+#endif
+#define DEFINE_PROBE_FUNCTION(x) _DEFINE_PROBE_FUNCTION(x)
+
+/*
+ * Tracepoint probe function parameters.
+ * These tracepoint signatures depend on kernel version.
+ */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,36)
+    #define PROBE_TPS_PARAMS sw_probe_power_start_i, unsigned int type, unsigned int state
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(2,6,38)
+    #define PROBE_TPS_PARAMS sw_probe_power_start_i, unsigned int type, unsigned int state, unsigned int cpu_id
+#else
+    #define PROBE_TPS_PARAMS sw_probe_cpu_idle_i, unsigned int state, unsigned int cpu_id
+#endif
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,38)
+    #define PROBE_TPF_PARAMS sw_probe_power_frequency_i, unsigned int type, unsigned int state
+#else
+    #define PROBE_TPF_PARAMS sw_probe_cpu_frequency_i, unsigned int new_freq, unsigned int cpu
+#endif
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,35)
+    #define PROBE_SCHED_WAKEUP_PARAMS sw_probe_sched_wakeup_i, struct rq *rq, struct task_struct *task, int success
+#else
+    #define PROBE_SCHED_WAKEUP_PARAMS sw_probe_sched_wakeup_i, struct task_struct *task, int success
+#endif
+
+#if DO_ANDROID
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(3,4,0)
+        #define PROBE_WAKE_LOCK_PARAMS sw_probe_wake_lock_i, struct wake_lock *lock
+        #define PROBE_WAKE_UNLOCK_PARAMS sw_probe_wake_unlock_i, struct wake_unlock *unlock
+    #else
+        #define PROBE_WAKE_LOCK_PARAMS sw_probe_wakeup_source_activate_i, const char *name, unsigned int state
+        #define PROBE_WAKE_UNLOCK_PARAMS sw_probe_wakeup_source_deactivate_i, const char *name, unsigned int state
+    #endif // version
+#endif // DO_ANDROID
+
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,35)
+    #define PROBE_WORKQUEUE_PARAMS sw_probe_workqueue_execution_i, struct task_struct *wq_thread, struct work_struct *work
+#else
+    #define PROBE_WORKQUEUE_PARAMS sw_probe_workqueue_execute_start_i, struct work_struct *work
+#endif
+
+#define PROBE_SCHED_SWITCH_PARAMS sw_probe_sched_switch_i, struct task_struct *prev, struct task_struct *next
+/*
+ * These tracepoint signatures are independent of kernel version.
+ */
+#define PROBE_IRQ_PARAMS sw_probe_irq_handler_entry_i, int irq, struct irqaction *action
+#define PROBE_TIMER_ARGS sw_probe_timer_expire_entry_i, struct timer_list *t
+#define PROBE_HRTIMER_PARAMS sw_probe_hrtimer_expire_entry_i, struct hrtimer *hrt, ktime_t *now
+#define PROBE_PROCESS_FORK_PARAMS sw_probe_sched_process_fork_i, struct task_struct *parent, struct task_struct *child
+#define PROBE_SCHED_PROCESS_EXIT_PARAMS sw_probe_sched_process_exit_i, struct task_struct *task
+#define PROBE_THERMAL_APIC_ENTRY_PARAMS sw_probe_thermal_apic_entry_i, int vector
+#define PROBE_THERMAL_APIC_EXIT_PARAMS sw_probe_thermal_apic_exit_i, int vector
+
+#define IS_VALID_WAKEUP_EVENT(cpu) ({ \
+        bool *per_cpu_event = &per_cpu(sw_is_valid_wakeup_event, (cpu)); \
+        bool old_value = CAS32(per_cpu_event, true, sw_wakeup_event_flag); \
+        old_value; \
+        })
+#define SHOULD_PRODUCE_WAKEUP_SAMPLE(cpu) (IS_VALID_WAKEUP_EVENT(cpu))
+#define RESET_VALID_WAKEUP_EVENT_COUNTER(cpu) (per_cpu(sw_is_valid_wakeup_event, (cpu)) = true)
+
+#define NUM_TRACEPOINT_NODES SW_ARRAY_SIZE(s_trace_collector_lists)
+#define NUM_VALID_TRACEPOINTS (NUM_TRACEPOINT_NODES - 1) /* "-1" for IPI */
+#define FOR_EACH_TRACEPOINT_NODE(idx, node) for (idx=0; idx<NUM_TRACEPOINT_NODES && (node=&s_trace_collector_lists[idx]); ++idx)
+
+#define FOR_EACH_NOTIFIER_NODE(idx, node) for (idx=0; idx<SW_ARRAY_SIZE(s_notifier_collector_lists) && (node = &s_notifier_collector_lists[idx]); ++idx)
+/*
+ * Use these macros if all tracepoint ID numbers ARE contiguous from 0 -- max tracepoint ID #
+ */
+#if 0
+#define IS_VALID_TRACE_NOTIFIER_ID(id) ( (id) >= 0 && (id) < SW_ARRAY_SIZE(s_trace_collector_lists) )
+#define GET_COLLECTOR_TRACE_NODE(id) (&s_trace_collector_lists[id])
+#define FOR_EACH_trace_notifier_id(idx) for (idx=0; idx < SW_ARRAY_SIZE(s_trace_collector_lists); ++idx)
+#endif // if 0
+/*
+ * Use these macros if all tracepoint ID numbers are NOT contiguous from 0 -- max tracepoint ID #
+ */
+#define GET_COLLECTOR_TRACE_NODE(idx) ({int __idx=0; struct sw_trace_notifier_data *__node=NULL, *__retVal=NULL; \
+        FOR_EACH_TRACEPOINT_NODE(__idx, __node) { \
+            if ((idx) == GET_TRACE_NOTIFIER_ID(__node)) { \
+                __retVal = __node; break; \
+            } \
+        } \
+        __retVal;})
+#define IS_VALID_TRACE_NOTIFIER_ID(idx) (GET_COLLECTOR_TRACE_NODE(idx) != NULL)
+
+#define GET_COLLECTOR_NOTIFIER_NODE(idx) ({int __idx=0; struct sw_trace_notifier_data *__node=NULL, *__retVal=NULL; \
+        FOR_EACH_NOTIFIER_NODE(__idx, __node) { \
+            if ((idx) == GET_TRACE_NOTIFIER_ID(__node)) { \
+                __retVal = __node; break; \
+            } \
+        } \
+        __retVal;})
+#define IS_VALID_NOTIFIER_ID(idx) (GET_COLLECTOR_NOTIFIER_NODE(idx) != NULL)
+
+/* -------------------------------------------------
+ * Local function declarations.
+ * -------------------------------------------------
+ */
+/*
+ * The tracepoint registration functions.
+ */
+int sw_register_trace_cpu_idle_i(struct sw_trace_notifier_data *node);
+int sw_unregister_trace_cpu_idle_i(struct sw_trace_notifier_data *node);
+int sw_register_trace_cpu_frequency_i(struct sw_trace_notifier_data *node);
+int sw_unregister_trace_cpu_frequency_i(struct sw_trace_notifier_data *node);
+int sw_register_trace_irq_handler_entry_i(struct sw_trace_notifier_data *node);
+int sw_unregister_trace_irq_handler_entry_i(struct sw_trace_notifier_data *node);
+int sw_register_trace_timer_expire_entry_i(struct sw_trace_notifier_data *node);
+int sw_unregister_trace_timer_expire_entry_i(struct sw_trace_notifier_data *node);
+int sw_register_trace_hrtimer_expire_entry_i(struct sw_trace_notifier_data *node);
+int sw_unregister_trace_hrtimer_expire_entry_i(struct sw_trace_notifier_data *node);
+int sw_register_trace_sched_wakeup_i(struct sw_trace_notifier_data *node);
+int sw_unregister_trace_sched_wakeup_i(struct sw_trace_notifier_data *node);
+int sw_register_trace_sched_process_fork_i(struct sw_trace_notifier_data *node);
+int sw_unregister_trace_sched_process_fork_i(struct sw_trace_notifier_data *node);
+int sw_register_trace_sched_process_exit_i(struct sw_trace_notifier_data *node);
+int sw_unregister_trace_sched_process_exit_i(struct sw_trace_notifier_data *node);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0)
+    int sw_register_trace_thermal_apic_entry_i(struct sw_trace_notifier_data *node);
+    int sw_unregister_trace_thermal_apic_entry_i(struct sw_trace_notifier_data *node);
+    int sw_register_trace_thermal_apic_exit_i(struct sw_trace_notifier_data *node);
+    int sw_unregister_trace_thermal_apic_exit_i(struct sw_trace_notifier_data *node);
+#endif // LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0)
+#if DO_ANDROID
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(3,4,0)
+        int sw_register_trace_wake_lock_i(struct sw_trace_notifier_data *node);
+        int sw_unregister_trace_wake_lock_i(struct sw_trace_notifier_data *node);
+        int sw_register_trace_wake_unlock_i(struct sw_trace_notifier_data *node);
+        int sw_unregister_trace_wake_unlock_i(struct sw_trace_notifier_data *node);
+    #else // LINUX_VERSION_CODE >= KERNEL_VERSION(3,4,0)
+        int sw_register_trace_wakeup_source_activate_i(struct sw_trace_notifier_data *node);
+        int sw_unregister_trace_wakeup_source_activate_i(struct sw_trace_notifier_data *node);
+        int sw_register_trace_wakeup_source_deactivate_i(struct sw_trace_notifier_data *node);
+        int sw_unregister_trace_wakeup_source_deactivate_i(struct sw_trace_notifier_data *node);
+    #endif // LINUX_VERSION_CODE < KERNEL_VERSION(3,4,0)
+#endif // DO_ANDROID
+int sw_register_trace_workqueue_execution_i(struct sw_trace_notifier_data *node);
+int sw_unregister_trace_workqueue_execution_i(struct sw_trace_notifier_data *node);
+int sw_register_trace_sched_switch_i(struct sw_trace_notifier_data *node);
+int sw_unregister_trace_sched_switch_i(struct sw_trace_notifier_data *node);
+int sw_register_pm_notifier_i(struct sw_trace_notifier_data *node);
+int sw_unregister_pm_notifier_i(struct sw_trace_notifier_data *node);
+int sw_register_cpufreq_notifier_i(struct sw_trace_notifier_data *node);
+int sw_unregister_cpufreq_notifier_i(struct sw_trace_notifier_data *node);
+int sw_register_hotcpu_notifier_i(struct sw_trace_notifier_data *node);
+int sw_unregister_hotcpu_notifier_i(struct sw_trace_notifier_data *node);
+void sw_handle_sched_wakeup_i(struct sw_collector_data *node, int source_cpu, int target_cpu);
+void sw_handle_timer_wakeup_helper_i(struct sw_collector_data *curr, struct sw_trace_notifier_data *node,
+                                     pid_t tid);
+void sw_handle_apic_timer_wakeup_i(struct sw_collector_data *node);
+void sw_handle_workqueue_wakeup_helper_i(int cpu, struct sw_collector_data *node);
+void sw_handle_sched_switch_helper_i(void);
+void sw_tps_apic_i(int cpu);
+void sw_tps_tps_i(int cpu);
+void sw_tps_wakeup_i(int cpu);
+void sw_tps_i(void);
+void sw_tpf_i(int cpu, struct sw_trace_notifier_data *node);
+void sw_process_fork_exit_helper_i(struct sw_collector_data *node, struct task_struct *task, bool is_fork);
+void sw_produce_wakelock_msg_i(int cpu, struct sw_collector_data *node, const char *name,
+                               int type, u64 timeout, int pid, int tid, const char *proc_name);
+u64 sw_my_local_arch_irq_stats_cpu_i(void);
+
+/*
+ * The tracepoint probes.
+ */
+/*
+ * The tracepoint handlers.
+ */
+void sw_handle_trace_notifier_i(struct sw_trace_notifier_data *node);
+void sw_handle_trace_notifier_on_cpu_i(int cpu, struct sw_trace_notifier_data *node);
+void sw_handle_reset_messages_i(struct sw_trace_notifier_data *node);
+
+/* -------------------------------------------------
+ * Variable definitions.
+ * -------------------------------------------------
+ */
+/*
+ * For overhead measurements.
+ */
+DECLARE_OVERHEAD_VARS(sw_handle_timer_wakeup_helper_i); // for the "timer_expire" family of probes
+DECLARE_OVERHEAD_VARS(sw_handle_irq_wakeup_i); // for IRQ wakeups
+DECLARE_OVERHEAD_VARS(sw_handle_sched_wakeup_i); // for SCHED
+DECLARE_OVERHEAD_VARS(sw_tps_i); // for TPS
+DECLARE_OVERHEAD_VARS(sw_tpf_i); // for TPF
+DECLARE_OVERHEAD_VARS(sw_process_fork_exit_helper_i);
+#if DO_ANDROID
+    DECLARE_OVERHEAD_VARS(sw_handle_wakelock_i); // for wake lock/unlock
+#endif // DO_ANDROID
+DECLARE_OVERHEAD_VARS(sw_handle_workqueue_wakeup_helper_i);
+DECLARE_OVERHEAD_VARS(sw_handle_sched_switch_helper_i);
+/*
+ * Per-cpu wakeup counters.
+ * Used to decide which wakeup event is the first to occur after a
+ * core wakes up from a C-state.
+ * Set to 'true' in TPS probe
+ */
+static DEFINE_PER_CPU(bool, sw_is_valid_wakeup_event) = {true};
+/*
+ * Per-cpu counts of the number of times the local APIC fired.
+ * We need a separate count because some apic timer fires don't seem
+ * to result in hrtimer/timer expires
+ */
+static DEFINE_PER_CPU(u64, sw_num_local_apic_timer_inters) = 0;
+/*
+ * Flag value to use to decide if the event is a valid wakeup event.
+ * Set to 'false' in TPS probe.
+ */
+static bool sw_wakeup_event_flag = true;
+/*
+ * Scheduler-based polling emulation.
+ */
+DEFINE_PER_CPU(unsigned long, sw_pcpu_polling_jiff);
+pw_u16_t sw_min_polling_interval_msecs;
+
+/*
+ * IDs for supported tracepoints.
+ */
+enum sw_trace_id {
+    SW_TRACE_ID_CPU_IDLE,
+    SW_TRACE_ID_CPU_FREQUENCY,
+    SW_TRACE_ID_IRQ_HANDLER_ENTRY,
+    SW_TRACE_ID_TIMER_EXPIRE_ENTRY,
+    SW_TRACE_ID_HRTIMER_EXPIRE_ENTRY,
+    SW_TRACE_ID_SCHED_WAKEUP,
+    SW_TRACE_ID_IPI,
+    SW_TRACE_ID_SCHED_PROCESS_FORK,
+    SW_TRACE_ID_SCHED_PROCESS_EXIT,
+    SW_TRACE_ID_THERMAL_APIC_ENTRY,
+    SW_TRACE_ID_THERMAL_APIC_EXIT,
+    SW_TRACE_ID_WAKE_LOCK,
+    SW_TRACE_ID_WAKE_UNLOCK,
+    SW_TRACE_ID_WORKQUEUE_EXECUTE_START,
+    SW_TRACE_ID_SCHED_SWITCH,
+};
+/*
+ * IDs for supported notifiers.
+ */
+enum sw_notifier_id {
+    SW_NOTIFIER_ID_SUSPEND, // TODO: change name?
+    SW_NOTIFIER_ID_SUSPEND_ENTER,
+    SW_NOTIFIER_ID_SUSPEND_EXIT,
+    SW_NOTIFIER_ID_HIBERNATE,
+    SW_NOTIFIER_ID_HIBERNATE_ENTER,
+    SW_NOTIFIER_ID_HIBERNATE_EXIT,
+    SW_NOTIFIER_ID_COUNTER_RESET,
+    SW_NOTIFIER_ID_CPUFREQ,
+    SW_NOTIFIER_ID_HOTCPU,
+};
+/*
+ * Names for supported tracepoints. A tracepoint
+ * 'name' consists of two strings: a "kernel" string
+ * that is used to locate the tracepoint within the kernel
+ * and an "abstract" string, that is used by Ring-3 to
+ * specify which tracepoints to use during a collection.
+ */
+static const struct sw_trace_notifier_name s_trace_names[] = {
+    [SW_TRACE_ID_CPU_IDLE] = {"cpu_idle", "CPU-IDLE"},
+    [SW_TRACE_ID_CPU_FREQUENCY] = {"cpu_frequency", "CPU-FREQUENCY"},
+    [SW_TRACE_ID_IRQ_HANDLER_ENTRY] = {"irq_handler_entry", "IRQ-ENTRY"},
+    [SW_TRACE_ID_TIMER_EXPIRE_ENTRY] = {"timer_expire_entry", "TIMER-ENTRY"},
+    [SW_TRACE_ID_HRTIMER_EXPIRE_ENTRY] = {"hrtimer_expire_entry", "HRTIMER-ENTRY"},
+    [SW_TRACE_ID_SCHED_WAKEUP] = {"sched_wakeup", "SCHED-WAKEUP"},
+    [SW_TRACE_ID_IPI] = {NULL, "IPI"},
+    [SW_TRACE_ID_SCHED_PROCESS_FORK] = {"sched_process_fork", "PROCESS-FORK"},
+    [SW_TRACE_ID_SCHED_PROCESS_EXIT] = {"sched_process_exit", "PROCESS-EXIT"},
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0)
+        [SW_TRACE_ID_THERMAL_APIC_ENTRY] = {"thermal_apic_entry", "THERMAL-THROTTLE-ENTRY"},
+        [SW_TRACE_ID_THERMAL_APIC_EXIT] = {"thermal_apic_exit", "THERMAL-THROTTLE-EXIT"},
+#endif // LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0)
+#if DO_ANDROID
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(3,4,0)
+            [SW_TRACE_ID_WAKE_LOCK] = {"wake_lock", "WAKE-LOCK"},
+            [SW_TRACE_ID_WAKE_UNLOCK] = {"wake_unlock", "WAKE-UNLOCK"},
+    #else // LINUX_VERSION_CODE >= KERNEL_VERSION(3,4,0)
+            [SW_TRACE_ID_WAKE_LOCK] = {"wakeup_source_activate", "WAKE-LOCK"},
+            [SW_TRACE_ID_WAKE_UNLOCK] = {"wakeup_source_deactivate", "WAKE-UNLOCK"},
+    #endif
+#endif
+    [SW_TRACE_ID_WORKQUEUE_EXECUTE_START] = {"workqueue_execute_start", "WORKQUEUE-START"},
+    [SW_TRACE_ID_SCHED_SWITCH] = {"sched_switch", "CONTEXT-SWITCH"},
+};
+
+/*
+ * Names for supported notifiers. A notifier
+ * 'name' consists of two strings: an unused "kernel" string
+ * and an "abstract" string, that is used by Ring-3 to
+ * specify which notifiers to use during a collection.
+ */
+static const struct sw_trace_notifier_name s_notifier_names[] = {
+    [SW_NOTIFIER_ID_SUSPEND] = {"suspend_notifier" /* don't care */, "SUSPEND-NOTIFIER"},
+    [SW_NOTIFIER_ID_SUSPEND_ENTER] = {NULL, "SUSPEND-ENTER"},
+    [SW_NOTIFIER_ID_SUSPEND_EXIT] = {NULL, "SUSPEND-EXIT"},
+    [SW_NOTIFIER_ID_HIBERNATE] = {"hibernate_notifier" /* don't care */, "HIBERNATE-NOTIFIER"},
+    [SW_NOTIFIER_ID_HIBERNATE_ENTER] = {NULL, "HIBERNATE-ENTER"},
+    [SW_NOTIFIER_ID_HIBERNATE_EXIT] = {NULL, "HIBERNATE-EXIT"},
+    [SW_NOTIFIER_ID_COUNTER_RESET] = {NULL, "COUNTER-RESET"},
+    [SW_NOTIFIER_ID_CPUFREQ] = {"cpufreq_notifier" /* don't care */, "CPUFREQ-NOTIFIER"},
+    [SW_NOTIFIER_ID_HOTCPU] = {"hotcpu_notifier" /* don't care */, "HOTCPU-NOTIFIER"},
+};
+
+#ifdef CONFIG_TRACEPOINTS
+/*
+ * A list of supported tracepoints.
+ */
+static struct sw_trace_notifier_data s_trace_collector_lists[] = {
+    {SW_TRACE_COLLECTOR_TRACEPOINT, &s_trace_names[SW_TRACE_ID_CPU_IDLE], &sw_register_trace_cpu_idle_i, &sw_unregister_trace_cpu_idle_i, NULL},
+    {SW_TRACE_COLLECTOR_TRACEPOINT, &s_trace_names[SW_TRACE_ID_CPU_FREQUENCY], &sw_register_trace_cpu_frequency_i, &sw_unregister_trace_cpu_frequency_i, NULL},
+    {SW_TRACE_COLLECTOR_TRACEPOINT, &s_trace_names[SW_TRACE_ID_IRQ_HANDLER_ENTRY], &sw_register_trace_irq_handler_entry_i, &sw_unregister_trace_irq_handler_entry_i, NULL},
+    {SW_TRACE_COLLECTOR_TRACEPOINT, &s_trace_names[SW_TRACE_ID_TIMER_EXPIRE_ENTRY], &sw_register_trace_timer_expire_entry_i, &sw_unregister_trace_timer_expire_entry_i, NULL},
+    {SW_TRACE_COLLECTOR_TRACEPOINT, &s_trace_names[SW_TRACE_ID_HRTIMER_EXPIRE_ENTRY], &sw_register_trace_hrtimer_expire_entry_i, &sw_unregister_trace_hrtimer_expire_entry_i, NULL},
+    {SW_TRACE_COLLECTOR_TRACEPOINT, &s_trace_names[SW_TRACE_ID_SCHED_WAKEUP], &sw_register_trace_sched_wakeup_i, &sw_unregister_trace_sched_wakeup_i, NULL},
+    /* Placeholder for IPI -- no tracepoints associated with it! */
+    {SW_TRACE_COLLECTOR_TRACEPOINT, &s_trace_names[SW_TRACE_ID_IPI], NULL, NULL, NULL},
+    {SW_TRACE_COLLECTOR_TRACEPOINT, &s_trace_names[SW_TRACE_ID_SCHED_PROCESS_FORK], &sw_register_trace_sched_process_fork_i, &sw_unregister_trace_sched_process_fork_i, NULL},
+    {SW_TRACE_COLLECTOR_TRACEPOINT, &s_trace_names[SW_TRACE_ID_SCHED_PROCESS_EXIT], &sw_register_trace_sched_process_exit_i, &sw_unregister_trace_sched_process_exit_i, NULL},
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0)
+        /*
+         * For thermal throttling.
+         * We probably only need one of either 'entry' or 'exit'. Use
+         * both, until we decide which one to keep. Note that
+         * tracepoint IDs for these, and subsequent tracepoints
+         * (e.g. 'wake_lock') will change once we've picked which
+         * one to use.
+         */
+        {SW_TRACE_COLLECTOR_TRACEPOINT, &s_trace_names[SW_TRACE_ID_THERMAL_APIC_ENTRY], &sw_register_trace_thermal_apic_entry_i, &sw_unregister_trace_thermal_apic_entry_i, NULL},
+        {SW_TRACE_COLLECTOR_TRACEPOINT, &s_trace_names[SW_TRACE_ID_THERMAL_APIC_EXIT], &sw_register_trace_thermal_apic_exit_i, &sw_unregister_trace_thermal_apic_exit_i, NULL},
+#endif // LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0)
+    /* Wakelocks have multiple tracepoints, depending on kernel version */
+#if DO_ANDROID
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(3,4,0)
+            {SW_TRACE_COLLECTOR_TRACEPOINT, &s_trace_names[SW_TRACE_ID_WAKE_LOCK], &sw_register_trace_wake_lock_i, &sw_unregister_trace_wake_lock_i, NULL},
+            {SW_TRACE_COLLECTOR_TRACEPOINT, &s_trace_names[SW_TRACE_ID_WAKE_UNLOCK], &sw_register_trace_wake_unlock_i, &sw_unregister_trace_wake_unlock_i, NULL},
+    #else // LINUX_VERSION_CODE >= KERNEL_VERSION(3,4,0)
+            {SW_TRACE_COLLECTOR_TRACEPOINT, &s_trace_names[SW_TRACE_ID_WAKE_LOCK], &sw_register_trace_wakeup_source_activate_i, &sw_unregister_trace_wakeup_source_activate_i, NULL},
+            {SW_TRACE_COLLECTOR_TRACEPOINT, &s_trace_names[SW_TRACE_ID_WAKE_UNLOCK], &sw_register_trace_wakeup_source_deactivate_i, &sw_unregister_trace_wakeup_source_deactivate_i, NULL},
+    #endif // LINUX_VERSION_CODE < KERNEL_VERSION(3,14,0)
+#endif // DO_ANDROID
+    {SW_TRACE_COLLECTOR_TRACEPOINT, &s_trace_names[SW_TRACE_ID_WORKQUEUE_EXECUTE_START], &sw_register_trace_workqueue_execution_i, &sw_unregister_trace_workqueue_execution_i, NULL},
+    {SW_TRACE_COLLECTOR_TRACEPOINT, &s_trace_names[SW_TRACE_ID_SCHED_SWITCH], &sw_register_trace_sched_switch_i, &sw_unregister_trace_sched_switch_i, NULL},
+};
+/*
+ * List of supported notifiers.
+ */
+static struct sw_trace_notifier_data s_notifier_collector_lists[] = {
+    {SW_TRACE_COLLECTOR_NOTIFIER, &s_notifier_names[SW_NOTIFIER_ID_SUSPEND], &sw_register_pm_notifier_i, &sw_unregister_pm_notifier_i, NULL, true /* always register */},
+    /* Placeholder for suspend enter/exit -- these will be called from within the pm notifier */
+    {SW_TRACE_COLLECTOR_NOTIFIER, &s_notifier_names[SW_NOTIFIER_ID_SUSPEND_ENTER], NULL, NULL, NULL},
+    {SW_TRACE_COLLECTOR_NOTIFIER, &s_notifier_names[SW_NOTIFIER_ID_SUSPEND_EXIT], NULL, NULL, NULL},
+    /* Placeholder for hibernate enter/exit -- these will be called from within the pm notifier */
+    {SW_TRACE_COLLECTOR_NOTIFIER, &s_notifier_names[SW_NOTIFIER_ID_HIBERNATE], NULL, NULL, NULL},
+    {SW_TRACE_COLLECTOR_NOTIFIER, &s_notifier_names[SW_NOTIFIER_ID_HIBERNATE_ENTER], NULL, NULL, NULL},
+    {SW_TRACE_COLLECTOR_NOTIFIER, &s_notifier_names[SW_NOTIFIER_ID_HIBERNATE_EXIT], NULL, NULL, NULL},
+    {SW_TRACE_COLLECTOR_NOTIFIER, &s_notifier_names[SW_NOTIFIER_ID_COUNTER_RESET], NULL, NULL, NULL},
+    {SW_TRACE_COLLECTOR_NOTIFIER, &s_notifier_names[SW_NOTIFIER_ID_CPUFREQ], &sw_register_cpufreq_notifier_i, &sw_unregister_cpufreq_notifier_i},
+};
+/*
+ * Special entry for CPU notifier (i.e. "hotplug" notifier)
+ * We don't want these to be visible to the user.
+ */
+static struct sw_trace_notifier_data s_hotplug_notifier_data = {
+    SW_TRACE_COLLECTOR_NOTIFIER, &s_notifier_names[SW_NOTIFIER_ID_HOTCPU], &sw_register_hotcpu_notifier_i, &sw_unregister_hotcpu_notifier_i, NULL, true /* always register */
+};
+
+#else // !CONFIG_TRACEPOINTS
+/*
+ * A list of supported tracepoints.
+ */
+static struct sw_trace_notifier_data s_trace_collector_lists[] = { /* EMPTY */ };
+/*
+ * List of supported notifiers.
+ */
+static struct sw_trace_notifier_data s_notifier_collector_lists[] = { /* EMPTY */ };
+
+#endif // CONFIG_TRACEPOINTS
+
+
+/*
+ * Macros to retrieve tracepoint and notifier IDs.
+ */
+#define GET_TRACE_ID_FROM_NODE(node) ( (node)->name - s_trace_names )
+#define GET_NOTIFIER_ID_FROM_NODE(node) ( (node)->name - s_notifier_names )
+
+#define GET_TRACE_NOTIFIER_ID(node) (int)( ( (node)->type == SW_TRACE_COLLECTOR_TRACEPOINT) ? GET_TRACE_ID_FROM_NODE(node) : GET_NOTIFIER_ID_FROM_NODE(node) )
+
+
+/* -------------------------------------------------
+ * Function definitions.
+ * -------------------------------------------------
+ */
+/*
+ * Retrieve a TSC value
+ */
+static inline u64 sw_tscval(void)
+{
+    unsigned int low, high;
+    asm volatile("rdtsc" : "=a" (low), "=d" (high));
+    return low | ((unsigned long long)high) << 32;
+};
+u64 sw_timestamp(void)
+{
+    struct timespec ts;
+    getnstimeofday(&ts);
+    return (ts.tv_sec * 1000000000ULL + ts.tv_nsec);
+}
+/*
+ * Basically the same as arch/x86/kernel/irq.c --> "arch_irq_stat_cpu(cpu)"
+ */
+u64 sw_my_local_arch_irq_stats_cpu_i(void)
+{
+    u64 sum = 0;
+    irq_cpustat_t *stats;
+#ifdef __arm__
+    int i=0;
+#endif
+    BEGIN_LOCAL_IRQ_STATS_READ(stats);
+    {
+#ifndef __arm__
+        sum += stats->__nmi_count;
+// #ifdef CONFIG_X86_LOCAL_APIC
+        sum += stats->apic_timer_irqs;
+// #endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 34)
+        sum += stats->x86_platform_ipis;
+#endif // 2,6,34
+        sum += stats->apic_perf_irqs;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,5,0)
+        sum += stats->apic_irq_work_irqs;
+#endif // 3,5,0
+#ifdef CONFIG_SMP
+        sum += stats->irq_call_count;
+        sum += stats->irq_resched_count;
+        sum += stats->irq_tlb_count;
+#endif
+#ifdef CONFIG_X86_THERMAL_VECTOR
+        sum += stats->irq_thermal_count;
+#endif
+        sum += stats->irq_spurious_count; // should NEVER be non-zero!!!
+#else
+        sum += stats->__softirq_pending;
+#ifdef CONFIG_SMP
+        for (i=0; i<NR_IPI; ++i) {
+            sum += stats->ipi_irqs[i];
+        }
+#endif
+#ifdef CONFIG_X86_MCE
+        sum += stats->mce_exception_count;
+        sum += stats->mce_poll_count;
+#endif
+#endif
+    }
+    END_LOCAL_IRQ_STATS_READ(stats);
+    return sum;
+};
+
+/*
+ * Generic tracepoint/notifier handling function.
+ */
+void sw_handle_trace_notifier_i(struct sw_trace_notifier_data *node)
+{
+    struct sw_collector_data *curr = NULL;
+    if (!node) {
+        return;
+    }
+    list_for_each_entry(curr, &node->list, list) {
+        pw_pr_debug("DEBUG: handling message\n");
+        sw_handle_per_cpu_msg(curr);
+    }
+};
+/*
+ * Generic tracepoint/notifier handling function.
+ */
+void sw_handle_trace_notifier_on_cpu_i(int cpu, struct sw_trace_notifier_data *node)
+{
+    struct sw_collector_data *curr = NULL;
+    if (!node) {
+        return;
+    }
+    list_for_each_entry(curr, &node->list, list) {
+        sw_handle_per_cpu_msg_on_cpu(cpu, curr);
+    }
+};
+void sw_handle_reset_messages_i(struct sw_trace_notifier_data *node)
+{
+    struct sw_collector_data *curr = NULL;
+    if (!node) {
+        return;
+    }
+    list_for_each_entry(curr, &node->list, list) {
+        pw_pr_debug("Handling message of unknown cpumask on cpu %d\n", RAW_CPU());
+        sw_schedule_work(&curr->cpumask, &sw_handle_per_cpu_msg, curr);
+    }
+}
+/*
+ * Tracepoint helpers.
+ */
+/*
+ * IRQ wakeup handling function.
+ */
+void sw_handle_irq_wakeup_i(struct sw_collector_data *node, int irq)
+{
+    int cpu = RAW_CPU();
+    sw_driver_msg_t *msg = GET_MSG_SLOT_FOR_CPU(node->msg, cpu, node->per_msg_payload_size);
+    // char *dst_vals = (char *)(unsigned long)msg->p_payload;
+    char *dst_vals = msg->p_payload;
+
+    // msg->tsc = sw_timestamp(); // msg TSC assigned when msg is written to buffer
+    msg->cpuidx = cpu;
+
+    /*
+     * IRQ handling ==> only return the irq number
+     */
+    *( (int *)dst_vals) = irq;
+
+    if (sw_produce_generic_msg(msg, SW_WAKEUP_ACTION_DIRECT)) {
+        pw_pr_warn("WARNING: could NOT produce message!\n");
+    }
+};
+/*
+ * TIMER wakeup handling funtion.
+ */
+void sw_handle_timer_wakeup_i(struct sw_collector_data *node, pid_t pid, pid_t tid)
+{
+    int cpu = RAW_CPU();
+    sw_driver_msg_t *msg = GET_MSG_SLOT_FOR_CPU(node->msg, cpu, node->per_msg_payload_size);
+    // char *dst_vals = (char *)(unsigned long)msg->p_payload;
+    char *dst_vals = msg->p_payload;
+
+    // msg->tsc = sw_timestamp(); // msg TSC assigned when msg is written to buffer
+    msg->cpuidx = cpu;
+
+    /*
+     * TIMER handling ==> only return the pid, tid
+     */
+    *( (int *)dst_vals) = pid; dst_vals += sizeof(pid);
+    *( (int *)dst_vals) = tid;
+
+    if (sw_produce_generic_msg(msg, SW_WAKEUP_ACTION_DIRECT)) {
+        pw_pr_warn("WARNING: could NOT produce message!\n");
+    }
+    pw_pr_debug("HANDLED timer expire for %d, %d\n", pid, tid);
+};
+/*
+ * Helper function for {hr}timer expires. Required for overhead tracking.
+ */
+void sw_handle_timer_wakeup_helper_i(struct sw_collector_data *curr, struct sw_trace_notifier_data *node, pid_t tid)
+{
+    pid_t pid = -1;
+    if (tid == 0) {
+        pid = 0;
+    } else {
+        struct task_struct *task =  pid_task(find_pid_ns(tid, &init_pid_ns), PIDTYPE_PID);
+        if (likely(task)) {
+            pid = task->tgid;
+        }
+    }
+    list_for_each_entry(curr, &node->list, list) {
+        sw_handle_timer_wakeup_i(curr, pid, tid);
+    }
+};
+/*
+ * SCHED wakeup handling funtion.
+ */
+void sw_handle_sched_wakeup_i(struct sw_collector_data *node, int source_cpu, int target_cpu)
+{
+    int cpu = source_cpu;
+    sw_driver_msg_t *msg = GET_MSG_SLOT_FOR_CPU(node->msg, cpu, node->per_msg_payload_size);
+    // char *dst_vals = (char *)(unsigned long)msg->p_payload;
+    char *dst_vals = msg->p_payload;
+
+    // msg->tsc = sw_timestamp(); // msg TSC assigned when msg is written to buffer
+    msg->cpuidx = source_cpu;
+
+    /*
+     * sched handling ==> only return the source, target CPUs
+     */
+    *( (int *)dst_vals) = source_cpu; dst_vals += sizeof(source_cpu);
+    *( (int *)dst_vals) = target_cpu;
+
+    if (sw_produce_generic_msg(msg, SW_WAKEUP_ACTION_NONE)) {
+        pw_pr_warn("WARNING: could NOT produce message!\n");
+    }
+};
+/*
+ * APIC timer wakeup
+ */
+void sw_handle_apic_timer_wakeup_i(struct sw_collector_data *node)
+{
+    /*
+     * Send an empty message back to Ring-3
+     */
+    int cpu = RAW_CPU();
+    sw_driver_msg_t *msg = GET_MSG_SLOT_FOR_CPU(node->msg, cpu, node->per_msg_payload_size);
+    // char *dst_vals = (char *)(unsigned long)msg->p_payload;
+
+    // msg->tsc = sw_timestamp(); // msg TSC assigned when msg is written to buffer
+    msg->cpuidx = cpu;
+
+    if (sw_produce_generic_msg(msg, SW_WAKEUP_ACTION_DIRECT)) {
+        pw_pr_warn("WARNING: could NOT produce message!\n");
+    }
+    pw_pr_debug("HANDLED APIC timer wakeup for cpu = %d\n", cpu);
+};
+/*
+ * Helper function for workqueue executions. Required for overhead tracking.
+ */
+void sw_handle_workqueue_wakeup_helper_i(int cpu, struct sw_collector_data *node)
+{
+    sw_driver_msg_t *msg = GET_MSG_SLOT_FOR_CPU(node->msg, cpu, node->per_msg_payload_size);
+
+    // msg->tsc = sw_timestamp(); // msg TSC assigned when msg is written to buffer
+    msg->cpuidx = cpu;
+
+    /*
+     * Workqueue wakeup ==> empty message.
+     */
+    if (sw_produce_generic_msg(msg, SW_WAKEUP_ACTION_DIRECT)) {
+        pw_pr_error("WARNING: could NOT produce message!\n");
+    }
+};
+/*
+ * Helper function for sched_switch. Required for overhead tracking.
+ */
+void sw_handle_sched_switch_helper_i(void)
+{
+    static struct sw_trace_notifier_data *node = NULL;
+    if (unlikely(node == NULL)) {
+        node = GET_COLLECTOR_TRACE_NODE(SW_TRACE_ID_SCHED_SWITCH);
+        pw_pr_debug("SCHED SWITCH NODE = %p\n", node);
+    }
+    if (!node) {
+        return;
+    }
+    preempt_disable();
+    {
+        struct sw_collector_data *curr = NULL;
+        list_for_each_entry(curr, &node->list, list) {
+            unsigned long curr_jiff = jiffies, prev_jiff = curr->last_update_jiffies;
+            unsigned long delta_msecs = jiffies_to_msecs(curr_jiff) - jiffies_to_msecs(prev_jiff);
+            struct cpumask *mask = &curr->cpumask;
+            u16 timeout = curr->info->sampling_interval_msec;
+
+            if (!timeout) {
+                timeout = sw_min_polling_interval_msecs;
+            }
+            /* Has there been enough time since the last collection point? */
+            if (delta_msecs < timeout) {
+                continue;
+            }
+            /* Update timestamp and handle message */
+            if (cpumask_test_cpu(RAW_CPU(), mask) /* This msg must be handled on the current CPU */
+                    || cpumask_empty(mask) /* This msg may be handled by any CPU */) {
+                if (!CAS64(&curr->last_update_jiffies, prev_jiff, curr_jiff)) {
+                    /*
+                     * CAS failure should only be possible for messages that can be handled
+                     * on any CPU, in which case it indicates a different CPU already handled
+                     * this message.
+                     */
+                    continue;
+                }
+                sw_handle_per_cpu_msg_no_sched(curr);
+            }
+        }
+    }
+    preempt_enable();
+};
+
+/*
+ * Probe functions.
+ */
+/*
+ * 1. TPS
+ */
+/*
+ * Check IPI wakeups within the cpu_idle tracepoint.
+ */
+void sw_tps_apic_i(int cpu)
+{
+    static struct sw_trace_notifier_data *apic_timer_node = NULL;
+    if (unlikely(apic_timer_node == NULL)) {
+        apic_timer_node = GET_COLLECTOR_TRACE_NODE(SW_TRACE_ID_IPI);
+        pw_pr_debug("apic NODE = %p\n", apic_timer_node);
+    }
+    if (apic_timer_node) {
+        bool local_apic_timer_fired = false;
+        u64 curr_num_local_apic = sw_my_local_arch_irq_stats_cpu_i();
+        u64 *old_num_local_apic = &__get_cpu_var(sw_num_local_apic_timer_inters);
+
+        if (*old_num_local_apic && (*old_num_local_apic != curr_num_local_apic)) {
+            local_apic_timer_fired = true;
+        }
+        *old_num_local_apic = curr_num_local_apic;
+
+        if (local_apic_timer_fired && SHOULD_PRODUCE_WAKEUP_SAMPLE(cpu)) {
+            struct sw_collector_data *curr = NULL;
+            list_for_each_entry(curr, &apic_timer_node->list, list) {
+                sw_handle_apic_timer_wakeup_i(curr);
+            }
+        }
+    }
+};
+/*
+ * Perform any user-defined tasks within the
+ * cpu_idle tracepoint.
+ */
+void sw_tps_tps_i(int cpu)
+{
+    static struct sw_trace_notifier_data *tps_node = NULL;
+    if (unlikely(tps_node == NULL)) {
+        tps_node = GET_COLLECTOR_TRACE_NODE(SW_TRACE_ID_CPU_IDLE);
+        pw_pr_debug("TPS NODE = %p\n", tps_node);
+    }
+    sw_handle_trace_notifier_i(tps_node);
+};
+/*
+ * Perform any wakeup-related tasks within the
+ * cpu_idle tracepoint.
+ */
+void sw_tps_wakeup_i(int cpu)
+{
+    /*
+     * For now, assume we will always have to
+     * do some wakeup book keeping. Later, we'll
+     * need to detect if the user requested wakeups.
+     */
+    sw_wakeup_event_flag  = false;
+    RESET_VALID_WAKEUP_EVENT_COUNTER(cpu);
+};
+void sw_tps_i(void)
+{
+    /*
+     * Update: FIRST handle IPI wakeups
+     * THEN handle TPS
+     */
+    int cpu = RAW_CPU();
+    sw_tps_apic_i(cpu);
+    sw_tps_tps_i(cpu);
+    sw_tps_wakeup_i(cpu);
+};
+
+DEFINE_PROBE_FUNCTION(PROBE_TPS_PARAMS)
+{
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,38)
+    if (state == PWR_EVENT_EXIT) {
+        return;
+    }
+#endif
+    DO_PER_CPU_OVERHEAD_FUNC(sw_tps_i);
+};
+
+/*
+ * 2. TPF
+ */
+/*
+ * Helper function for overhead measurements.
+ */
+void sw_tpf_i(int cpu, struct sw_trace_notifier_data *node)
+{
+    sw_handle_trace_notifier_on_cpu_i((int)cpu, node);
+};
+
+DEFINE_PROBE_FUNCTION(PROBE_TPF_PARAMS)
+{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,38)
+    int cpu = RAW_CPU();
+#endif // version < 2.6.38
+    static struct sw_trace_notifier_data *node = NULL;
+    if (unlikely(node == NULL)) {
+        node = GET_COLLECTOR_TRACE_NODE(SW_TRACE_ID_CPU_FREQUENCY);
+        pw_pr_debug("NODE = %p\n", node);
+    }
+    DO_PER_CPU_OVERHEAD_FUNC(sw_tpf_i, (int)cpu, node);
+};
+
+/*
+ * 3. IRQ handler entry
+ */
+DEFINE_PROBE_FUNCTION(PROBE_IRQ_PARAMS)
+{
+    int cpu = RAW_CPU();
+    static struct sw_trace_notifier_data *node = NULL;
+    struct sw_collector_data *curr = NULL;
+    if (unlikely(node == NULL)) {
+        node = GET_COLLECTOR_TRACE_NODE(SW_TRACE_ID_IRQ_HANDLER_ENTRY);
+        pw_pr_debug("NODE = %p\n", node);
+    }
+    if (!node || !SHOULD_PRODUCE_WAKEUP_SAMPLE(cpu)) {
+        return;
+    }
+    list_for_each_entry(curr, &node->list, list) {
+        DO_PER_CPU_OVERHEAD_FUNC(sw_handle_irq_wakeup_i, curr, irq);
+    }
+};
+/*
+ * 4. TIMER expire
+ */
+DEFINE_PROBE_FUNCTION(PROBE_TIMER_ARGS)
+{
+    int cpu = RAW_CPU();
+    static struct sw_trace_notifier_data *node = NULL;
+    struct sw_collector_data *curr = NULL;
+    pid_t tid = GET_TIMER_THREAD_ID(t);
+
+    if (unlikely(node == NULL)) {
+        node = GET_COLLECTOR_TRACE_NODE(SW_TRACE_ID_TIMER_EXPIRE_ENTRY);
+        pw_pr_debug("NODE = %p\n", node);
+    }
+
+    if (!node || !SHOULD_PRODUCE_WAKEUP_SAMPLE(cpu)) {
+        return;
+    }
+    DO_PER_CPU_OVERHEAD_FUNC(sw_handle_timer_wakeup_helper_i, curr, node, tid);
+};
+/*
+ * 5. HRTIMER expire
+ */
+DEFINE_PROBE_FUNCTION(PROBE_HRTIMER_PARAMS)
+{
+    int cpu = RAW_CPU();
+    static struct sw_trace_notifier_data *node = NULL;
+    struct sw_collector_data *curr = NULL;
+    pid_t tid = GET_TIMER_THREAD_ID(hrt);
+
+    if (unlikely(node == NULL)) {
+        node = GET_COLLECTOR_TRACE_NODE(SW_TRACE_ID_HRTIMER_EXPIRE_ENTRY);
+        pw_pr_debug("NODE = %p\n", node);
+    }
+
+    if (!node || !SHOULD_PRODUCE_WAKEUP_SAMPLE(cpu)) {
+        return;
+    }
+    DO_PER_CPU_OVERHEAD_FUNC(sw_handle_timer_wakeup_helper_i, curr, node, tid);
+};
+/*
+ * 6. SCHED wakeup
+ */
+DEFINE_PROBE_FUNCTION(PROBE_SCHED_WAKEUP_PARAMS)
+{
+    static struct sw_trace_notifier_data *node = NULL;
+    struct sw_collector_data *curr = NULL;
+    int target_cpu = task_cpu(task), source_cpu = RAW_CPU();
+    /*
+     * "Self-sched" samples are "don't care".
+     */
+    if (target_cpu == source_cpu) {
+        return;
+    }
+    if (unlikely(node == NULL)) {
+        node = GET_COLLECTOR_TRACE_NODE(SW_TRACE_ID_SCHED_WAKEUP);
+        pw_pr_debug("NODE = %p\n", node);
+    }
+    /*
+     * Unlike other wakeup sources, we check the per-cpu flag
+     * of the TARGET cpu to decide if we should produce a sample.
+     */
+    if (!node || !SHOULD_PRODUCE_WAKEUP_SAMPLE(target_cpu)) {
+        return;
+    }
+    list_for_each_entry(curr, &node->list, list) {
+        // sw_handle_sched_wakeup_i(curr, source_cpu, target_cpu);
+        DO_PER_CPU_OVERHEAD_FUNC(sw_handle_sched_wakeup_i, curr, source_cpu, target_cpu);
+    }
+};
+/*
+ * 8. PROCESS fork
+ */
+/*
+ * Helper for PROCESS fork, PROCESS exit
+ */
+void sw_process_fork_exit_helper_i(struct sw_collector_data *node, struct task_struct *task, bool is_fork)
+{
+    int cpu = RAW_CPU();
+    pid_t pid = task->tgid, tid = task->pid;
+    const char *name = task->comm;
+    sw_driver_msg_t *msg = GET_MSG_SLOT_FOR_CPU(node->msg, cpu, node->per_msg_payload_size);
+    char *dst_vals = msg->p_payload;
+
+    msg->cpuidx = cpu;
+
+    /*
+     * Fork/Exit ==> return pid, tid
+     * Fork ==> also return name
+     */
+    *( (int *)dst_vals) = pid; dst_vals += sizeof(pid);
+    *( (int *)dst_vals) = tid; dst_vals += sizeof(tid);
+    if (is_fork) {
+        memcpy(dst_vals, name, SW_MAX_PROC_NAME_SIZE);
+    }
+
+    if (sw_produce_generic_msg(msg, SW_WAKEUP_ACTION_DIRECT)) {
+        pw_pr_warn("WARNING: could NOT produce message!\n");
+    }
+    pw_pr_debug("HANDLED process %s event for task: pid = %d, tid = %d, name = %s\n", is_fork ? "FORK" : "EXIT", pid, tid, name);
+};
+
+DEFINE_PROBE_FUNCTION(PROBE_PROCESS_FORK_PARAMS)
+{
+    static struct sw_trace_notifier_data *node = NULL;
+    struct sw_collector_data *curr = NULL;
+    if (unlikely(node == NULL)) {
+        node = GET_COLLECTOR_TRACE_NODE(SW_TRACE_ID_SCHED_PROCESS_FORK);
+        pw_pr_debug("NODE = %p\n", node);
+    }
+    if (!node) {
+        return;
+    }
+    list_for_each_entry(curr, &node->list, list) {
+        DO_PER_CPU_OVERHEAD_FUNC(sw_process_fork_exit_helper_i, curr, child, true /* true ==> fork */);
+    }
+};
+/*
+ * 9. PROCESS exit
+ */
+DEFINE_PROBE_FUNCTION(PROBE_SCHED_PROCESS_EXIT_PARAMS)
+{
+    static struct sw_trace_notifier_data *node = NULL;
+    struct sw_collector_data *curr = NULL;
+    if (unlikely(node == NULL)) {
+        node = GET_COLLECTOR_TRACE_NODE(SW_TRACE_ID_SCHED_PROCESS_EXIT);
+        pw_pr_debug("NODE = %p\n", node);
+    }
+    if (!node) {
+        return;
+    }
+    list_for_each_entry(curr, &node->list, list) {
+        DO_PER_CPU_OVERHEAD_FUNC(sw_process_fork_exit_helper_i, curr, task, false /* false ==> exit */);
+    }
+};
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0)
+/*
+ * 10. THERMAL_APIC entry
+ */
+DEFINE_PROBE_FUNCTION(PROBE_THERMAL_APIC_ENTRY_PARAMS)
+{
+    int cpu = RAW_CPU();
+    static struct sw_trace_notifier_data *node = NULL;
+    if (unlikely(node == NULL)) {
+        node = GET_COLLECTOR_TRACE_NODE(SW_TRACE_ID_THERMAL_APIC_ENTRY);
+        pw_pr_debug("NODE = %p\n", node);
+    }
+    DO_PER_CPU_OVERHEAD_FUNC(sw_tpf_i, (int)cpu, node);
+};
+/*
+ * 10. THERMAL_APIC exit
+ */
+DEFINE_PROBE_FUNCTION(PROBE_THERMAL_APIC_EXIT_PARAMS)
+{
+    int cpu = RAW_CPU();
+    static struct sw_trace_notifier_data *node = NULL;
+    if (unlikely(node == NULL)) {
+        node = GET_COLLECTOR_TRACE_NODE(SW_TRACE_ID_THERMAL_APIC_EXIT);
+        pw_pr_debug("NODE = %p\n", node);
+    }
+    DO_PER_CPU_OVERHEAD_FUNC(sw_tpf_i, (int)cpu, node);
+};
+#endif // LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0)
+
+#if DO_ANDROID
+/*
+ * 11. WAKE lock / WAKEUP source activate.
+ */
+/*
+ * Helper function to produce wake lock/unlock messages.
+ */
+void sw_produce_wakelock_msg_i(int cpu, struct sw_collector_data *node,
+			       const char *name, int type, u64 timeout,
+			       int pid, int tid, const char *proc_name)
+{
+    sw_driver_msg_t *msg = GET_MSG_SLOT_FOR_CPU(node->msg, cpu, node->per_msg_payload_size);
+    char *dst_vals = msg->p_payload;
+
+    msg->cpuidx = cpu;
+
+    /*
+     * Protocol:
+     * wakelock_timeout, wakelock_type, wakelock_name, proc_pid, proc_tid, proc_name
+     */
+    *((u64 *)dst_vals) = timeout; dst_vals += sizeof(timeout);
+    *((int *)dst_vals) = type; dst_vals += sizeof(type);
+    strncpy(dst_vals, name, SW_MAX_KERNEL_WAKELOCK_NAME_SIZE); dst_vals += SW_MAX_KERNEL_WAKELOCK_NAME_SIZE;
+
+    *((int *)dst_vals) = pid; dst_vals += sizeof(pid);
+    *((int *)dst_vals) = tid; dst_vals += sizeof(tid);
+    strncpy(dst_vals, proc_name, SW_MAX_PROC_NAME_SIZE); dst_vals += SW_MAX_PROC_NAME_SIZE;
+
+    if (sw_produce_generic_msg(msg, SW_WAKEUP_ACTION_DIRECT)) {
+        pw_pr_warn("WARNING: could NOT produce message!\n");
+    }
+};
+/*
+ * Helper function to handle wake lock/unlock callbacks.
+ */
+void sw_handle_wakelock_i(int cpu, struct sw_trace_notifier_data *node, const char *name, int type, u64 timeout)
+{
+    int pid = PID(), tid = TID();
+    const char *proc_name = NAME();
+    struct sw_collector_data *curr = NULL;
+
+    if (!node) {
+        return;
+    }
+
+    list_for_each_entry(curr, &node->list, list) {
+        sw_produce_wakelock_msg_i(cpu, curr, name, type, timeout, pid, tid, proc_name);
+    }
+};
+DEFINE_PROBE_FUNCTION(PROBE_WAKE_LOCK_PARAMS)
+{
+    int cpu = RAW_CPU();
+    static struct sw_trace_notifier_data *node = NULL;
+    enum sw_kernel_wakelock_type type = SW_WAKE_LOCK;
+    u64 timeout = 0;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,4,0)
+    const char *name = lock->name;
+#endif
+
+    if (unlikely(node == NULL)) {
+        node = GET_COLLECTOR_TRACE_NODE(SW_TRACE_ID_WAKE_LOCK);
+        pw_pr_debug("NODE = %p\n", node);
+    }
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,4,0)
+    /*
+     * Was this wakelock acquired with a timeout i.e.
+     * is this an auto expire wakelock?
+     */
+    if (lock->flags & (1U << 10)) {
+        type = SW_WAKE_LOCK_TIMEOUT;
+        timeout = jiffies_to_msecs(lock->expires - jiffies);
+    }
+#endif //LINUX_VERSION_CODE < KERNEL_VERSION(3,4,0)
+    DO_PER_CPU_OVERHEAD_FUNC(sw_handle_wakelock_i, cpu, node, name, (int)type, timeout);
+};
+/*
+ * 11. WAKE unlock / WAKEUP source deactivate.
+ */
+DEFINE_PROBE_FUNCTION(PROBE_WAKE_UNLOCK_PARAMS)
+{
+    int cpu = RAW_CPU();
+    static struct sw_trace_notifier_data *node = NULL;
+    enum sw_kernel_wakelock_type type = SW_WAKE_UNLOCK;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,4,0)
+    const char *name = lock->name;
+#endif
+
+    if (unlikely(node == NULL)) {
+        node = GET_COLLECTOR_TRACE_NODE(SW_TRACE_ID_WAKE_UNLOCK);
+        pw_pr_debug("NODE = %p\n", node);
+    }
+    DO_PER_CPU_OVERHEAD_FUNC(sw_handle_wakelock_i, cpu, node, name, (int)type, 0 /*timeout*/);
+};
+#endif // DO_ANDROID
+
+/*
+ * 12. WORKQUEUE
+ */
+DEFINE_PROBE_FUNCTION(PROBE_WORKQUEUE_PARAMS)
+{
+    int cpu = RAW_CPU();
+    static struct sw_trace_notifier_data *node = NULL;
+    struct sw_collector_data *curr = NULL;
+
+    if (unlikely(node == NULL)) {
+        node = GET_COLLECTOR_TRACE_NODE(SW_TRACE_ID_WORKQUEUE_EXECUTE_START);
+        pw_pr_debug("NODE = %p\n", node);
+    }
+
+    if (!node || !SHOULD_PRODUCE_WAKEUP_SAMPLE(cpu)) {
+        return;
+    }
+    list_for_each_entry(curr, &node->list, list) {
+        DO_PER_CPU_OVERHEAD_FUNC(sw_handle_workqueue_wakeup_helper_i, cpu, curr);
+    }
+};
+
+/*
+ * 13. SCHED switch
+ */
+DEFINE_PROBE_FUNCTION(PROBE_SCHED_SWITCH_PARAMS)
+{
+    DO_PER_CPU_OVERHEAD_FUNC(sw_handle_sched_switch_helper_i);
+};
+
+/*
+ * 1. SUSPEND notifier
+ */
+static void sw_send_pm_notification_i(enum sw_pm_action action)
+{
+    struct sw_driver_msg *msg = NULL;
+    size_t buffer_len = sizeof(*msg) + sizeof(action);
+    char *buffer = vmalloc(buffer_len);
+    if (!buffer) {
+        pw_pr_error("couldn't allocate memory when sending suspend notification!\n");
+        return;
+    }
+    msg = (struct sw_driver_msg *)buffer;
+    msg->tsc = sw_timestamp();
+    msg->cpuidx = RAW_CPU();
+    msg->plugin_id = 0; // "0" indicates a system message
+    msg->metric_id = 1; // "1" indicates a suspend/resume message (TODO)
+    msg->msg_id = 0; /* don't care; TODO: use the 'msg_id' to encode the 'action'? */
+    msg->payload_len = sizeof(action);
+    msg->p_payload = buffer + sizeof(*msg);
+    *((enum sw_pm_action *)msg->p_payload) = action;
+    if (sw_produce_generic_msg(msg, SW_WAKEUP_ACTION_DIRECT)) {
+        pw_pr_error("couldn't produce generic message!\n");
+    }
+    printk(KERN_INFO "OK, enqueued suspend/resume notification at tsc = %llu, action = %d\n", msg->tsc, action);
+    vfree(buffer);
+}
+
+static u64 sw_pm_enter_tsc = 0;
+static bool sw_is_reset_i(void)
+{
+    /*
+     * TODO: rely on checking the IA32_FIXED_CTR2 instead?
+     */
+    u64 curr_tsc = sw_tscval();
+    bool is_reset = sw_pm_enter_tsc > curr_tsc;
+
+    pw_pr_force("DEBUG: curr tsc = %llu, prev tsc = %llu, is reset = %s\n", curr_tsc, sw_pm_enter_tsc, is_reset ? "true" : "false");
+
+    return is_reset;
+}
+void sw_probe_pm_helper_i(int id, int both_id, bool is_enter, enum sw_pm_action action)
+{
+    struct sw_trace_notifier_data *node = GET_COLLECTOR_NOTIFIER_NODE(id);
+    struct sw_trace_notifier_data *both_node = GET_COLLECTOR_NOTIFIER_NODE(both_id);
+    struct sw_trace_notifier_data *reset_node = GET_COLLECTOR_NOTIFIER_NODE(SW_NOTIFIER_ID_COUNTER_RESET);
+    if (is_enter) {
+        /*
+         * Entering HIBERNATION/SUSPEND
+         */
+        sw_pm_enter_tsc = sw_tscval();
+    } else {
+        /*
+         * Exitting HIBERNATION/SUSPEND
+         */
+        if (sw_is_reset_i() && reset_node) {
+            sw_handle_reset_messages_i(reset_node);
+        }
+    }
+    if (node) {
+        sw_handle_trace_notifier_i(node);
+    }
+    if (both_node) {
+        sw_handle_trace_notifier_i(both_node);
+    }
+    /* Send the suspend-resume notification */
+    sw_send_pm_notification_i(action);
+}
+
+int sw_probe_pm_notifier_i(struct notifier_block *block, unsigned long state, void *dummy)
+{
+    static const struct {
+        enum sw_pm_action action;
+        int node_id;
+        int both_id;
+        bool is_enter;
+    } pm_data[PM_POST_RESTORE] = {
+        [PM_HIBERNATION_PREPARE] = {SW_PM_ACTION_HIBERNATE_ENTER, SW_NOTIFIER_ID_HIBERNATE_ENTER, SW_NOTIFIER_ID_HIBERNATE, true},
+        [PM_POST_HIBERNATION] = {SW_PM_ACTION_HIBERNATE_EXIT, SW_NOTIFIER_ID_HIBERNATE_EXIT, SW_NOTIFIER_ID_HIBERNATE, false},
+        [PM_SUSPEND_PREPARE] = {SW_PM_ACTION_SUSPEND_ENTER, SW_NOTIFIER_ID_SUSPEND_ENTER, SW_NOTIFIER_ID_SUSPEND, true},
+        [PM_POST_SUSPEND] = {SW_PM_ACTION_SUSPEND_EXIT, SW_NOTIFIER_ID_SUSPEND_EXIT, SW_NOTIFIER_ID_SUSPEND, false},
+    };
+    enum sw_pm_action action = pm_data[state].action;
+    if (action != SW_PM_ACTION_NONE) {
+        int node_id = pm_data[state].node_id, both_id = pm_data[state].both_id;
+        bool is_enter = pm_data[state].is_enter;
+        printk(KERN_INFO "DEBUG: state = %lu, node_id = %d\n", state, node_id);
+        sw_probe_pm_helper_i(node_id, both_id, is_enter, action);
+    } else {
+        /* Not supported */
+        pw_pr_error("ERROR: unknown state %lu passed to SWA pm notifier!\n", state);
+    }
+    return NOTIFY_DONE;
+}
+
+void sw_store_topology_change_i(enum cpu_action type, int cpu, int core_id, int pkg_id)
+{
+    struct sw_topology_node *node = sw_kmalloc(sizeof(*node), GFP_ATOMIC);
+    if (!node) {
+        pw_pr_error("couldn't allocate a node for topology change tracking!\n");
+        return;
+    }
+    node->change.timestamp = sw_timestamp();
+    node->change.type = type;
+    node->change.cpu = cpu;
+    node->change.core = core_id;
+    node->change.pkg = pkg_id;
+
+    SW_LIST_ADD(&sw_topology_list, node, list);
+    ++sw_num_topology_entries;
+}
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
+int sw_probe_hotplug_notifier_i(struct notifier_block *block, unsigned long action, void *pcpu)
+{
+    unsigned int cpu = (unsigned long)pcpu;
+    unsigned int pkg_id = topology_physical_package_id(cpu);
+    unsigned int core_id = topology_core_id(cpu);
+
+    switch (action) {
+        case CPU_UP_PREPARE:
+        case CPU_UP_PREPARE_FROZEN:
+            /* CPU is coming online -- store top change */
+            sw_store_topology_change_i(SW_CPU_ACTION_ONLINE_PREPARE, cpu, core_id, pkg_id);
+            pw_pr_debug("DEBUG: SoC Watch has cpu %d (phys = %d, core = %d) preparing to come online at tsc = %llu! Current cpu = %d\n", cpu, pkg_id, core_id, sw_timestamp(), RAW_CPU());
+            break;
+        case CPU_ONLINE:
+        case CPU_ONLINE_FROZEN:
+            /* CPU is online -- first store top change then take BEGIN snapshot */
+            sw_store_topology_change_i(SW_CPU_ACTION_ONLINE, cpu, core_id, pkg_id);
+            sw_process_snapshot_on_cpu(SW_WHEN_TYPE_BEGIN, cpu);
+            pw_pr_debug("DEBUG: SoC Watch has cpu %d (phys = %d, core = %d) online at tsc = %llu! Current cpu = %d\n", cpu, pkg_id, core_id, sw_timestamp(), RAW_CPU());
+            break;
+        case CPU_DOWN_PREPARE:
+        case CPU_DOWN_PREPARE_FROZEN:
+            /* CPU is going offline -- take END snapshot */
+            sw_process_snapshot_on_cpu(SW_WHEN_TYPE_END, cpu);
+            pw_pr_debug("DEBUG: SoC Watch has cpu %d preparing to go offline at tsc = %llu! Current cpu = %d\n", cpu, sw_timestamp(), RAW_CPU());
+            break;
+        case CPU_DEAD:
+        case CPU_DEAD_FROZEN:
+            /* CPU is offline -- store top change */
+            sw_store_topology_change_i(SW_CPU_ACTION_OFFLINE, cpu, core_id, pkg_id);
+            pw_pr_debug("DEBUG: SoC Watch has cpu %d offlined at tsc = %llu! Current cpu = %d\n", cpu, sw_timestamp(), RAW_CPU());
+            break;
+        default:
+            break;
+    }
+    return NOTIFY_OK;
+};
+#else
+void sw_probe_cpuhp_helper_i(unsigned int cpu, enum cpu_action action)
+{
+    unsigned int pkg_id = topology_physical_package_id(cpu);
+    unsigned int core_id = topology_core_id(cpu);
+
+    switch (action) {
+        case SW_CPU_ACTION_ONLINE_PREPARE:
+            /* CPU is coming online -- store top change */
+            sw_store_topology_change_i(action, cpu, core_id, pkg_id);
+            break;
+        case SW_CPU_ACTION_ONLINE:
+            /* CPU is online -- first store top change then take BEGIN snapshot */
+            sw_store_topology_change_i(action, cpu, core_id, pkg_id);
+            sw_process_snapshot_on_cpu(SW_WHEN_TYPE_BEGIN, cpu);
+            break;
+        case SW_CPU_ACTION_OFFLINE:
+            /* CPU is preparing to go offline -- take END snapshot then store top change */
+            sw_process_snapshot_on_cpu(SW_WHEN_TYPE_END, cpu);
+            sw_store_topology_change_i(action, cpu, core_id, pkg_id);
+            break;
+        default:
+            break;
+    }
+}
+int sw_probe_cpu_offline_i(unsigned int cpu)
+{
+    printk(KERN_INFO "DEBUG: offline notification for cpu %u at %llu\n", cpu, sw_tscval());
+    sw_probe_cpuhp_helper_i(cpu, SW_CPU_ACTION_OFFLINE);
+    return 0;
+}
+int sw_probe_cpu_online_i(unsigned int cpu)
+{
+    printk(KERN_INFO "DEBUG: online notification for cpu %u at %llu\n", cpu, sw_tscval());
+    sw_probe_cpuhp_helper_i(cpu, SW_CPU_ACTION_ONLINE_PREPARE);
+    sw_probe_cpuhp_helper_i(cpu, SW_CPU_ACTION_ONLINE);
+    return 0;
+}
+#endif // LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
+
+/*
+ * 2. CPUFREQ notifier
+ */
+int sw_probe_cpufreq_notifier_i(struct notifier_block *block, unsigned long state, void *data)
+{
+    struct cpufreq_freqs *freqs = data;
+    static struct sw_trace_notifier_data *node = NULL;
+    int cpu = freqs->cpu;
+
+    if (state == CPUFREQ_PRECHANGE) {
+        pw_pr_debug("CPU %d reports a CPUFREQ_PRECHANGE for target CPU %d at TSC = %llu\n", RAW_CPU(), cpu, sw_timestamp());
+        if (unlikely(node == NULL)) {
+            node = GET_COLLECTOR_NOTIFIER_NODE(SW_NOTIFIER_ID_CPUFREQ);
+            pw_pr_debug("NODE = %p\n", node);
+        }
+        /* Force an atomic context by disabling preemption */
+        get_cpu();
+        DO_PER_CPU_OVERHEAD_FUNC(sw_tpf_i, cpu, node);
+        put_cpu();
+    }
+    return NOTIFY_DONE;
+}
+/*
+ * 1. TPS.
+ */
+int sw_register_trace_cpu_idle_i(struct sw_trace_notifier_data *node)
+{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,38)
+    DO_REGISTER_SW_TRACEPOINT_PROBE(node, power_start, sw_probe_power_start_i);
+#else // kernel version >= 2.6.38
+    DO_REGISTER_SW_TRACEPOINT_PROBE(node, cpu_idle, sw_probe_cpu_idle_i);
+#endif // LINUX_VERSION_CODE < KERNEL_VERSION(2,6,38)
+    return PW_SUCCESS;
+};
+int sw_unregister_trace_cpu_idle_i(struct sw_trace_notifier_data *node)
+{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,38)
+    DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, power_start, sw_probe_power_start_i);
+#else // kernel version >= 2.6.38
+    DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, cpu_idle, sw_probe_cpu_idle_i);
+#endif // LINUX_VERSION_CODE < KERNEL_VERSION(2,6,38)
+    return PW_SUCCESS;
+};
+/*
+ * 2. TPF
+ */
+int sw_register_trace_cpu_frequency_i(struct sw_trace_notifier_data *node)
+{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,38)
+    DO_REGISTER_SW_TRACEPOINT_PROBE(node, power_frequency, sw_probe_power_frequency_i);
+#else // kernel version >= 2.6.38
+    DO_REGISTER_SW_TRACEPOINT_PROBE(node, cpu_frequency, sw_probe_cpu_frequency_i);
+#endif // LINUX_VERSION_CODE < KERNEL_VERSION(2,6,38)
+    return PW_SUCCESS;
+};
+int sw_unregister_trace_cpu_frequency_i(struct sw_trace_notifier_data *node)
+{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,38)
+    DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, power_frequency, sw_probe_power_frequency_i);
+#else // kernel version >= 2.6.38
+    DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, cpu_frequency, sw_probe_cpu_frequency_i);
+#endif // LINUX_VERSION_CODE < KERNEL_VERSION(2,6,38)
+    return PW_SUCCESS;
+};
+/*
+ * 3. IRQ handler entry
+ */
+int sw_register_trace_irq_handler_entry_i(struct sw_trace_notifier_data *node)
+{
+    DO_REGISTER_SW_TRACEPOINT_PROBE(node, irq_handler_entry, sw_probe_irq_handler_entry_i);
+    return PW_SUCCESS;
+};
+int sw_unregister_trace_irq_handler_entry_i(struct sw_trace_notifier_data *node)
+{
+    DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, irq_handler_entry, sw_probe_irq_handler_entry_i);
+    return PW_SUCCESS;
+};
+/*
+ * 4. TIMER expire.
+ */
+int sw_register_trace_timer_expire_entry_i(struct sw_trace_notifier_data *node)
+{
+    DO_REGISTER_SW_TRACEPOINT_PROBE(node, timer_expire_entry, sw_probe_timer_expire_entry_i);
+    return PW_SUCCESS;
+};
+int sw_unregister_trace_timer_expire_entry_i(struct sw_trace_notifier_data *node)
+{
+    DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, timer_expire_entry, sw_probe_timer_expire_entry_i);
+    return PW_SUCCESS;
+};
+/*
+ * 5. HRTIMER expire.
+ */
+int sw_register_trace_hrtimer_expire_entry_i(struct sw_trace_notifier_data *node)
+{
+    DO_REGISTER_SW_TRACEPOINT_PROBE(node, hrtimer_expire_entry, sw_probe_hrtimer_expire_entry_i);
+    return PW_SUCCESS;
+};
+int sw_unregister_trace_hrtimer_expire_entry_i(struct sw_trace_notifier_data *node)
+{
+    DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, hrtimer_expire_entry, sw_probe_hrtimer_expire_entry_i);
+    return PW_SUCCESS;
+};
+/*
+ * 6. SCHED wakeup
+ */
+int sw_register_trace_sched_wakeup_i(struct sw_trace_notifier_data *node)
+{
+    DO_REGISTER_SW_TRACEPOINT_PROBE(node, sched_wakeup, sw_probe_sched_wakeup_i);
+    return PW_SUCCESS;
+};
+int sw_unregister_trace_sched_wakeup_i(struct sw_trace_notifier_data *node)
+{
+    DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, sched_wakeup, sw_probe_sched_wakeup_i);
+    return PW_SUCCESS;
+};
+/*
+ * 8. PROCESS fork
+ */
+int sw_register_trace_sched_process_fork_i(struct sw_trace_notifier_data *node)
+{
+    DO_REGISTER_SW_TRACEPOINT_PROBE(node, sched_process_fork, sw_probe_sched_process_fork_i);
+    return PW_SUCCESS;
+};
+int sw_unregister_trace_sched_process_fork_i(struct sw_trace_notifier_data *node)
+{
+    DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, sched_process_fork, sw_probe_sched_process_fork_i);
+    return PW_SUCCESS;
+};
+/*
+ * 9. PROCESS exit
+ */
+int sw_register_trace_sched_process_exit_i(struct sw_trace_notifier_data *node)
+{
+    DO_REGISTER_SW_TRACEPOINT_PROBE(node, sched_process_exit, sw_probe_sched_process_exit_i);
+    return PW_SUCCESS;
+};
+int sw_unregister_trace_sched_process_exit_i(struct sw_trace_notifier_data *node)
+{
+    DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, sched_process_exit, sw_probe_sched_process_exit_i);
+    return PW_SUCCESS;
+};
+/*
+ * 10. THERMAL_APIC entry
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0)
+int sw_register_trace_thermal_apic_entry_i(struct sw_trace_notifier_data *node)
+{
+    DO_REGISTER_SW_TRACEPOINT_PROBE(node, thermal_apic_entry, sw_probe_thermal_apic_entry_i);
+    return PW_SUCCESS;
+};
+int sw_unregister_trace_thermal_apic_entry_i(struct sw_trace_notifier_data *node)
+{
+    DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, thermal_apic_entry, sw_probe_thermal_apic_entry_i);
+    return PW_SUCCESS;
+};
+/*
+ * 10. THERMAL_APIC exit
+ */
+int sw_register_trace_thermal_apic_exit_i(struct sw_trace_notifier_data *node)
+{
+    DO_REGISTER_SW_TRACEPOINT_PROBE(node, thermal_apic_exit, sw_probe_thermal_apic_exit_i);
+    return PW_SUCCESS;
+};
+int sw_unregister_trace_thermal_apic_exit_i(struct sw_trace_notifier_data *node)
+{
+    DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, thermal_apic_exit, sw_probe_thermal_apic_exit_i);
+    return PW_SUCCESS;
+};
+#endif // LINUX_VERSION_CODE >= KERNEL_VERSION(3,14,0)
+/*
+ * 11. WAKE lock / WAKEUP source activate.
+ */
+#if DO_ANDROID
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,4,0)
+int sw_register_trace_wake_lock_i(struct sw_trace_notifier_data *node)
+{
+    DO_REGISTER_SW_TRACEPOINT_PROBE(node, wake_lock, sw_probe_wake_lock_i);
+    return PW_SUCCESS;
+};
+int sw_unregister_trace_wake_lock_i(struct sw_trace_notifier_data *node)
+{
+    DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, wake_lock, sw_probe_wake_lock_i);
+    return PW_SUCCESS;
+};
+#else // LINUX_VERSION_CODE >= KERNEL_VERSION(3,4,0)
+int sw_register_trace_wakeup_source_activate_i(struct sw_trace_notifier_data *node)
+{
+    DO_REGISTER_SW_TRACEPOINT_PROBE(node, wakeup_source_activate, sw_probe_wakeup_source_activate_i);
+    return PW_SUCCESS;
+};
+int sw_unregister_trace_wakeup_source_activate_i(struct sw_trace_notifier_data *node)
+{
+    DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, wakeup_source_activate, sw_probe_wakeup_source_activate_i);
+    return PW_SUCCESS;
+};
+#endif // LINUX_VERSION_CODE < KERNEL_VERSION(3,4,0)
+/*
+ * 11. WAKE unlock / WAKEUP source deactivate.
+ */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,4,0)
+int sw_register_trace_wake_unlock_i(struct sw_trace_notifier_data *node)
+{
+    DO_REGISTER_SW_TRACEPOINT_PROBE(node, wake_unlock, sw_probe_wake_unlock_i);
+    return PW_SUCCESS;
+};
+int sw_unregister_trace_wake_unlock_i(struct sw_trace_notifier_data *node)
+{
+    DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, wake_unlock, sw_probe_wake_unlock_i);
+    return PW_SUCCESS;
+};
+#else // LINUX_VERSION_CODE >= KERNEL_VERSION(3,4,0)
+int sw_register_trace_wakeup_source_deactivate_i(struct sw_trace_notifier_data *node)
+{
+    DO_REGISTER_SW_TRACEPOINT_PROBE(node, wakeup_source_deactivate, sw_probe_wakeup_source_deactivate_i);
+    return PW_SUCCESS;
+};
+int sw_unregister_trace_wakeup_source_deactivate_i(struct sw_trace_notifier_data *node)
+{
+    DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, wakeup_source_deactivate, sw_probe_wakeup_source_deactivate_i);
+    return PW_SUCCESS;
+};
+#endif // LINUX_VERSION_CODE < KERNEL_VERSION(3,4,0)
+#endif // DO_ANDROID
+/*
+ * 12. WORKQUEUE execution.
+ */
+int sw_register_trace_workqueue_execution_i(struct sw_trace_notifier_data *node)
+{
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,35)
+    DO_REGISTER_SW_TRACEPOINT_PROBE(node, workqueue_execution, sw_probe_workqueue_execution_i);
+#else
+    DO_REGISTER_SW_TRACEPOINT_PROBE(node, workqueue_execute_start, sw_probe_workqueue_execute_start_i);
+#endif
+    return PW_SUCCESS;
+};
+int sw_unregister_trace_workqueue_execution_i(struct sw_trace_notifier_data *node)
+{
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(2,6,35)
+    DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, workqueue_execution, sw_probe_workqueue_execution_i);
+#else
+    DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, workqueue_execute_start, sw_probe_workqueue_execute_start_i);
+#endif
+    return PW_SUCCESS;
+};
+/*
+ * 13. SCHED switch
+ */
+int sw_register_trace_sched_switch_i(struct sw_trace_notifier_data *node)
+{
+    /*
+     * Set polling tick time, in jiffies.
+     * Used by the context switch tracepoint to decide
+     * if enough time has elapsed since the last
+     * collection point to read resources again.
+     */
+    {
+        int cpu = 0;
+        for_each_present_cpu(cpu) {
+            *(&per_cpu(sw_pcpu_polling_jiff, cpu)) = jiffies;
+        }
+    }
+    DO_REGISTER_SW_TRACEPOINT_PROBE(node, sched_switch, sw_probe_sched_switch_i);
+    return PW_SUCCESS;
+};
+int sw_unregister_trace_sched_switch_i(struct sw_trace_notifier_data *node)
+{
+    DO_UNREGISTER_SW_TRACEPOINT_PROBE(node, sched_switch, sw_probe_sched_switch_i);
+    return PW_SUCCESS;
+};
+/*
+ * Notifier register/unregister functions.
+ */
+/*
+ * 1. SUSPEND notifier.
+ */
+struct notifier_block sw_pm_notifier = {
+    .notifier_call = &sw_probe_pm_notifier_i,
+};
+int sw_register_pm_notifier_i(struct sw_trace_notifier_data *node)
+{
+    register_pm_notifier(&sw_pm_notifier);
+    return PW_SUCCESS;
+};
+int sw_unregister_pm_notifier_i(struct sw_trace_notifier_data *node)
+{
+    unregister_pm_notifier(&sw_pm_notifier);
+    return PW_SUCCESS;
+};
+/*
+ * 2. CPUFREQ notifier.
+ */
+struct notifier_block sw_cpufreq_notifier = {
+    .notifier_call = &sw_probe_cpufreq_notifier_i,
+};
+int sw_register_cpufreq_notifier_i(struct sw_trace_notifier_data *node)
+{
+    cpufreq_register_notifier(&sw_cpufreq_notifier, CPUFREQ_TRANSITION_NOTIFIER);
+    return PW_SUCCESS;
+};
+int sw_unregister_cpufreq_notifier_i(struct sw_trace_notifier_data *node)
+{
+    cpufreq_unregister_notifier(&sw_cpufreq_notifier, CPUFREQ_TRANSITION_NOTIFIER);
+    return PW_SUCCESS;
+};
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
+/*
+ * 3. CPU hot plug notifier.
+ */
+struct notifier_block sw_cpu_hotplug_notifier = {
+    .notifier_call = &sw_probe_hotplug_notifier_i,
+};
+
+int sw_register_hotcpu_notifier_i(struct sw_trace_notifier_data *node)
+{
+    register_hotcpu_notifier(&sw_cpu_hotplug_notifier);
+    return PW_SUCCESS;
+};
+int sw_unregister_hotcpu_notifier_i(struct sw_trace_notifier_data *node)
+{
+    unregister_hotcpu_notifier(&sw_cpu_hotplug_notifier);
+    return PW_SUCCESS;
+};
+#else // LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)
+static int sw_cpuhp_state = -1;
+int sw_register_hotcpu_notifier_i(struct sw_trace_notifier_data *node)
+{
+    sw_cpuhp_state = cpuhp_setup_state_nocalls(CPUHP_AP_ONLINE_DYN, "socwatch:online", &sw_probe_cpu_online_i, &sw_probe_cpu_offline_i);
+    if (sw_cpuhp_state < 0) {
+        pw_pr_error("couldn't register socwatch hotplug callbacks!\n");
+        return -EIO;
+    }
+    return 0;
+};
+int sw_unregister_hotcpu_notifier_i(struct sw_trace_notifier_data *node)
+{
+    if (sw_cpuhp_state >= 0) {
+        cpuhp_remove_state_nocalls((enum cpuhp_state)sw_cpuhp_state);
+    }
+    return 0;
+};
+#endif // LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0)
+
+/*
+ * Tracepoint extraction routines.
+ * Required for newer kernels (>=3.15)
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,15,0)
+static void sw_extract_tracepoint_callback(struct tracepoint *tp, void *priv)
+{
+    struct sw_trace_notifier_data *node = NULL;
+    int i=0;
+    int *numStructsFound = (int *)priv;
+    if (*numStructsFound == NUM_VALID_TRACEPOINTS) {
+        /*
+         * We've found all the tracepoints we need.
+         */
+        return;
+    }
+    if (tp) {
+        FOR_EACH_TRACEPOINT_NODE(i, node) {
+            if (node->tp == NULL && node->name) {
+                const char *name = sw_get_trace_notifier_kernel_name(node);
+                if (name && !strcmp(tp->name, name)) {
+                    node->tp = tp;
+                    ++*numStructsFound;
+                    pw_pr_debug("OK, found TP %s\n", tp->name);
+                }
+            }
+        }
+    }
+};
+#endif // LINUX_VERSION_CODE >= KERNEL_VERSION(3,15,0)
+
+/*
+ * Retrieve the list of tracepoint structs to use when registering and unregistering
+ * tracepoint handlers.
+ */
+int sw_extract_trace_notifier_providers(void)
+{
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,15,0) && defined(CONFIG_TRACEPOINTS)
+    int numCallbacks = 0;
+    for_each_kernel_tracepoint(&sw_extract_tracepoint_callback, &numCallbacks);
+    /*
+     * Did we get the complete list?
+     */
+    if (numCallbacks != NUM_VALID_TRACEPOINTS) {
+        printk(KERN_WARNING "WARNING: Could NOT find tracepoint structs for some tracepoints!\n");
+    }
+#endif // LINUX_VERSION_CODE >= KERNEL_VERSION(3,15,0)
+    return PW_SUCCESS;
+};
+
+void sw_reset_trace_notifier_providers(void)
+{
+    /*
+     * Reset the wakeup flag. Not strictly required if we aren't probing
+     * any of the wakeup tracepoints.
+     */
+    {
+        int cpu = 0;
+        for_each_online_cpu(cpu) {
+            RESET_VALID_WAKEUP_EVENT_COUNTER(cpu);
+        }
+    }
+    /*
+     * Reset the wakeup event flag. Not strictly required if we
+     * aren't probing any of the wakeup tracepoints. Will be reset
+     * in the power_start tracepoint if user requested a c-state
+     * collection.
+     */
+    sw_wakeup_event_flag = true;
+};
+
+void sw_print_trace_notifier_provider_overheads(void)
+{
+    PRINT_CUMULATIVE_OVERHEAD_PARAMS(sw_tps_i, "TPS");
+    PRINT_CUMULATIVE_OVERHEAD_PARAMS(sw_tpf_i, "TPF");
+    PRINT_CUMULATIVE_OVERHEAD_PARAMS(sw_handle_irq_wakeup_i, "IRQ");
+    PRINT_CUMULATIVE_OVERHEAD_PARAMS(sw_handle_timer_wakeup_helper_i, "TIMER_EXPIRE");
+    PRINT_CUMULATIVE_OVERHEAD_PARAMS(sw_handle_sched_wakeup_i, "SCHED WAKEUP");
+    PRINT_CUMULATIVE_OVERHEAD_PARAMS(sw_process_fork_exit_helper_i, "PROCESS FORK/EXIT");
+#if DO_ANDROID
+    PRINT_CUMULATIVE_OVERHEAD_PARAMS(sw_handle_wakelock_i, "WAKE LOCK/UNLOCK");
+#endif // DO_ANDROID
+    PRINT_CUMULATIVE_OVERHEAD_PARAMS(sw_handle_workqueue_wakeup_helper_i, "WORKQUEUE");
+    PRINT_CUMULATIVE_OVERHEAD_PARAMS(sw_handle_sched_switch_helper_i, "SCHED SWITCH");
+};
+/*
+ * Add all trace/notifier providers.
+ */
+int sw_add_trace_notifier_providers(void)
+{
+    struct sw_trace_notifier_data *node = NULL;
+    int i = 0;
+    FOR_EACH_TRACEPOINT_NODE(i, node) {
+        if (sw_register_trace_notify_provider(node)) {
+            pw_pr_error("ERROR: couldn't add a trace provider!\n");
+            return -EIO;
+        }
+    }
+    FOR_EACH_NOTIFIER_NODE(i, node) {
+        if (sw_register_trace_notify_provider(node)) {
+            pw_pr_error("ERROR: couldn't add a notifier provider!\n");
+            return -EIO;
+        }
+    }
+    /*
+     * Add the cpu hot plug notifier.
+     */
+    {
+        if (sw_register_trace_notify_provider(&s_hotplug_notifier_data)) {
+            pw_pr_error("ERROR: couldn't add cpu notifier provider!\n");
+            return -EIO;
+        }
+    }
+    return PW_SUCCESS;
+}
+/*
+ * Remove previously added providers.
+ */
+void sw_remove_trace_notifier_providers(void) { /* NOP */ }

--- a/perftools-external/socwatch_driver/src/sw_tracepoint_handlers.c
+++ b/perftools-external/socwatch_driver/src/sw_tracepoint_handlers.c
@@ -1,0 +1,358 @@
+/*
+
+  This file is provided under a dual BSD/GPLv2 license.  When using or
+  redistributing this file, you may do so under either license.
+
+  GPL LICENSE SUMMARY
+
+  Copyright(c) 2014 - 2018 Intel Corporation.
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+  Contact Information:
+  SoC Watch Developer Team <socwatchdevelopers@intel.com>
+  Intel Corporation,
+  1906 Fox Drive,
+  Champaign, IL 61820
+
+  BSD LICENSE
+
+  Copyright(c) 2014 - 2018 Intel Corporation.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+#include "sw_structs.h"
+#include "sw_defines.h"
+#include "sw_types.h"
+#include "sw_tracepoint_handlers.h"
+#include "sw_trace_notifier_provider.h"
+#include "sw_mem.h"
+
+/* -------------------------------------------------
+ * Data structures and variable definitions.
+ * -------------------------------------------------
+ */
+struct sw_trace_list_node {
+    struct sw_trace_notifier_data *data;
+    int id;
+    SW_LIST_ENTRY(list, sw_trace_list_node);
+};
+static SW_DEFINE_LIST_HEAD(s_trace_list, sw_trace_list_node) = SW_LIST_HEAD_INITIALIZER(s_trace_list);
+static SW_DEFINE_LIST_HEAD(s_notifier_list, sw_trace_list_node) = SW_LIST_HEAD_INITIALIZER(s_notifier_list);
+static int s_trace_idx = -1, s_notifier_idx = -1;
+
+SW_DEFINE_LIST_HEAD(sw_topology_list, sw_topology_node) = SW_LIST_HEAD_INITIALIZER(sw_topology_list);
+size_t sw_num_topology_entries = 0;
+
+
+/* -------------------------------------------------
+ * Function definitions.
+ * -------------------------------------------------
+ */
+int sw_extract_tracepoints(void)
+{
+    return sw_extract_trace_notifier_providers();
+}
+
+void sw_reset_trace_notifier_lists(void)
+{
+    sw_reset_trace_notifier_providers();
+}
+
+void sw_print_trace_notifier_overheads(void)
+{
+    sw_print_trace_notifier_provider_overheads();
+}
+
+static int sw_for_each_node_i(void *list_head,
+                              int (*func)(struct sw_trace_notifier_data *node, void *priv),
+                              void *priv, bool return_on_error)
+{
+    SW_LIST_HEAD_VAR(sw_trace_list_node) *head = list_head;
+    int retval = PW_SUCCESS;
+    struct sw_trace_list_node *lnode = NULL;
+    SW_LIST_FOR_EACH_ENTRY(lnode, head, list) {
+        if ((*func)(lnode->data, priv)) {
+            retval = -EIO;
+            if (return_on_error) {
+                break;
+            }
+        }
+    }
+    return retval;
+}
+
+int sw_for_each_tracepoint_node(int (*func)(struct sw_trace_notifier_data *node, void *priv), void *priv, bool return_on_error)
+{
+    if (func) {
+        return sw_for_each_node_i(&s_trace_list, func, priv, return_on_error);
+    }
+    return PW_SUCCESS;
+}
+
+int sw_for_each_notifier_node(int (*func)(struct sw_trace_notifier_data *node, void *priv), void *priv, bool return_on_error)
+{
+    if (func) {
+        return sw_for_each_node_i(&s_notifier_list, func, priv, return_on_error);
+    }
+    return PW_SUCCESS;
+}
+
+/*
+ * Retrieve the ID for the corresponding tracepoint/notifier.
+ */
+int sw_get_trace_notifier_id(struct sw_trace_notifier_data *tnode)
+{
+    struct sw_trace_list_node *lnode = NULL;
+    SW_LIST_HEAD_VAR(sw_trace_list_node) *head = (void *)&s_trace_list;
+    if (!tnode) {
+        pw_pr_error("ERROR: cannot get ID for NULL trace/notifier data!\n");
+        return -EIO;
+    }
+    if (!(tnode->type == SW_TRACE_COLLECTOR_TRACEPOINT || tnode->type == SW_TRACE_COLLECTOR_NOTIFIER)) {
+        pw_pr_error("ERROR: cannot get ID for invalid trace/notifier data!\n");
+        return -EIO;
+    }
+    if (!tnode->name || !tnode->name->abstract_name) {
+        pw_pr_error("ERROR: cannot get ID for trace/notifier data without valid name!\n");
+        return -EIO;
+    }
+#ifdef LINUX_VERSION_CODE
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,15,0) && defined(CONFIG_TRACEPOINTS)
+    if (tnode->type == SW_TRACE_COLLECTOR_TRACEPOINT &&
+            tnode->name->kernel_name && !tnode->tp) {
+        /* No tracepoint structure found so no ID possible */
+        return -EIO;
+    }
+#endif
+#endif
+    if (tnode->type == SW_TRACE_COLLECTOR_NOTIFIER) {
+        head = (void *)&s_notifier_list;
+    }
+    SW_LIST_FOR_EACH_ENTRY(lnode, head, list) {
+        struct sw_trace_notifier_data *data = lnode->data;
+        if (!strcmp(data->name->abstract_name, tnode->name->abstract_name)) {
+            return lnode->id;
+        }
+    }
+    return -1;
+}
+/*
+ * Retrieve the "kernel" name for this tracepoint/notifier.
+ */
+const char *sw_get_trace_notifier_kernel_name(struct sw_trace_notifier_data *node)
+{
+    return node->name->kernel_name;
+};
+/*
+ * Retrieve the "abstract" name for this tracepoint/notifier.
+ */
+const char *sw_get_trace_notifier_abstract_name(struct sw_trace_notifier_data *node)
+{
+    return node->name->abstract_name;
+};
+
+/*
+ * Add a single TRACE/NOTIFY provider.
+ */
+int sw_register_trace_notify_provider(struct sw_trace_notifier_data *data)
+{
+    struct sw_trace_list_node *lnode = NULL;
+    if (!data) {
+        pw_pr_error("ERROR: cannot add NULL trace/notifier provider!\n");
+        return -EIO;
+    }
+    if (!(data->type == SW_TRACE_COLLECTOR_TRACEPOINT || data->type == SW_TRACE_COLLECTOR_NOTIFIER)) {
+        pw_pr_error("ERROR: cannot add invalid trace/notifier data!\n");
+        return -EIO;
+    }
+    /*
+     * Kernel name is allowed to be NULL, but abstract name MUST be present!
+     */
+    if (!data->name || !data->name->abstract_name) {
+        pw_pr_error("ERROR: cannot add trace/notifier provider without an abstract name!\n");
+        pw_pr_error("ERROR: data->name = %p\n", data->name);
+        return -EIO;
+    }
+    lnode = sw_kmalloc(sizeof(*lnode), GFP_KERNEL);
+    if (!lnode) {
+        pw_pr_error("ERROR: couldn't allocate a list node when adding a trace/notifier provider!\n");
+        return -ENOMEM;
+    }
+    lnode->data = data;
+    SW_LIST_ENTRY_INIT(lnode, list);
+    if (data->type == SW_TRACE_COLLECTOR_TRACEPOINT) {
+        lnode->id = ++s_trace_idx;
+        SW_LIST_ADD(&s_trace_list, lnode, list);
+    } else {
+        lnode->id = ++s_notifier_idx;
+        SW_LIST_ADD(&s_notifier_list, lnode, list);
+    }
+    return PW_SUCCESS;
+}
+/*
+ * Add all TRACE/NOTIFY providers.
+ */
+int sw_add_trace_notify(void)
+{
+    return sw_add_trace_notifier_providers();
+}
+
+static void sw_free_trace_notifier_list_i(void *list_head)
+{
+    SW_LIST_HEAD_VAR(sw_trace_list_node) *head = list_head;
+    while (!SW_LIST_EMPTY(head)) {
+        struct sw_trace_list_node *lnode = SW_LIST_GET_HEAD_ENTRY(head, sw_trace_list_node, list);
+        SW_LIST_UNLINK(lnode, list);
+        sw_kfree(lnode);
+    }
+}
+/*
+ * Remove TRACE/NOTIFY providers.
+ */
+void sw_remove_trace_notify(void)
+{
+    /*
+     * Free all nodes.
+     */
+    sw_free_trace_notifier_list_i(&s_trace_list);
+    sw_free_trace_notifier_list_i(&s_notifier_list);
+    /*
+     * Call our providers to deallocate resources.
+     */
+    sw_remove_trace_notifier_providers();
+    /*
+     * Clear out the topology list
+     */
+    sw_clear_topology_list();
+}
+
+#define REG_FLAG (void *)1
+#define UNREG_FLAG (void *)2
+static int sw_reg_unreg_node_i(struct sw_trace_notifier_data *node, void *is_reg)
+{
+    if (is_reg == REG_FLAG) {
+        /*
+         * Do we have anything to collect?
+         * Update: or were we asked to always register?
+         */
+        if (SW_LIST_EMPTY(&node->list) && !node->always_register) {
+            return PW_SUCCESS;
+        }
+        /*
+         * Sanity: ensure we have a register AND an unregister function before proceeding!
+         */
+        if (node->probe_register == NULL || node->probe_unregister == NULL) {
+            pw_pr_debug("WARNING: invalid trace/notifier register/unregister function for %s\n", sw_get_trace_notifier_kernel_name(node));
+            /*
+             * Don't flag this as an error -- some socwatch trace providers don't have a
+             * register/unregister function
+             */
+            return PW_SUCCESS;
+        }
+        if ((*node->probe_register)(node)) {
+            return -EIO;
+        }
+        node->was_registered = true;
+        return PW_SUCCESS;
+    } else if (is_reg == UNREG_FLAG) {
+        if (node->was_registered) {
+            /*
+             * No need to check for validity of probe unregister function -- 'sw_register_notifiers_i()'
+             * would already have done so!
+             */
+            WARN_ON((*node->probe_unregister)(node));
+            node->was_registered = false;
+            pw_pr_debug("OK, unregistered trace/notifier for %s\n", sw_get_trace_notifier_kernel_name(node));
+        }
+        return PW_SUCCESS;
+    }
+    pw_pr_error("ERROR: invalid reg/unreg flag value 0x%lx\n", (unsigned long)is_reg);
+    return -EIO;
+}
+/*
+ * Register all required tracepoints and notifiers.
+ */
+int sw_register_trace_notifiers(void)
+{
+    /*
+     * First, the tracepoints.
+     */
+    if (sw_for_each_tracepoint_node(&sw_reg_unreg_node_i, REG_FLAG, true /* return on error */)) {
+        pw_pr_error("ERROR registering some tracepoints\n");
+        return -EIO;
+    }
+    /*
+     * And then the notifiers.
+     */
+    if (sw_for_each_notifier_node(&sw_reg_unreg_node_i, REG_FLAG, true /* return on error */)) {
+        pw_pr_error("ERROR registering some tracepoints\n");
+        return -EIO;
+    }
+    return PW_SUCCESS;
+};
+/*
+ * Unregister all previously registered tracepoints and notifiers.
+ */
+int sw_unregister_trace_notifiers(void)
+{
+    /*
+     * First, the notifiers.
+     */
+    if (sw_for_each_notifier_node(&sw_reg_unreg_node_i, UNREG_FLAG, true /* return on error */)) {
+        pw_pr_error("ERROR registering some tracepoints\n");
+        return -EIO;
+    }
+    /*
+     * And then the tracepoints.
+     */
+    if (sw_for_each_tracepoint_node(&sw_reg_unreg_node_i, UNREG_FLAG, true /* return on error */)) {
+        pw_pr_error("ERROR registering some tracepoints\n");
+        return -EIO;
+    }
+    return PW_SUCCESS;
+};
+
+void sw_clear_topology_list(void)
+{
+    SW_LIST_HEAD_VAR(sw_topology_node) *head = &sw_topology_list;
+    while (!SW_LIST_EMPTY(head)) {
+        struct sw_topology_node *lnode = SW_LIST_GET_HEAD_ENTRY(head, sw_topology_node, list);
+        pw_pr_debug("Clearing topology node for cpu %d\n", lnode->change.cpu);
+        SW_LIST_UNLINK(lnode, list);
+        sw_kfree(lnode);
+    }
+    sw_num_topology_entries  = 0;
+}

--- a/perftools-external/socwatch_driver/strip_driver_debug_sections.sh
+++ b/perftools-external/socwatch_driver/strip_driver_debug_sections.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+# ##################################################################################
+# Copyright 2014 - 2017 Intel Corporation
+
+# The source code contained or described herein and all documents related
+# to the source code ("Material") are owned by Intel Corporation or its
+# suppliers or licensors. Title to the Material remains with Intel Corporation
+# or its suppliers and licensors. The Material contains trade secrets and
+# proprietary and confidential information of Intel or its suppliers and
+# licensors. The Material is protected by worldwide copyright and trade secret
+# laws and treaty provisions. No part of the Material may be used, copied,
+# reproduced, modified, published, uploaded, posted, transmitted, distributed,
+# or disclosed in any way without Intel's prior express written permission.
+
+# No license under any patent, copyright, trade secret or other intellectual
+# property right is granted to or conferred upon you by disclosure or delivery
+# of the Materials, either expressly, by implication, inducement, estoppel or
+# otherwise. Any license under such intellectual property rights must be express
+# and approved by Intel in writing.
+# #################################################################################
+
+# Remove driver debug sections. Execute this script if
+# "insmod" fails with the following error:
+# "ERROR: could not insert module socwatch2_4.ko: Cannot allocate memory"
+
+DRIVER_MAJOR=2
+DRIVER_MINOR=4
+DRIVER_NAME=socwatch
+FULL_NAME="${DRIVER_NAME}${DRIVER_MAJOR}_${DRIVER_MINOR}.ko"
+STRIPPED_NAME="tmp"
+
+INPUT_FILE_NAME=${FULL_NAME}
+OUTPUT_FILE_NAME=${FULL_NAME}
+
+usage()
+{
+    echo "Usage: ./strip_debug_sections.sh [ -i path to input file ] [ -o path to output file ]"
+    echo "Where input and output paths are optional and default to $INPUT_FILE_NAME and $OUTPUT_FILE_NAME, respectively";
+}
+
+get_args()
+{
+    while [ $# -gt 0 ]; do
+        case $1 in
+            -h)
+                usage;
+                exit 0;;
+            -i)
+                INPUT_FILE_NAME=$2;
+                shift;;
+            -o)
+                OUTPUT_FILE_NAME=$2;
+                shift;;
+            *) usage; exit 255;;
+        esac
+        shift;
+    done
+}
+
+run()
+{
+    echo "Input file name is ${INPUT_FILE_NAME}";
+    echo "Output file name is ${OUTPUT_FILE_NAME}";
+    objcopy -R .debug_aranges \
+        -R .debug_info \
+        -R .debug_abbrev \
+        -R .debug_line \
+        -R .debug_frame \
+        -R .debug_str \
+        -R .debug_loc \
+        -R .debug_ranges \
+        ${INPUT_FILE_NAME} ${STRIPPED_NAME}
+
+    if [ $? -ne 0 ]; then
+        echo "Failed";
+    else
+        mv ${STRIPPED_NAME} ${OUTPUT_FILE_NAME}
+    fi
+}
+
+get_args $*
+run


### PR DESCRIPTION
This adds socwatch v2.6.1 and socperf v2.0 kernel driver. Its build
as part of image to avoid building it separate from source for profiling
tools.

Tracked-On: OAM-56483
Signed-off-by: Ankit Navik <ankit.tarot@gmail.com>