### PR TITLE
Fixes for kernel-6.1

### DIFF
--- a/VBoxGuestAdditions/vboxguest-6.1.36/vboxguest/r0drv/linux/memobj-r0drv-linux.c
+++ b/VBoxGuestAdditions/vboxguest-6.1.36/vboxguest/r0drv/linux/memobj-r0drv-linux.c
@@ -1301,7 +1301,11 @@ DECLHIDDEN(int) rtR0MemObjNativeLockUser(PPRTR0MEMOBJINTERNAL ppMem, RTR3PTR R3P
             while (rc-- > 0)
             {
                 flush_dcache_page(pMemLnx->apPages[rc]);
+#if RTLNX_VER_MIN(6,1,0)
+                vm_flags_set(papVMAs[rc], VM_DONTCOPY | VM_LOCKED);
+#else
                 papVMAs[rc]->vm_flags |= VM_DONTCOPY | VM_LOCKED;
+#endif
             }
 
             LNX_MM_UP_READ(pTask->mm);
@@ -1771,7 +1775,11 @@ DECLHIDDEN(int) rtR0MemObjNativeMapUser(PPRTR0MEMOBJINTERNAL ppMem, RTR0MEMOBJ p
                     /* Thes flags help making 100% sure some bad stuff wont happen (swap, core, ++).
                      * See remap_pfn_range() in mm/memory.c */
 #if    RTLNX_VER_MIN(3,7,0)
+#if RTLNX_VER_MIN(6,1,0)
+                    vm_flags_set(vma, VM_DONTEXPAND | VM_DONTDUMP);
+#else
                     vma->vm_flags |= VM_DONTEXPAND | VM_DONTDUMP;
+#endif
 #else
                     vma->vm_flags |= VM_RESERVED;
 #endif

--- a/VBoxGuestAdditions/vboxguest-6.1.36/vboxsf/dirops.c
+++ b/VBoxGuestAdditions/vboxguest-6.1.36/vboxsf/dirops.c
@@ -77,7 +77,12 @@ static int vbsf_dir_open(struct inode *inode, struct file *file)
          */
         pReq = (VBOXSFCREATEREQ *)VbglR0PhysHeapAlloc(RT_UOFFSETOF(VBOXSFCREATEREQ, StrPath.String) + sf_i->path->u16Size);
         if (pReq) {
+#if RTLNX_VER_MIN(5,19,0)
+            unsafe_memcpy(&pReq->StrPath, sf_i->path, SHFLSTRING_HEADER_SIZE + sf_i->path->u16Size,
+                         /* "pReq->StrPath was allocated by VbglR0PhysHeapAlloc()" above*/);
+#else
             memcpy(&pReq->StrPath, sf_i->path, SHFLSTRING_HEADER_SIZE + sf_i->path->u16Size);
+#endif
             RT_ZERO(pReq->CreateParms);
             pReq->CreateParms.Handle      = SHFL_HANDLE_NIL;
             pReq->CreateParms.CreateFlags = SHFL_CF_DIRECTORY
@@ -687,7 +692,12 @@ static struct dentry *vbsf_inode_lookup(struct inode *parent, struct dentry *den
             struct inode *pInode = NULL;
 
             RT_ZERO(*pReq);
+#if RTLNX_VER_MIN(5,19,0)
+            unsafe_memcpy(&pReq->StrPath, path, SHFLSTRING_HEADER_SIZE + path->u16Size,
+			    /* "pReq->StrPath was allocated by VbglR0PhysHeapAlloc() above" */);
+#else
             memcpy(&pReq->StrPath, path, SHFLSTRING_HEADER_SIZE + path->u16Size);
+#endif
             pReq->CreateParms.Handle = SHFL_HANDLE_NIL;
             pReq->CreateParms.CreateFlags = SHFL_CF_LOOKUP | SHFL_CF_ACT_FAIL_IF_NEW;
 
@@ -823,7 +833,12 @@ static int vbsf_create_worker(struct inode *parent, struct dentry *dentry, umode
             VBOXSFCLOSEREQ  Close;
         } *pReq = (union CreateAuxReq *)VbglR0PhysHeapAlloc(RT_UOFFSETOF(VBOXSFCREATEREQ, StrPath.String) + path->u16Size);
         if (pReq) {
+#if RTLNX_VER_MIN(5,19,0)
+            unsafe_memcpy(&pReq->Create.StrPath, path, SHFLSTRING_HEADER_SIZE + path->u16Size,
+                         /* "pReq->Create.StrPath was allocated by VbglR0PhysHeapAlloc() above" */);
+#else
             memcpy(&pReq->Create.StrPath, path, SHFLSTRING_HEADER_SIZE + path->u16Size);
+#endif
             RT_ZERO(pReq->Create.CreateParms);
             pReq->Create.CreateParms.Handle                  = SHFL_HANDLE_NIL;
             pReq->Create.CreateParms.CreateFlags             = fCreateFlags;
@@ -1126,7 +1141,12 @@ static int vbsf_unlink_worker(struct inode *parent, struct dentry *dentry, int f
         VBOXSFREMOVEREQ *pReq = (VBOXSFREMOVEREQ *)VbglR0PhysHeapAlloc(RT_UOFFSETOF(VBOXSFREMOVEREQ, StrPath.String)
                                                                        + path->u16Size);
         if (pReq) {
+#if RTLNX_VER_MIN(5,19,0)
+            unsafe_memcpy(&pReq->StrPath, path, SHFLSTRING_HEADER_SIZE + path->u16Size,
+                         /* "pReq->StrPath was allocated by VbglR0PhysHeapAlloc() above" */);
+#else
             memcpy(&pReq->StrPath, path, SHFLSTRING_HEADER_SIZE + path->u16Size);
+#endif
             uint32_t fFlags = fDirectory ? SHFL_REMOVE_DIR : SHFL_REMOVE_FILE;
             if (dentry->d_inode && ((dentry->d_inode->i_mode & S_IFLNK) == S_IFLNK))
                 fFlags |= SHFL_REMOVE_SYMLINK;

--- a/VBoxGuestAdditions/vboxguest-6.1.36/vboxsf/regops.c
+++ b/VBoxGuestAdditions/vboxguest-6.1.36/vboxsf/regops.c
@@ -2185,7 +2185,12 @@ static int vbsf_iter_lock_pages(struct iov_iter *iter, bool fWrite, struct vbsf_
                 while (!iov_iter_single_seg_count(iter)) /* Old code didn't skip empty segments which caused EFAULTs. */
                     iov_iter_advance(iter, 0);
 # endif
+
+#if RTLNX_VER_MIN(6,0,0)
+                cbSegRet = iov_iter_get_pages2(iter, papPages, iov_iter_count(iter), cMaxPages, &offPage0);
+#else
                 cbSegRet = iov_iter_get_pages(iter, papPages, iov_iter_count(iter), cMaxPages, &offPage0);
+#endif
                 if (cbSegRet > 0) {
                     iov_iter_advance(iter, cbSegRet);
                     cbChunk    = (size_t)cbSegRet;
@@ -2211,7 +2216,11 @@ static int vbsf_iter_lock_pages(struct iov_iter *iter, bool fWrite, struct vbsf_
                     iov_iter_advance(iter, 0);
                     cbSeg = iov_iter_single_seg_count(iter);
                 }
+#if RTLNX_VER_MIN(6,0,0)
+                cbSegRet = iov_iter_get_pages2(iter, &papPages[cPages], iov_iter_count(iter), 1, &offPgProbe);
+#else
                 cbSegRet = iov_iter_get_pages(iter, &papPages[cPages], iov_iter_count(iter), 1, &offPgProbe);
+#endif
                 if (cbSegRet > 0) {
                     iov_iter_advance(iter, cbSegRet); /** @todo maybe not do this if we stash the page? */
                     Assert(offPgProbe + cbSegRet <= PAGE_SIZE);
@@ -2229,7 +2238,11 @@ static int vbsf_iter_lock_pages(struct iov_iter *iter, bool fWrite, struct vbsf_
                          */
                         cbSeg -= cbSegRet;
                         if (cbSeg > 0) {
+#if RTLNX_VER_MIN(6,0,0)
+                            cbSegRet = iov_iter_get_pages2(iter, &papPages[cPages], iov_iter_count(iter), cMaxPages, &offPgProbe);
+#else
                             cbSegRet = iov_iter_get_pages(iter, &papPages[cPages], iov_iter_count(iter), cMaxPages, &offPgProbe);
+#endif
                             if (cbSegRet > 0) {
                                 size_t const cPgRet = RT_ALIGN_Z((size_t)cbSegRet, PAGE_SIZE) >> PAGE_SHIFT;
                                 Assert(offPgProbe == 0);

--- a/VBoxGuestAdditions/vboxguest-6.1.36/vboxsf/regops.c
+++ b/VBoxGuestAdditions/vboxguest-6.1.36/vboxsf/regops.c
@@ -3073,7 +3073,12 @@ static int vbsf_reg_open(struct inode *inode, struct file *file)
         LogRelFunc(("Failed to allocate a VBOXSFCREATEREQ buffer!\n"));
         return -ENOMEM;
     }
+#if RTLNX_VER_MIN(5,19,0)
+    unsafe_memcpy(&pReq->StrPath, sf_i->path, SHFLSTRING_HEADER_SIZE + sf_i->path->u16Size,
+                 /* "pReq->StrPath was allocated by VbglR0PhysHeapAlloc() above" */);
+#else
     memcpy(&pReq->StrPath, sf_i->path, SHFLSTRING_HEADER_SIZE + sf_i->path->u16Size);
+#endif
     RT_ZERO(pReq->CreateParms);
     pReq->CreateParms.Handle = SHFL_HANDLE_NIL;
 


### PR DESCRIPTION
Fix build error with kernel 6.1 due to prototype change
Tracked-On: OAM-112944
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>

vboxsf: silence runtime memcpy() false positive warning
Tracked-On: OAM-114506
Signed-off-by: Qi, Yadong <yadong.qi@intel.com>